### PR TITLE
Feat/update interface for pool tracker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/KyberNetwork/blockchain-toolkit v0.2.0
 	github.com/KyberNetwork/elastic-go-sdk/v2 v2.0.2
-	github.com/KyberNetwork/ethrpc v0.3.0
+	github.com/KyberNetwork/ethrpc v0.4.0
 	github.com/KyberNetwork/logger v0.1.0
 	github.com/KyberNetwork/pancake-v3-sdk v0.1.0
 	github.com/daoleno/uniswap-sdk-core v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/KyberNetwork/elastic-go-sdk/v2 v2.0.2 h1:kN7ez6MPJEaFbacmvR+22PRa5pJk
 github.com/KyberNetwork/elastic-go-sdk/v2 v2.0.2/go.mod h1:3DThBH6zHAYSWUVmtj9deQO1XuiwbawdKxj5yV4SuMo=
 github.com/KyberNetwork/ethrpc v0.3.0 h1:LoqtmSR4ABgsCvSc+qPUbPibPhVZpd12YQLbMGAyVWk=
 github.com/KyberNetwork/ethrpc v0.3.0/go.mod h1:QOlJ7bWKIVlo3ZfJt3cmyc5oke9uU+4hl9Vth5IHK/Y=
+github.com/KyberNetwork/ethrpc v0.4.0 h1:ghG8s8D/V9fWAQMnTicIDUv0I6VFDSqN3T6kbE9No6c=
+github.com/KyberNetwork/ethrpc v0.4.0/go.mod h1:QOlJ7bWKIVlo3ZfJt3cmyc5oke9uU+4hl9Vth5IHK/Y=
 github.com/KyberNetwork/logger v0.1.0 h1:Iibu9Ls+tipjR+C0iXhzUYM1VtRgmmR1HHWGufPYcbs=
 github.com/KyberNetwork/logger v0.1.0/go.mod h1:zBqHbtJ3nJn6HQnp6UW8pbQkR+U6tSRFd5CzfiKL3Kw=
 github.com/KyberNetwork/pancake-v3-sdk v0.1.0 h1:HVUD13Qbwl4kiU1uSprQVpkis6fYYp3A32mVuK+f1Iw=
@@ -114,6 +116,7 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/source/algebrav1/pool_tracker.go
+++ b/pkg/source/algebrav1/pool_tracker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
@@ -42,7 +42,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	logger.Infof("[%v] Start getting new state of pool: %v", d.config.DexID, p.Address)
 

--- a/pkg/source/algebrav1/pool_tracker.go
+++ b/pkg/source/algebrav1/pool_tracker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
@@ -38,7 +39,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[%v] Start getting new state of pool: %v", d.config.DexID, p.Address)
 
 	var (

--- a/pkg/source/balancer-composable-stable/pool_tracker.go
+++ b/pkg/source/balancer-composable-stable/pool_tracker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
@@ -28,7 +29,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	}).Infof("[Balancer-Composable-Stable] Start updating state ...")

--- a/pkg/source/balancer/pool_tracker.go
+++ b/pkg/source/balancer/pool_tracker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -27,7 +28,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	}).Infof("[Balancer] Start updating state ...")

--- a/pkg/source/biswap/pool_tracker.go
+++ b/pkg/source/biswap/pool_tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -25,7 +26,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	}).Infof("[%s] Start getting new state of pool", d.config.DexID)

--- a/pkg/source/camelot/pool_tracker.go
+++ b/pkg/source/camelot/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/timer"
 )
 
@@ -26,7 +27,11 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	finish := timer.Start(fmt.Sprintf("[%s] get new pool state", d.cfg.DexID))
 	defer finish()
 

--- a/pkg/source/curve/pool_tracker.go
+++ b/pkg/source/curve/pool_tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -34,6 +35,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	switch p.Type {
 	case poolTypeBase:

--- a/pkg/source/dmm/pool_tracker.go
+++ b/pkg/source/dmm/pool_tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -23,7 +24,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	}).Infof("[DMM] Start getting new state of pool")

--- a/pkg/source/dodo/pool_tracker.go
+++ b/pkg/source/dodo/pool_tracker.go
@@ -15,6 +15,7 @@ import (
 	cmap "github.com/orcaman/concurrent-map"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -39,7 +40,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	var staticExtraData = struct {
 		Type string `json:"type"`
 	}{}

--- a/pkg/source/dystopia/pool_tracker.go
+++ b/pkg/source/dystopia/pool_tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -20,7 +21,11 @@ func NewPoolTracker(ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})

--- a/pkg/source/elastic/pool_tracker.go
+++ b/pkg/source/elastic/pool_tracker.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
@@ -39,7 +39,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	logger.Infof("[Elastic] Start getting new state of pool: %v", p.Address)
 

--- a/pkg/source/elastic/pool_tracker.go
+++ b/pkg/source/elastic/pool_tracker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
@@ -35,7 +36,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[Elastic] Start getting new state of pool: %v", p.Address)
 
 	var (

--- a/pkg/source/fraxswap/pool_tracker.go
+++ b/pkg/source/fraxswap/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -22,7 +23,11 @@ func NewPoolTracker(ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})

--- a/pkg/source/gmx/pool_tracker.go
+++ b/pkg/source/gmx/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -27,7 +28,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"liquiditySource": DexTypeGmx,
 		"poolAddress":     p.Address,

--- a/pkg/source/ironstable/pool_tracker.go
+++ b/pkg/source/ironstable/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/timer"
 )
 
@@ -26,7 +27,11 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) (*PoolTracker, err
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	finish := timer.Start(fmt.Sprintf("[%s] get new pool state", d.cfg.DexID))
 	defer finish()
 

--- a/pkg/source/iziswap/pool_tracker.go
+++ b/pkg/source/iziswap/pool_tracker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/izumiFinance/iZiSwap-SDK-go/swap"
@@ -31,7 +32,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[iZiSwap] Start getting new state of pool: %v", p.Address)
 
 	g := pool.New().WithContext(ctx)

--- a/pkg/source/iziswap/pool_tracker.go
+++ b/pkg/source/iziswap/pool_tracker.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/izumiFinance/iZiSwap-SDK-go/swap"
@@ -35,7 +35,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	logger.Infof("[iZiSwap] Start getting new state of pool: %v", p.Address)
 

--- a/pkg/source/kyber-pmm/pool_tracker.go
+++ b/pkg/source/kyber-pmm/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -24,7 +25,11 @@ func NewPoolTracker(cfg *Config, client IClient) *PoolTracker {
 	}
 }
 
-func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[Kyber PMM] Start getting new states for pool %v", p.Address)
 
 	if len(p.Tokens) != 2 {

--- a/pkg/source/lido-steth/pool_tracker.go
+++ b/pkg/source/lido-steth/pool_tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -21,7 +22,11 @@ func NewPoolTracker(ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})

--- a/pkg/source/lido/pool_tracker.go
+++ b/pkg/source/lido/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -23,7 +24,11 @@ func NewPoolTracker(ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})

--- a/pkg/source/limitorder/pool_tracker.go
+++ b/pkg/source/limitorder/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -27,7 +28,11 @@ func NewPoolTracker(cfg *Config) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[LimitOrder] Start getting new states for pool %v", p.Address)
 	if len(p.Tokens) < 2 {
 		err := errors.New("number of token should be greater than or equal 2")

--- a/pkg/source/madmex/pool_tracker.go
+++ b/pkg/source/madmex/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -27,7 +28,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"liquiditySource": DexTypeMadmex,
 		"poolAddress":     p.Address,

--- a/pkg/source/makerpsm/pool_tracker.go
+++ b/pkg/source/makerpsm/pool_tracker.go
@@ -10,7 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -30,7 +30,7 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	pool entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	defer func(startTime time.Time) {
 		logger.

--- a/pkg/source/makerpsm/pool_tracker.go
+++ b/pkg/source/makerpsm/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -26,7 +27,11 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, pool entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	pool entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	defer func(startTime time.Time) {
 		logger.
 			WithFields(logger.Fields{

--- a/pkg/source/maverickv1/pool_tracker.go
+++ b/pkg/source/maverickv1/pool_tracker.go
@@ -3,12 +3,14 @@ package maverickv1
 import (
 	"context"
 	"encoding/json"
-	"github.com/KyberNetwork/ethrpc"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	"github.com/KyberNetwork/logger"
 	"math/big"
 	"strconv"
 	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/logger"
 )
 
 type PoolTracker struct {
@@ -26,7 +28,11 @@ func NewPoolTracker(
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new state of pool", p.Type)

--- a/pkg/source/metavault/pool_tracker.go
+++ b/pkg/source/metavault/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -27,7 +28,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"liquiditySource": DexTypeMetavault,
 		"poolAddress":     p.Address,

--- a/pkg/source/muteswitch/pool_tracker.go
+++ b/pkg/source/muteswitch/pool_tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -26,7 +27,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new state of pool", p.Type)

--- a/pkg/source/nerve/pool_tracker.go
+++ b/pkg/source/nerve/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -28,7 +29,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"liquiditySource": DexTypeNerve,
 		"poolAddress":     p.Address,

--- a/pkg/source/oneswap/pool_tracker.go
+++ b/pkg/source/oneswap/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -23,7 +24,11 @@ func NewPoolTracker(ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[Oneswap] Start getting new state of pool %v", p.Address)
 
 	var (

--- a/pkg/source/pancakev3/pool_tracker.go
+++ b/pkg/source/pancakev3/pool_tracker.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
@@ -39,7 +39,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	logger.Infof("[Pancake V3] Start getting new state of pool: %v", p.Address)
 

--- a/pkg/source/pancakev3/pool_tracker.go
+++ b/pkg/source/pancakev3/pool_tracker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
@@ -35,7 +36,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[Pancake V3] Start getting new state of pool: %v", p.Address)
 
 	var (

--- a/pkg/source/pearl/pool_tracker.go
+++ b/pkg/source/pearl/pool_tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -26,7 +27,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new state of pool", p.Type)

--- a/pkg/source/platypus/pool_tracker.go
+++ b/pkg/source/platypus/pool_tracker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -24,7 +25,11 @@ func NewPoolTracker(ethClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[Platypus] Start getting new pool's state")

--- a/pkg/source/polydex/pool_tracker.go
+++ b/pkg/source/polydex/pool_tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -22,7 +23,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	log := logger.WithFields(logger.Fields{
 		"liquiditySource": DexTypePolydex,
 		"poolAddress":     p.Address,

--- a/pkg/source/pool/iface.go
+++ b/pkg/source/pool/iface.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type IPoolsListUpdater interface {
@@ -15,6 +16,10 @@ type IPoolsListUpdater interface {
 	// @return []byte the new metadataBytes for the next round
 	// @return error if there is any error
 	GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error)
+}
+
+type GetNewPoolStateParams struct {
+	Logs []types.Log
 }
 
 type IPoolTracker interface {

--- a/pkg/source/ramses/pool_tracker.go
+++ b/pkg/source/ramses/pool_tracker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -29,7 +30,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	var (
 		reserve                         Reserves
 		stableFee, volatileFee, pairFee *big.Int

--- a/pkg/source/saddle/pool_tracker.go
+++ b/pkg/source/saddle/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -24,7 +25,11 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[%s] Start getting new state of pool: %v", d.config.DexID, p.Address)
 
 	var (

--- a/pkg/source/syncswap/pool_tracker.go
+++ b/pkg/source/syncswap/pool_tracker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -29,7 +30,11 @@ func NewPoolTracker(
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	switch p.Type {
 	case poolTypeSyncSwapClassic:
 		return d.getClassicPoolState(ctx, p)

--- a/pkg/source/synthetix/pool_tracker.go
+++ b/pkg/source/synthetix/pool_tracker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/timer"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
@@ -51,7 +52,11 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, pool entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	pool entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	finish := timer.Start(fmt.Sprintf("[%s] get new pool state", d.cfg.DexID))
 	defer finish()
 

--- a/pkg/source/synthetix/pool_tracker.go
+++ b/pkg/source/synthetix/pool_tracker.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/timer"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
@@ -55,7 +55,7 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	pool entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	finish := timer.Start(fmt.Sprintf("[%s] get new pool state", d.cfg.DexID))
 	defer finish()

--- a/pkg/source/traderjoev20/pool_test.go
+++ b/pkg/source/traderjoev20/pool_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/traderjoecommon"
 )
 
@@ -68,7 +69,7 @@ func TestGetPoolState(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: usdceUSDCPool})
+	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: usdceUSDCPool}, dexpool.GetNewPoolStateParams{})
 	require.NoError(t, err)
 
 	spew.Dump(pool)

--- a/pkg/source/traderjoev20/pool_test.go
+++ b/pkg/source/traderjoev20/pool_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/traderjoecommon"
 )
 
@@ -69,7 +69,7 @@ func TestGetPoolState(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: usdceUSDCPool}, dexpool.GetNewPoolStateParams{})
+	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: usdceUSDCPool}, sourcePool.GetNewPoolStateParams{})
 	require.NoError(t, err)
 
 	spew.Dump(pool)

--- a/pkg/source/traderjoev20/pool_tracker.go
+++ b/pkg/source/traderjoev20/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/traderjoecommon"
 )
 
@@ -29,7 +30,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[TraderJoe v2.0] Start getting new state of pool: %v", p.Address)
 
 	rpcRequest := d.EthrpcClient.NewRequest()

--- a/pkg/source/traderjoev21/pool_test.go
+++ b/pkg/source/traderjoev21/pool_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/traderjoecommon"
 )
 
@@ -66,7 +66,7 @@ func TestGetPoolState(t *testing.T) {
 	tracker, err := NewPoolTracker(client)
 	require.NoError(t, err)
 
-	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: btcbUSDCPool}, dexpool.GetNewPoolStateParams{})
+	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: btcbUSDCPool}, sourcePool.GetNewPoolStateParams{})
 	require.NoError(t, err)
 
 	spew.Dump(pool)

--- a/pkg/source/traderjoev21/pool_test.go
+++ b/pkg/source/traderjoev21/pool_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/traderjoecommon"
 )
 
@@ -65,7 +66,7 @@ func TestGetPoolState(t *testing.T) {
 	tracker, err := NewPoolTracker(client)
 	require.NoError(t, err)
 
-	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: btcbUSDCPool})
+	pool, err := tracker.GetNewPoolState(context.Background(), entity.Pool{Address: btcbUSDCPool}, dexpool.GetNewPoolStateParams{})
 	require.NoError(t, err)
 
 	spew.Dump(pool)

--- a/pkg/source/traderjoev21/pool_tracker.go
+++ b/pkg/source/traderjoev21/pool_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/traderjoecommon"
 )
 
@@ -25,7 +26,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[TraderJoe v2.0] Start getting new state of pool: %v", p.Address)
 
 	rpcRequest := d.EthrpcClient.NewRequest()

--- a/pkg/source/uniswap/pool_tracker.go
+++ b/pkg/source/uniswap/pool_tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -22,7 +23,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[Uniswap V2] Start getting new state of pool: %v", p.Address)
 
 	rpcRequest := d.ethrpcClient.NewRequest()

--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
@@ -70,7 +71,11 @@ func initializeConfig(cfg *Config) (*Config, error) {
 	return cfg, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ dexpool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.Infof("[%s] Start getting new state of pool: %v", d.config.DexID, p.Address)
 
 	var (

--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	dexpool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
@@ -74,7 +74,7 @@ func initializeConfig(cfg *Config) (*Config, error) {
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ dexpool.GetNewPoolStateParams,
+	_ sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	logger.Infof("[%s] Start getting new state of pool: %v", d.config.DexID, p.Address)
 

--- a/pkg/source/velocimeter/pool_tracker.go
+++ b/pkg/source/velocimeter/pool_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -28,14 +29,18 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new state of pool", p.Type)
 
 	var (
-		reserve                Reserves
-		poolFee 			   *big.Int
+		reserve Reserves
+		poolFee *big.Int
 	)
 
 	calls := d.ethrpcClient.NewRequest().SetContext(ctx)

--- a/pkg/source/velodrome/pool_tracker.go
+++ b/pkg/source/velodrome/pool_tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KyberNetwork/logger"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -26,7 +27,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new state of pool", p.Type)

--- a/pkg/source/velodromev2/pool_tracker.go
+++ b/pkg/source/velodromev2/pool_tracker.go
@@ -2,14 +2,15 @@ package velodromev2
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"time"
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
 type PoolTracker struct {
@@ -27,7 +28,11 @@ func NewPoolTracker(
 	}, nil
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new state of pool", p.Type)

--- a/pkg/source/wombat/pool_tracker.go
+++ b/pkg/source/wombat/pool_tracker.go
@@ -3,12 +3,14 @@ package wombat
 import (
 	"context"
 	"encoding/json"
-	"github.com/KyberNetwork/ethrpc"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	"github.com/KyberNetwork/logger"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type PoolTracker struct {
@@ -23,7 +25,11 @@ func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
 	}
 }
 
-func (d *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+func (d *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
 	logger.WithFields(logger.Fields{
 		"address": p.Address,
 	}).Infof("[%s] Start getting new states of pool", p.Type)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update IPoolTracker interface for accepting more params

## Why did we need it?
<!--- Describe your changes in detail -->
We need to pass event logs for pool to handle properly:

- We need to fetch pool state from node at a specified block number
- We can use event logs to update uniswapv2 reserves instead of fetching it from node to reduce cost

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
