### PR TITLE
use get_underlying_decimals for curve aave/compound

### DIFF
--- a/pkg/source/curve/constant.go
+++ b/pkg/source/curve/constant.go
@@ -13,6 +13,7 @@ const (
 	registryOrFactoryMethodIsMeta             = "is_meta"
 	registryOrFactoryMethodGetBasePool        = "get_base_pool"
 	registryOrFactoryMethodGetDecimals        = "get_decimals"
+	registryOrFactoryMethodGetUnderDecimals   = "get_underlying_decimals"
 	registryOrFactoryMethodGetRates           = "get_rates"
 	registryOrFactoryMethodGetLpToken         = "get_lp_token"
 

--- a/pkg/source/curve/pool_aave.go
+++ b/pkg/source/curve/pool_aave.go
@@ -45,7 +45,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeAave(
 		calls.AddCall(&ethrpc.Call{
 			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
 			Target: *poolAndRegistry.RegistryOrFactoryAddress,
-			Method: registryOrFactoryMethodGetDecimals,
+			Method: registryOrFactoryMethodGetUnderDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
 

--- a/pkg/source/curve/pool_base.go
+++ b/pkg/source/curve/pool_base.go
@@ -20,7 +20,6 @@ func (d *PoolsListUpdater) getNewPoolsTypeBase(
 ) ([]entity.Pool, error) {
 	var (
 		coins           = make([][8]common.Address, len(poolAndRegistries))
-		underlyingCoins = make([][8]common.Address, len(poolAndRegistries))
 		decimals        = make([][8]*big.Int, len(poolAndRegistries))
 		aList           = make([]*big.Int, len(poolAndRegistries))
 		aPreciseList    = make([]*big.Int, len(poolAndRegistries))
@@ -37,13 +36,6 @@ func (d *PoolsListUpdater) getNewPoolsTypeBase(
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
-
-		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
-			Method: registryOrFactoryMethodGetUnderlyingCoins,
-			Params: []interface{}{poolAndRegistry.PoolAddress},
-		}, []interface{}{&underlyingCoins[i]})
 
 		calls.AddCall(&ethrpc.Call{
 			ABI:    *poolAndRegistry.RegistryOrFactoryABI,

--- a/pkg/source/curve/pool_compound.go
+++ b/pkg/source/curve/pool_compound.go
@@ -46,7 +46,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeCompound(
 		calls.AddCall(&ethrpc.Call{
 			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
 			Target: *poolAndRegistry.RegistryOrFactoryAddress,
-			Method: registryOrFactoryMethodGetDecimals,
+			Method: registryOrFactoryMethodGetUnderDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
 


### PR DESCRIPTION
we're using underlying tokens for aave/compound curve pools, so should use underlying decimals instead of normal decimals