### PR TITLE
fix: handle error insufficient liquidity in PMM price levels

### DIFF
--- a/pkg/source/kyber-pmm/error.go
+++ b/pkg/source/kyber-pmm/error.go
@@ -6,5 +6,6 @@ var (
 	ErrTokenNotFound          = errors.New("token not found")
 	ErrNoPriceLevelsForPool   = errors.New("no price levels for pool")
 	ErrEmptyPriceLevels       = errors.New("empty price levels")
+	ErrInsufficientLiquidity  = errors.New("insufficient liquidity")
 	ErrInvalidFirmQuoteParams = errors.New("invalid firm quote params")
 )

--- a/pkg/source/kyber-pmm/pool_simulator_test.go
+++ b/pkg/source/kyber-pmm/pool_simulator_test.go
@@ -28,37 +28,9 @@ func TestPoolSimulator_getAmountOut(t *testing.T) {
 			expectedErr:       ErrEmptyPriceLevels,
 		},
 		{
-			name: "it should return correct amount out when fully filled",
+			name: "it should return insufficient liquidity error when the requested amount is greater than available amount in price levels",
 			args: args{
-				amountIn: new(big.Float).SetFloat64(1),
-				priceLevels: []PriceLevel{
-					{
-						Price:  100,
-						Amount: 1,
-					},
-				},
-			},
-			expectedAmountOut: new(big.Float).SetFloat64(100),
-			expectedErr:       nil,
-		},
-		{
-			name: "it should return correct amount out when the amountIn is greater than the amount available in the single price level",
-			args: args{
-				amountIn: new(big.Float).SetFloat64(2),
-				priceLevels: []PriceLevel{
-					{
-						Price:  100,
-						Amount: 1,
-					},
-				},
-			},
-			expectedAmountOut: new(big.Float).SetFloat64(100),
-			expectedErr:       nil,
-		},
-		{
-			name: "it should return correct amount out when the amountIn is greater than the amount available in the all price levels",
-			args: args{
-				amountIn: new(big.Float).SetFloat64(5),
+				amountIn: new(big.Float).SetFloat64(4),
 				priceLevels: []PriceLevel{
 					{
 						Price:  100,
@@ -70,7 +42,21 @@ func TestPoolSimulator_getAmountOut(t *testing.T) {
 					},
 				},
 			},
-			expectedAmountOut: new(big.Float).SetFloat64(298),
+			expectedAmountOut: nil,
+			expectedErr:       ErrInsufficientLiquidity,
+		},
+		{
+			name: "it should return correct amount out when fully filled",
+			args: args{
+				amountIn: new(big.Float).SetFloat64(1),
+				priceLevels: []PriceLevel{
+					{
+						Price:  100,
+						Amount: 1,
+					},
+				},
+			},
+			expectedAmountOut: new(big.Float).SetFloat64(100),
 			expectedErr:       nil,
 		},
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
If the amount in is greater than the available amount that price levels can provide, we should return error insufficient liquidity instead of allowing the simulation to continue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
