### PR TITLE
ci: run release only on release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,16 @@ on:
 
 jobs:
   prepare:
-    runs-on: [ ubuntu-22.04 ]
+    runs-on: [ubuntu-22.04]
     outputs:
       version_tag: ${{ steps.version_tag.outputs.value }}
       build_date: ${{ steps.build_date.outputs.value }}
     steps:
+      - name: Check branch
+        if: ${{ !startsWith(github.ref, 'refs/heads/release') }}
+        run: |
+          echo "This workflow should be triggered with workflow_dispatch on release branch"
+          exit 1
       - name: Format version tag
         shell: bash
         id: version_tag
@@ -45,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.19.x"
+          go-version: "1.21.x"
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
Limit branch to run release to `release`.
Some notes:
- Github Action doesn't have a way to limit the select branch when triggering action with `workflow_dispatch`. I use the `if` condition to limit the release to the `release` branch. Note that, developers can always remove this line and run the workflow on their branch. Reference: https://stackoverflow.com/questions/74633548/how-to-allow-manual-workflow-dispatch-only-on-specific-branches
- Github Action doesn't support regex matching. I use `startsWith` function to check the matching branch. Reference: https://github.com/orgs/community/discussions/26186

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
