### PR TITLE
fix (curve-meta): add underlaying tokens in get tokens

### DIFF
--- a/pkg/source/curve/meta/pool_simulator.go
+++ b/pkg/source/curve/meta/pool_simulator.go
@@ -261,6 +261,13 @@ func (t *Pool) GetMetaInfo(tokenIn string, tokenOut string) interface{} {
 	}
 }
 
+func (t *Pool) GetTokens() []string {
+	var result []string
+	result = append(result, t.GetInfo().Tokens...)
+	result = append(result, t.BasePool.GetInfo().Tokens...)
+	return result
+}
+
 func (t *Pool) getUnderlyingIndex(token string) int {
 	var tokenIndex = t.GetTokenIndex(token)
 	if tokenIndex >= 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
Context: https://team-kyber.slack.com/archives/C04R9NSNEKF/p1695017808835559
Summary: While `curve-meta` can swap to underlying tokens, the current `GetTokens()` function only returns the direct tokens in pools. This leads to the wrong calculate `MinHopsToTokenOut`, due to the wrong create `tokenToPoolAddress` ([code](https://github.com/KyberNetwork/router-service/blob/main/internal/pkg/usecase/findroute/spfav2/best_route.go#L32-L37)).

This PR fixes the above issue.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
