### PR TITLE
fix: update slot0.feeProtocol from uint8 to uint32

### DIFF
--- a/pkg/source/uniswapv3/abis/UniswapV3Pool.json
+++ b/pkg/source/uniswapv3/abis/UniswapV3Pool.json
@@ -782,9 +782,9 @@
         "type": "uint16"
       },
       {
-        "internalType": "uint8",
+        "internalType": "uint32",
         "name": "feeProtocol",
-        "type": "uint8"
+        "type": "uint32"
       },
       {
         "internalType": "bool",

--- a/pkg/source/uniswapv3/type.go
+++ b/pkg/source/uniswapv3/type.go
@@ -71,7 +71,7 @@ type Slot0 struct {
 	ObservationIndex           uint16   `json:"observationIndex"`
 	ObservationCardinality     uint16   `json:"observationCardinality"`
 	ObservationCardinalityNext uint16   `json:"observationCardinalityNext"`
-	FeeProtocol                uint8    `json:"feeProtocol"`
+	FeeProtocol                uint32   `json:"feeProtocol"`
 	Unlocked                   bool     `json:"unlocked"`
 }
 


### PR DESCRIPTION
## Description
In pancake-v3, they defined feeProtocol as uint32 which is different than uniswap-v3. This is a quick and dirty solution to make the current uniswap-v3 integration fit with pancake-v3