### PR TITLE
fix: curve incorrect pool classify

### DIFF
--- a/pkg/source/curve/constant.go
+++ b/pkg/source/curve/constant.go
@@ -70,6 +70,15 @@ const (
 	poolTypeCompound    = "curve-compound"
 	poolTypeTricrypto   = "curve-tricrypto"
 	poolTypeTwo         = "curve-two"
+	poolTypeUnsupported = "unsupported"
+)
+
+// Curve pool types
+const (
+	sourceMainRegistry = iota
+	sourceMetaPoolsFactory
+	sourceCryptoPoolsRegistry
+	sourceCryptoPoolsFactory
 )
 
 // Known weth9 implementation addresses, used in our implementation of Ether#wrapped

--- a/pkg/source/curve/pool_aave.go
+++ b/pkg/source/curve/pool_aave.go
@@ -29,37 +29,35 @@ func (d *PoolsListUpdater) getNewPoolsTypeAave(
 
 	for i, poolAndRegistry := range poolAndRegistries {
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetUnderlyingCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&underlyingCoins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetUnderDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetLpToken,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&lpAddresses[i]})
 	}
 	if _, err := calls.TryAggregate(); err != nil {
-		logger.WithFields(logger.Fields{
-			"error": err,
-		}).Errorf("failed to aggregate call to get pool data")
+		logger.Errorf("failed to aggregate call to get pool data, err: %v", err)
 		return nil, err
 	}
 
@@ -87,9 +85,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeAave(
 		}
 		staticExtraBytes, err := json.Marshal(staticExtra)
 		if err != nil {
-			logger.WithFields(logger.Fields{
-				"error": err,
-			}).Errorf("failed to marshal static extra data")
+			logger.Errorf("failed to marshal static extra data, err: %v", err)
 			return nil, err
 		}
 

--- a/pkg/source/curve/pool_base.go
+++ b/pkg/source/curve/pool_base.go
@@ -31,15 +31,15 @@ func (d *PoolsListUpdater) getNewPoolsTypeBase(
 
 	for i, poolAndRegistry := range poolAndRegistries {
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
@@ -102,7 +102,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeBase(
 			APrecision: aPrecisions[i].String(),
 		}
 		// The curve-base found inside the metaFactory has the lpToken equals its own pool Address and has the totalSupply method.
-		if strings.EqualFold(staticExtra.LpToken, addressZero) && strings.EqualFold(*poolAndRegistries[i].RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
+		if strings.EqualFold(staticExtra.LpToken, addressZero) && strings.EqualFold(poolAndRegistries[i].RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
 			staticExtra.LpToken = strings.ToLower(poolAndRegistries[i].PoolAddress.Hex())
 		}
 		for j := range coins[i] {

--- a/pkg/source/curve/pool_compound.go
+++ b/pkg/source/curve/pool_compound.go
@@ -30,29 +30,29 @@ func (d *PoolsListUpdater) getNewPoolsTypeCompound(
 
 	for i, poolAndRegistry := range poolAndRegistries {
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetUnderlyingCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&underlyingCoins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetUnderDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetLpToken,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&lpAddresses[i]})

--- a/pkg/source/curve/pool_lists_classifier.go
+++ b/pkg/source/curve/pool_lists_classifier.go
@@ -181,6 +181,7 @@ func (d *PoolsListUpdater) classifyCurveV2PoolTypes(
 		} else if d.isTricrypto(coins[i]) {
 			poolTypes[i] = poolTypeTricrypto
 		} else {
+			logger.Infof("unsupported curve v2 pool: %s", poolAddresses[i].Hex())
 			poolTypes[i] = poolTypeUnsupported
 		}
 	}

--- a/pkg/source/curve/pool_lists_classifier.go
+++ b/pkg/source/curve/pool_lists_classifier.go
@@ -13,16 +13,23 @@ import (
 
 func (d *PoolsListUpdater) classifyPoolTypes(
 	ctx context.Context,
+	poolsSourceIndex int,
 	registryOrFactoryABI abi.ABI,
 	registryOrFactoryAddress string,
 	poolAddresses []common.Address,
 ) ([]string, error) {
-	if strings.EqualFold(registryOrFactoryAddress, d.config.CryptoPoolsRegistryAddress) ||
-		strings.EqualFold(registryOrFactoryAddress, d.config.CryptoPoolsFactoryAddress) {
+	switch poolsSourceIndex {
+	case sourceMainRegistry:
+		return d.classifyCurveV1PoolTypes(ctx, registryOrFactoryABI, registryOrFactoryAddress, poolAddresses)
+	case sourceMetaPoolsFactory:
+		return d.classifyCurveV1PoolTypes(ctx, registryOrFactoryABI, registryOrFactoryAddress, poolAddresses)
+	case sourceCryptoPoolsRegistry:
 		return d.classifyCurveV2PoolTypes(ctx, registryOrFactoryABI, registryOrFactoryAddress, poolAddresses)
+	case sourceCryptoPoolsFactory:
+		return d.classifyCurveV2PoolTypes(ctx, registryOrFactoryABI, registryOrFactoryAddress, poolAddresses)
+	default:
+		return d.classifyCurveV1PoolTypes(ctx, registryOrFactoryABI, registryOrFactoryAddress, poolAddresses)
 	}
-
-	return d.classifyCurveV1PoolTypes(ctx, registryOrFactoryABI, registryOrFactoryAddress, poolAddresses)
 }
 
 // classifyCurveV1PoolTypes includes plainOracle, base, meta, aave, compound
@@ -150,7 +157,7 @@ func (d *PoolsListUpdater) classifyCurveV2PoolTypes(
 	registryOrFactoryAddress string,
 	poolAddresses []common.Address,
 ) ([]string, error) {
-	var coins = make([][8]common.Address, len(poolAddresses))
+	coins := make([][8]common.Address, len(poolAddresses))
 	calls := d.ethrpcClient.NewRequest().SetContext(ctx)
 	for i, poolAddress := range poolAddresses {
 		calls.AddCall(&ethrpc.Call{
@@ -171,8 +178,10 @@ func (d *PoolsListUpdater) classifyCurveV2PoolTypes(
 	for i := range poolAddresses {
 		if d.isTwo(coins[i]) {
 			poolTypes[i] = poolTypeTwo
-		} else {
+		} else if d.isTricrypto(coins[i]) {
 			poolTypes[i] = poolTypeTricrypto
+		} else {
+			poolTypes[i] = poolTypeUnsupported
 		}
 	}
 
@@ -265,7 +274,7 @@ func (d *PoolsListUpdater) isCompoundPool(
 // isTwo TwoCryptoPool
 // is curveV2, belongs to CryptoFactory and CryptoRegistry
 // has "gamma" in its contracts
-// has only 2 coins (has 2 coins is TriCryptoPool)
+// has only 2 coins (has 3 coins is TricryptoPool)
 func (d *PoolsListUpdater) isTwo(coins [8]common.Address) bool {
 	var numberOfCoin = 0
 	for _, coin := range coins {
@@ -276,4 +285,19 @@ func (d *PoolsListUpdater) isTwo(coins [8]common.Address) bool {
 	}
 
 	return numberOfCoin == 2
+}
+
+// isTricrypto is curveV2, belongs to CryptoRegistry and CryptoFactory
+// has "gamma" in its contracts
+// has only 3 coins (has 2 coins is TwoPool)
+func (d *PoolsListUpdater) isTricrypto(coins [8]common.Address) bool {
+	var numberOfCoin = 0
+	for _, coin := range coins {
+		if strings.EqualFold(coin.Hex(), addressZero) {
+			break
+		}
+		numberOfCoin += 1
+	}
+
+	return numberOfCoin == 3
 }

--- a/pkg/source/curve/pool_meta.go
+++ b/pkg/source/curve/pool_meta.go
@@ -30,7 +30,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeMeta(
 	calls := d.ethrpcClient.NewRequest().SetContext(ctx)
 
 	for i, poolAndRegistry := range poolAndRegistries {
-		if strings.EqualFold(*poolAndRegistry.RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
+		if strings.EqualFold(poolAndRegistry.RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
 			calls.AddCall(&ethrpc.Call{
 				ABI:    metaPoolFactoryABI,
 				Target: d.config.MetaPoolsFactoryAddress,
@@ -47,22 +47,22 @@ func (d *PoolsListUpdater) getNewPoolsTypeMeta(
 		}
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetUnderlyingCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&underlyingCoins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
@@ -82,17 +82,13 @@ func (d *PoolsListUpdater) getNewPoolsTypeMeta(
 		}, []interface{}{&aPreciseList[i]})
 	}
 	if _, err := calls.TryAggregate(); err != nil {
-		logger.WithFields(logger.Fields{
-			"error": err,
-		}).Errorf("failed to aggregate call to get pool data")
+		logger.Errorf("failed to aggregate call to get pool data, err: %v", err)
 		return nil, err
 	}
 
 	aPrecisions, err := getAPrecisions(aList, aPreciseList)
 	if err != nil {
-		logger.WithFields(logger.Fields{
-			"error": err,
-		}).Errorf("failed to calculate aPrecisions")
+		logger.Errorf("failed to calculate aPrecisions, err: %v", err)
 		return nil, err
 	}
 
@@ -124,9 +120,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeMeta(
 		}
 		staticExtraBytes, err := json.Marshal(staticExtra)
 		if err != nil {
-			logger.WithFields(logger.Fields{
-				"error": err,
-			}).Errorf("failed to marshal static extra data")
+			logger.Errorf("failed to marshal static extra data, err: %v", err)
 			return nil, err
 		}
 

--- a/pkg/source/curve/pool_plain_oracle.go
+++ b/pkg/source/curve/pool_plain_oracle.go
@@ -20,35 +20,27 @@ func (d *PoolsListUpdater) getNewPoolsTypePlainOracle(
 	poolAndRegistries []PoolAndRegistries,
 ) ([]entity.Pool, error) {
 	var (
-		coins           = make([][8]common.Address, len(poolAndRegistries))
-		underlyingCoins = make([][8]common.Address, len(poolAndRegistries))
-		decimals        = make([][8]*big.Int, len(poolAndRegistries))
-		aList           = make([]*big.Int, len(poolAndRegistries))
-		aPreciseList    = make([]*big.Int, len(poolAndRegistries))
-		plainOracles    = make([]common.Address, len(poolAndRegistries))
-		lpAddresses     = make([]common.Address, len(poolAndRegistries))
+		coins        = make([][8]common.Address, len(poolAndRegistries))
+		decimals     = make([][8]*big.Int, len(poolAndRegistries))
+		aList        = make([]*big.Int, len(poolAndRegistries))
+		aPreciseList = make([]*big.Int, len(poolAndRegistries))
+		plainOracles = make([]common.Address, len(poolAndRegistries))
+		lpAddresses  = make([]common.Address, len(poolAndRegistries))
 	)
 
 	calls := d.ethrpcClient.NewRequest().SetContext(ctx)
 
 	for i, poolAndRegistry := range poolAndRegistries {
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
-			Method: registryOrFactoryMethodGetUnderlyingCoins,
-			Params: []interface{}{poolAndRegistry.PoolAddress},
-		}, []interface{}{&underlyingCoins[i]})
-
-		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
@@ -106,7 +98,7 @@ func (d *PoolsListUpdater) getNewPoolsTypePlainOracle(
 			Oracle:     plainOracles[i].Hex(),
 		}
 		// The curve-base found inside the metaFactory has the lpToken equals its own pool Address and has the totalSupply method.
-		if strings.EqualFold(staticExtra.LpToken, addressZero) && strings.EqualFold(*poolAndRegistries[i].RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
+		if strings.EqualFold(staticExtra.LpToken, addressZero) && strings.EqualFold(poolAndRegistries[i].RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
 			staticExtra.LpToken = strings.ToLower(poolAndRegistries[i].PoolAddress.Hex())
 		}
 		for j := range coins[i] {

--- a/pkg/source/curve/pool_tricrypto.go
+++ b/pkg/source/curve/pool_tricrypto.go
@@ -28,15 +28,15 @@ func (d *PoolsListUpdater) getNewPoolsTypeTricrypto(
 
 	for i, poolAndRegistry := range poolAndRegistries {
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})

--- a/pkg/source/curve/pool_two.go
+++ b/pkg/source/curve/pool_two.go
@@ -28,15 +28,15 @@ func (d *PoolsListUpdater) getNewPoolsTypeTwo(
 
 	for i, poolAndRegistry := range poolAndRegistries {
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetCoins,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&coins[i]})
 
 		calls.AddCall(&ethrpc.Call{
-			ABI:    *poolAndRegistry.RegistryOrFactoryABI,
-			Target: *poolAndRegistry.RegistryOrFactoryAddress,
+			ABI:    poolAndRegistry.RegistryOrFactoryABI,
+			Target: poolAndRegistry.RegistryOrFactoryAddress,
 			Method: registryOrFactoryMethodGetDecimals,
 			Params: []interface{}{poolAndRegistry.PoolAddress},
 		}, []interface{}{&decimals[i]})
@@ -50,9 +50,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeTwo(
 	}
 
 	if _, err := calls.Aggregate(); err != nil {
-		logger.WithFields(logger.Fields{
-			"error": err,
-		}).Errorf("failed to aggregate call to get pool data")
+		logger.Errorf("failed to aggregate call to get pool data, err: %v", err)
 		return nil, err
 	}
 
@@ -79,9 +77,7 @@ func (d *PoolsListUpdater) getNewPoolsTypeTwo(
 		}
 		staticExtraBytes, err := json.Marshal(staticExtra)
 		if err != nil {
-			logger.WithFields(logger.Fields{
-				"error": err,
-			}).Errorf("failed to marshal static extra data")
+			logger.Errorf("failed to marshal static extra data, err: %v", err)
 			return nil, err
 		}
 

--- a/pkg/source/curve/type.go
+++ b/pkg/source/curve/type.go
@@ -9,8 +9,8 @@ import (
 
 type PoolAndRegistries struct {
 	PoolAddress              common.Address
-	RegistryOrFactoryABI     *abi.ABI
-	RegistryOrFactoryAddress *string
+	RegistryOrFactoryABI     abi.ABI
+	RegistryOrFactoryAddress string
 }
 
 type Metadata struct {


### PR DESCRIPTION
- Change `*abi.ABI` and `*string` to `abi.ABI` and `string` to avoid weird issue wrong ABI file => `get_underlying_coins not found`
- Stop using `logger.WithFields` because it logs incorrect position of code
- In case of Optimism, the `meta pools factory` address is equal to the `crypto pools factory` address
  - We should only process Curve Two and Curve Tricrypto for `crypto pools registry` and `crypto pools factory`
  - Thus, now I added `poolsSourceIndex`. 
    - 1 = `main registry`, 2 = `meta pools factory`, 3 = `crypto pools registry`, 4 = `crypto pools factory`
    - Only 3 and 4 should be applied for Curve Two and Curve Tricrypto