### PR TITLE
[AG-364] integrate Lido eth-steth

### DIFF
--- a/pkg/source/handler.go
+++ b/pkg/source/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/gmx"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/ironstable"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/lido"
+	lido_steth "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/lido-steth"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/limitorder"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/madmex"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/makerpsm"
@@ -229,6 +230,15 @@ func NewPoolsListUpdaterHandler(
 		cfg.DexID = scanDexCfg.Id
 
 		return lido.NewPoolsListUpdater(&cfg), nil
+	case lido_steth.DexTypeLidoStETH:
+		var cfg lido_steth.Config
+		err := PropertiesToStruct(scanDexCfg.Properties, &cfg)
+		if err != nil {
+			return nil, err
+		}
+		cfg.DexID = scanDexCfg.Id
+
+		return lido_steth.NewPoolsListUpdater(&cfg), nil
 	case gmx.DexTypeGmx:
 		var cfg gmx.Config
 		err := PropertiesToStruct(scanDexCfg.Properties, &cfg)
@@ -430,6 +440,8 @@ func NewPoolTrackerHandler(
 
 	case lido.DexTypeLido:
 		return lido.NewPoolTracker(ethrpcClient), nil
+	case lido_steth.DexTypeLidoStETH:
+		return lido_steth.NewPoolTracker(ethrpcClient), nil
 	case gmx.DexTypeGmx:
 		var cfg gmx.Config
 		err := PropertiesToStruct(scanDexCfg.Properties, &cfg)

--- a/pkg/source/lido-steth/abis.go
+++ b/pkg/source/lido-steth/abis.go
@@ -1,0 +1,30 @@
+package lido_steth
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	stEthABI abi.ABI
+)
+
+func init() {
+	builder := []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{
+			&stEthABI, stEthABIData,
+		},
+	}
+
+	for _, b := range builder {
+		var err error
+		*b.ABI, err = abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkg/source/lido-steth/abis/stETH.json
+++ b/pkg/source/lido-steth/abis/stETH.json
@@ -1,0 +1,516 @@
+[
+  { "constant": false, "inputs": [], "name": "resume", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+  { "constant": true, "inputs": [], "name": "name", "outputs": [{ "name": "", "type": "string" }], "payable": false, "stateMutability": "pure", "type": "function" },
+  { "constant": false, "inputs": [], "name": "stop", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+  { "constant": true, "inputs": [], "name": "hasInitialized", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "STAKING_CONTROL_ROLE", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "totalSupply", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_ethAmount", "type": "uint256" }],
+    "name": "getSharesByPooledEth",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "isStakingPaused", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_sender", "type": "address" },
+      { "name": "_recipient", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_script", "type": "bytes" }],
+    "name": "getEVMScriptExecutor",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_maxStakeLimit", "type": "uint256" },
+      { "name": "_stakeLimitIncreasePerBlock", "type": "uint256" }
+    ],
+    "name": "setStakingLimit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "RESUME_ROLE", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_lidoLocator", "type": "address" },
+      { "name": "_eip712StETH", "type": "address" }
+    ],
+    "name": "finalizeUpgrade_v2",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "decimals", "outputs": [{ "name": "", "type": "uint8" }], "payable": false, "stateMutability": "pure", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getRecoveryVault", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "DOMAIN_SEPARATOR", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getTotalPooledEther", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_newDepositedValidators", "type": "uint256" }],
+    "name": "unsafeChangeDepositedValidators",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "PAUSE_ROLE", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "getTreasury", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "isStopped", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getBufferedEther", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_lidoLocator", "type": "address" },
+      { "name": "_eip712StETH", "type": "address" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  { "constant": false, "inputs": [], "name": "receiveELRewards", "outputs": [], "payable": true, "stateMutability": "payable", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getWithdrawalCredentials", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getCurrentStakeLimit", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getStakeLimitFullInfo",
+    "outputs": [
+      { "name": "isStakingPaused", "type": "bool" },
+      { "name": "isStakingLimitSet", "type": "bool" },
+      { "name": "currentStakeLimit", "type": "uint256" },
+      { "name": "maxStakeLimit", "type": "uint256" },
+      { "name": "maxStakeLimitGrowthBlocks", "type": "uint256" },
+      { "name": "prevStakeLimit", "type": "uint256" },
+      { "name": "prevStakeBlockNumber", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_sender", "type": "address" },
+      { "name": "_recipient", "type": "address" },
+      { "name": "_sharesAmount", "type": "uint256" }
+    ],
+    "name": "transferSharesFrom",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": false, "inputs": [], "name": "resumeStaking", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getFeeDistribution",
+    "outputs": [
+      { "name": "treasuryFeeBasisPoints", "type": "uint16" },
+      { "name": "insuranceFeeBasisPoints", "type": "uint16" },
+      { "name": "operatorsFeeBasisPoints", "type": "uint16" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": false, "inputs": [], "name": "receiveWithdrawals", "outputs": [], "payable": true, "stateMutability": "payable", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_sharesAmount", "type": "uint256" }],
+    "name": "getPooledEthByShares",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "token", "type": "address" }],
+    "name": "allowRecoverability",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "owner", "type": "address" }],
+    "name": "nonces",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "appId", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getOracle", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      { "name": "name", "type": "string" },
+      { "name": "version", "type": "string" },
+      { "name": "chainId", "type": "uint256" },
+      { "name": "verifyingContract", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "getContractVersion", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getInitializationBlock", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_recipient", "type": "address" },
+      { "name": "_sharesAmount", "type": "uint256" }
+    ],
+    "name": "transferShares",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "symbol", "outputs": [{ "name": "", "type": "string" }], "payable": false, "stateMutability": "pure", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getEIP712StETH", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": false, "inputs": [{ "name": "", "type": "address" }], "name": "transferToVault", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_sender", "type": "address" },
+      { "name": "_role", "type": "bytes32" },
+      { "name": "_params", "type": "uint256[]" }
+    ],
+    "name": "canPerform",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_referral", "type": "address" }],
+    "name": "submit",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "getEVMScriptRegistry", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_recipient", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_maxDepositsCount", "type": "uint256" },
+      { "name": "_stakingModuleId", "type": "uint256" },
+      { "name": "_depositCalldata", "type": "bytes" }
+    ],
+    "name": "deposit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "UNSAFE_CHANGE_DEPOSITED_VALIDATORS_ROLE",
+    "outputs": [{ "name": "", "type": "bytes32" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getBeaconStat",
+    "outputs": [
+      { "name": "depositedValidators", "type": "uint256" },
+      { "name": "beaconValidators", "type": "uint256" },
+      { "name": "beaconBalance", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": false, "inputs": [], "name": "removeStakingLimit", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_reportTimestamp", "type": "uint256" },
+      { "name": "_timeElapsed", "type": "uint256" },
+      { "name": "_clValidators", "type": "uint256" },
+      { "name": "_clBalance", "type": "uint256" },
+      { "name": "_withdrawalVaultBalance", "type": "uint256" },
+      { "name": "_elRewardsVaultBalance", "type": "uint256" },
+      { "name": "_sharesRequestedToBurn", "type": "uint256" },
+      { "name": "_withdrawalFinalizationBatches", "type": "uint256[]" },
+      { "name": "_simulatedShareRate", "type": "uint256" }
+    ],
+    "name": "handleOracleReport",
+    "outputs": [{ "name": "postRebaseAmounts", "type": "uint256[4]" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "getFee", "outputs": [{ "name": "totalFee", "type": "uint16" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "kernel", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getTotalShares", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" },
+      { "name": "_deadline", "type": "uint256" },
+      { "name": "_v", "type": "uint8" },
+      { "name": "_r", "type": "bytes32" },
+      { "name": "_s", "type": "bytes32" }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": true, "inputs": [], "name": "isPetrified", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getLidoLocator", "outputs": [{ "name": "", "type": "address" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "canDeposit", "outputs": [{ "name": "", "type": "bool" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "STAKING_PAUSE_ROLE", "outputs": [{ "name": "", "type": "bytes32" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getDepositableEther", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_account", "type": "address" }],
+    "name": "sharesOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "constant": false, "inputs": [], "name": "pauseStaking", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+  { "constant": true, "inputs": [], "name": "getTotalELRewardsCollected", "outputs": [{ "name": "", "type": "uint256" }], "payable": false, "stateMutability": "view", "type": "function" },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  { "anonymous": false, "inputs": [], "name": "StakingPaused", "type": "event" },
+  { "anonymous": false, "inputs": [], "name": "StakingResumed", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "name": "maxStakeLimit", "type": "uint256" },
+      { "indexed": false, "name": "stakeLimitIncreasePerBlock", "type": "uint256" }
+    ],
+    "name": "StakingLimitSet",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [], "name": "StakingLimitRemoved", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "reportTimestamp", "type": "uint256" },
+      { "indexed": false, "name": "preCLValidators", "type": "uint256" },
+      { "indexed": false, "name": "postCLValidators", "type": "uint256" }
+    ],
+    "name": "CLValidatorsUpdated",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "depositedValidators", "type": "uint256" }], "name": "DepositedValidatorsChanged", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "reportTimestamp", "type": "uint256" },
+      { "indexed": false, "name": "preCLBalance", "type": "uint256" },
+      { "indexed": false, "name": "postCLBalance", "type": "uint256" },
+      { "indexed": false, "name": "withdrawalsWithdrawn", "type": "uint256" },
+      { "indexed": false, "name": "executionLayerRewardsWithdrawn", "type": "uint256" },
+      { "indexed": false, "name": "postBufferedEther", "type": "uint256" }
+    ],
+    "name": "ETHDistributed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "reportTimestamp", "type": "uint256" },
+      { "indexed": false, "name": "timeElapsed", "type": "uint256" },
+      { "indexed": false, "name": "preTotalShares", "type": "uint256" },
+      { "indexed": false, "name": "preTotalEther", "type": "uint256" },
+      { "indexed": false, "name": "postTotalShares", "type": "uint256" },
+      { "indexed": false, "name": "postTotalEther", "type": "uint256" },
+      { "indexed": false, "name": "sharesMintedAsFees", "type": "uint256" }
+    ],
+    "name": "TokenRebased",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "lidoLocator", "type": "address" }], "name": "LidoLocatorSet", "type": "event" },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "amount", "type": "uint256" }], "name": "ELRewardsReceived", "type": "event" },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "amount", "type": "uint256" }], "name": "WithdrawalsReceived", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "sender", "type": "address" },
+      { "indexed": false, "name": "amount", "type": "uint256" },
+      { "indexed": false, "name": "referral", "type": "address" }
+    ],
+    "name": "Submitted",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "amount", "type": "uint256" }], "name": "Unbuffered", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "executor", "type": "address" },
+      { "indexed": false, "name": "script", "type": "bytes" },
+      { "indexed": false, "name": "input", "type": "bytes" },
+      { "indexed": false, "name": "returnData", "type": "bytes" }
+    ],
+    "name": "ScriptResult",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "vault", "type": "address" },
+      { "indexed": true, "name": "token", "type": "address" },
+      { "indexed": false, "name": "amount", "type": "uint256" }
+    ],
+    "name": "RecoverToVault",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "eip712StETH", "type": "address" }], "name": "EIP712StETHInitialized", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "from", "type": "address" },
+      { "indexed": true, "name": "to", "type": "address" },
+      { "indexed": false, "name": "sharesValue", "type": "uint256" }
+    ],
+    "name": "TransferShares",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "account", "type": "address" },
+      { "indexed": false, "name": "preRebaseTokenAmount", "type": "uint256" },
+      { "indexed": false, "name": "postRebaseTokenAmount", "type": "uint256" },
+      { "indexed": false, "name": "sharesAmount", "type": "uint256" }
+    ],
+    "name": "SharesBurnt",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [], "name": "Stopped", "type": "event" },
+  { "anonymous": false, "inputs": [], "name": "Resumed", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "from", "type": "address" },
+      { "indexed": true, "name": "to", "type": "address" },
+      { "indexed": false, "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "owner", "type": "address" },
+      { "indexed": true, "name": "spender", "type": "address" },
+      { "indexed": false, "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [{ "indexed": false, "name": "version", "type": "uint256" }], "name": "ContractVersionSet", "type": "event" }
+]

--- a/pkg/source/lido-steth/config.go
+++ b/pkg/source/lido-steth/config.go
@@ -1,0 +1,6 @@
+package lido_steth
+
+type Config struct {
+	DexID    string `json:"dexID"`
+	PoolPath string `json:"poolPath"`
+}

--- a/pkg/source/lido-steth/constant.go
+++ b/pkg/source/lido-steth/constant.go
@@ -1,0 +1,11 @@
+package lido_steth
+
+const (
+	DexTypeLidoStETH = "lido-steth"
+
+	methodTotalPooledEther = "getTotalPooledEther"
+	methodTotalShares      = "getTotalShares"
+
+	defaultTokenWeight = 1
+	reserveZero        = "0"
+)

--- a/pkg/source/lido-steth/embed.go
+++ b/pkg/source/lido-steth/embed.go
@@ -1,0 +1,13 @@
+package lido_steth
+
+import _ "embed"
+
+//go:embed pools/ethereum.json
+var ethereumPoolData []byte
+
+//go:embed abis/stETH.json
+var stEthABIData []byte
+
+var bytesByPath = map[string][]byte{
+	"pools/ethereum.json": ethereumPoolData,
+}

--- a/pkg/source/lido-steth/pool_tracker.go
+++ b/pkg/source/lido-steth/pool_tracker.go
@@ -37,7 +37,6 @@ func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entit
 	}
 
 	p.Reserves = reserves
-	p.Extra = "{}"
 	p.Timestamp = time.Now().Unix()
 
 	log.Infof("[Lido-stETH] Finish getting new state of pool")

--- a/pkg/source/lido-steth/pool_tracker.go
+++ b/pkg/source/lido-steth/pool_tracker.go
@@ -1,0 +1,78 @@
+package lido_steth
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+type PoolTracker struct {
+	ethrpcClient *ethrpc.Client
+}
+
+func NewPoolTracker(ethrpcClient *ethrpc.Client) *PoolTracker {
+	return &PoolTracker{
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+	log := logger.WithFields(logger.Fields{
+		"poolAddress": p.Address,
+	})
+
+	log.Infof("[Lido-stETH] Start getting new pool's state")
+
+	reserves, err := d.getPoolReserves(ctx, p)
+	if err != nil {
+		log.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to getPoolReserves")
+		return entity.Pool{}, err
+	}
+
+	p.Reserves = reserves
+	p.Extra = "{}"
+	p.Timestamp = time.Now().Unix()
+
+	log.Infof("[Lido-stETH] Finish getting new state of pool")
+
+	return p, nil
+}
+
+func (d *PoolTracker) getPoolReserves(ctx context.Context, p entity.Pool) (entity.PoolReserves, error) {
+	rpcRequest := d.ethrpcClient.NewRequest()
+	rpcRequest.SetContext(ctx)
+
+	var totalPooledEther *big.Int
+	var totalShares *big.Int
+
+	rpcRequest.AddCall(&ethrpc.Call{
+		ABI:    stEthABI,
+		Target: p.Address,
+		Method: methodTotalPooledEther,
+		Params: nil,
+	}, []interface{}{&totalPooledEther})
+
+	rpcRequest.AddCall(&ethrpc.Call{
+		ABI:    stEthABI,
+		Target: p.Address,
+		Method: methodTotalShares,
+		Params: nil,
+	}, []interface{}{&totalShares})
+
+	if _, err := rpcRequest.TryAggregate(); err != nil {
+		logger.WithFields(logger.Fields{
+			"poolAddress": p.Address,
+			"error":       err,
+		}).Error("failed to process tryAggregate")
+		return nil, err
+	}
+
+	return entity.PoolReserves{totalPooledEther.String(), totalShares.String()}, nil
+}

--- a/pkg/source/lido-steth/pools/ethereum.json
+++ b/pkg/source/lido-steth/pools/ethereum.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+    "name": "stETH",
+    "type": "lido-steth",
+    "lpToken": "",
+    "tokens": [
+      {
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "name": "wETH",
+        "symbol": "wETH",
+        "decimals": 18
+      },
+      {
+        "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+        "name": "stETH",
+        "symbol": "stETH",
+        "decimals": 18
+      }
+    ]
+  }
+]

--- a/pkg/source/lido-steth/pools_list_updater.go
+++ b/pkg/source/lido-steth/pools_list_updater.go
@@ -1,0 +1,119 @@
+package lido_steth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/logger"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+type PoolsListUpdater struct {
+	config         *Config
+	hasInitialized bool
+}
+
+func NewPoolsListUpdater(cfg *Config) *PoolsListUpdater {
+	return &PoolsListUpdater{
+		config: cfg,
+	}
+}
+
+func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	if d.hasInitialized {
+		logger.Info("skip since pool has been initialized")
+		return nil, nil, nil
+	}
+
+	pools, err := d.initPools()
+	if err != nil {
+		logger.WithFields(logger.Fields{
+			"error": err,
+		}).Errorf("failed to initPool")
+		return nil, nil, err
+	}
+	logger.WithFields(logger.Fields{"pool": pools}).Info("finish fetching pools")
+
+	return pools, nil, nil
+}
+
+func (d *PoolsListUpdater) initPools() ([]entity.Pool, error) {
+	byteData, ok := bytesByPath[d.config.PoolPath]
+	if !ok {
+		logger.Errorf("misconfigured poolPath")
+		return nil, errors.New("misconfigured poolPath")
+	}
+	var poolItems []PoolItem
+	if err := json.Unmarshal(byteData, &poolItems); err != nil {
+		logger.WithFields(logger.Fields{
+			"error": err,
+		}).Errorf("failed to unmarshal poolData")
+		return nil, err
+	}
+
+	pools, err := d.processBatch(poolItems)
+	if err != nil {
+		logger.WithFields(logger.Fields{
+			"error": err,
+		}).Errorf("failed to processBatch")
+		return nil, err
+	}
+	d.hasInitialized = true
+
+	return pools, nil
+}
+
+func (d *PoolsListUpdater) processBatch(poolItems []PoolItem) ([]entity.Pool, error) {
+	var pools = make([]entity.Pool, 0, len(poolItems))
+
+	for _, pool := range poolItems {
+		var err error
+		var poolEntity entity.Pool
+
+		poolEntity, err = d.getNewPool(&pool)
+
+		if err != nil {
+			return nil, err
+		}
+
+		pools = append(pools, poolEntity)
+	}
+
+	return pools, nil
+}
+
+func (d *PoolsListUpdater) getNewPool(pool *PoolItem) (entity.Pool, error) {
+	var tokens = make([]*entity.PoolToken, 0, len(pool.Tokens))
+	var reserves = make(entity.PoolReserves, 0, len(pool.Tokens))
+
+	for _, token := range pool.Tokens {
+		tokenEntity := entity.PoolToken{
+			Address:   strings.ToLower(token.Address),
+			Name:      token.Name,
+			Symbol:    token.Symbol,
+			Decimals:  token.Decimals,
+			Weight:    defaultTokenWeight,
+			Swappable: true,
+		}
+
+		tokens = append(tokens, &tokenEntity)
+		reserves = append(reserves, reserveZero)
+	}
+
+	poolEntity := entity.Pool{
+		Address:     pool.ID,
+		Exchange:    d.config.DexID,
+		Type:        DexTypeLidoStETH,
+		Timestamp:   time.Now().Unix(),
+		Reserves:    reserves,
+		Tokens:      tokens,
+		Extra:       "{}",
+		StaticExtra: "{}",
+	}
+
+	return poolEntity, nil
+}

--- a/pkg/source/lido-steth/pools_list_updater.go
+++ b/pkg/source/lido-steth/pools_list_updater.go
@@ -25,7 +25,7 @@ func NewPoolsListUpdater(cfg *Config) *PoolsListUpdater {
 
 func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
 	if d.hasInitialized {
-		logger.Info("skip since pool has been initialized")
+		logger.Debug("skip since pool has been initialized")
 		return nil, nil, nil
 	}
 

--- a/pkg/source/lido-steth/type.go
+++ b/pkg/source/lido-steth/type.go
@@ -1,0 +1,12 @@
+package lido_steth
+
+import (
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+type PoolItem struct {
+	ID      string             `json:"id"`
+	Type    string             `json:"type"`
+	LpToken string             `json:"lpToken"`
+	Tokens  []entity.PoolToken `json:"tokens"`
+}


### PR DESCRIPTION
For Lido ETH->stETH we need to get 2 reserved amounts (totalShares and totalPooledEther)

Formula in their contract code:
```
/**
     * @return the amount of shares that corresponds to `_ethAmount` protocol-controlled Ether.
     */
    function getSharesByPooledEth(uint256 _ethAmount) public view returns (uint256) {
        return _ethAmount
            .mul(_getTotalShares())
            .div(_getTotalPooledEther());
    }
```