### PR TITLE
[AG-704][AG-705] update LO pool list updater/tracker multi SCs

### DIFF
--- a/pkg/source/limitorder/config.go
+++ b/pkg/source/limitorder/config.go
@@ -4,4 +4,5 @@ type Config struct {
 	DexID             string `json:"dexID"`
 	LimitOrderHTTPUrl string `json:"limitOrderHTTPUrl"`
 	ChainID           uint   `json:"chainID"`
+	SupportMultiSCs   bool   `json:"supportMultiSCs"`
 }

--- a/pkg/source/limitorder/http_client.go
+++ b/pkg/source/limitorder/http_client.go
@@ -25,12 +25,13 @@ func NewHTTPClient(baseURL string) *httpClient {
 func (c *httpClient) ListAllPairs(
 	ctx context.Context,
 	chainID ChainID,
+	supportMultiSCs bool,
 ) ([]*limitOrderPair, error) {
 	req := c.client.R().SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
 		SetQueryParams(map[string]string{
 			"chainId":                    strconv.Itoa(int(chainID)),
-			"hasDistinctContractAddress": "true",
+			"hasDistinctContractAddress": strconv.FormatBool(supportMultiSCs),
 		})
 
 	var result listAllPairsResult

--- a/pkg/source/limitorder/http_client.go
+++ b/pkg/source/limitorder/http_client.go
@@ -29,7 +29,8 @@ func (c *httpClient) ListAllPairs(
 	req := c.client.R().SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
 		SetQueryParams(map[string]string{
-			"chainId": strconv.Itoa(int(chainID)),
+			"chainId":                    strconv.Itoa(int(chainID)),
+			"hasDistinctContractAddress": "true",
 		})
 
 	var result listAllPairsResult
@@ -54,9 +55,10 @@ func (c *httpClient) ListOrders(
 	req := c.client.R().SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
 		SetQueryParams(map[string]string{
-			"takerAsset": filter.TakerAsset,
-			"makerAsset": filter.MakerAsset,
-			"chainId":    strconv.Itoa(int(filter.ChainID)),
+			"takerAsset":      filter.TakerAsset,
+			"makerAsset":      filter.MakerAsset,
+			"chainId":         strconv.Itoa(int(filter.ChainID)),
+			"contractAddress": filter.ContractAddress,
 		})
 	var result listOrdersResult
 	resp, err := req.SetResult(&result).Get(listOrdersEndpoint)

--- a/pkg/source/limitorder/http_client_dto.go
+++ b/pkg/source/limitorder/http_client_dto.go
@@ -29,8 +29,9 @@ type (
 	}
 
 	limitOrderPair struct {
-		MakerAsset string `json:"makerAsset"`
-		TakeAsset  string `json:"takerAsset"`
+		MakerAsset      string `json:"makerAsset"`
+		TakeAsset       string `json:"takerAsset"`
+		ContractAddress string `json:"contractAddress"`
 	}
 
 	listOrdersData struct {
@@ -67,6 +68,7 @@ type (
 		ChainID             ChainID
 		MakerAsset          string
 		TakerAsset          string
+		ContractAddress     string
 		ExcludeExpiredOrder bool
 	}
 

--- a/pkg/source/limitorder/pool_simulator.go
+++ b/pkg/source/limitorder/pool_simulator.go
@@ -23,6 +23,8 @@ type (
 		// extra fields
 		sellOrderIDs []int64
 		buyOrderIDs  []int64
+
+		contractAddress string
 	}
 )
 
@@ -36,6 +38,15 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	for i := 0; i < numTokens; i += 1 {
 		tokens[i] = entityPool.Tokens[i].Address
 		reserves[i] = utils.NewBig10(entityPool.Reserves[i])
+	}
+
+	var contractAddress string
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(entityPool.StaticExtra), &staticExtra); err != nil {
+		// this is optional for now, will changed to required later
+		contractAddress = ""
+	} else {
+		contractAddress = staticExtra.ContractAddress
 	}
 
 	var extra Extra
@@ -70,6 +81,8 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 		buyOrderIDs:   buyOrderIDs,
 		ordersMapping: ordersMapping,
 		tokens:        entity.ClonePoolTokens(entityPool.Tokens),
+
+		contractAddress: contractAddress,
 	}, nil
 }
 
@@ -246,7 +259,7 @@ func (p *PoolSimulator) getSwapSide(tokenIn string, TokenOut string) SwapSide {
 }
 
 func (p *PoolSimulator) GetMetaInfo(_ string, _ string) interface{} {
-	return nil
+	return p.contractAddress
 }
 
 func newFilledOrderInfo(order *order, filledTakingAmount, filledMakingAmount string, feeAmount string) *FilledOrderInfo {

--- a/pkg/source/limitorder/pool_tracker.go
+++ b/pkg/source/limitorder/pool_tracker.go
@@ -39,9 +39,15 @@ func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entit
 		token0, token1 = p.Tokens[1], p.Tokens[0]
 	}
 
-	var staticExtra StaticExtra
-	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
-		return entity.Pool{}, err
+	var contractAddress string
+	if d.config.SupportMultiSCs {
+		var staticExtra StaticExtra
+		if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+			return entity.Pool{}, err
+		}
+		contractAddress = staticExtra.ContractAddress
+	} else {
+		contractAddress = ""
 	}
 
 	extra := Extra{}
@@ -52,7 +58,7 @@ func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entit
 			ChainID:         ChainID(d.config.ChainID),
 			MakerAsset:      token0.Address,
 			TakerAsset:      token1.Address,
-			ContractAddress: staticExtra.ContractAddress,
+			ContractAddress: contractAddress,
 		})
 		if err != nil {
 			logger.WithFields(logger.Fields{
@@ -69,7 +75,7 @@ func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entit
 			ChainID:         ChainID(d.config.ChainID),
 			MakerAsset:      token1.Address,
 			TakerAsset:      token0.Address,
-			ContractAddress: staticExtra.ContractAddress,
+			ContractAddress: contractAddress,
 		})
 		if err != nil {
 			logger.WithFields(logger.Fields{

--- a/pkg/source/limitorder/type.go
+++ b/pkg/source/limitorder/type.go
@@ -3,13 +3,18 @@ package limitorder
 type ChainID uint
 
 type tokenPair struct {
-	Token0 string `json:"token0"`
-	Token1 string `json:"token1"`
+	Token0          string `json:"token0"`
+	Token1          string `json:"token1"`
+	ContractAddress string `json:"contractAddress"`
 }
 
 type Extra struct {
 	SellOrders []*order
 	BuyOrders  []*order
+}
+
+type StaticExtra struct {
+	ContractAddress string
 }
 
 type SwapSide string


### PR DESCRIPTION
Now each limit-order pool need to have info about SC address that was used to create all orders in that pool

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
