### PR TITLE
Update feeToAmount of smardex pool state

### DIFF
--- a/pkg/source/smardex/pool_simulator_test.go
+++ b/pkg/source/smardex/pool_simulator_test.go
@@ -93,7 +93,7 @@ func TestCalcAmountOut(t *testing.T) {
 	if !ok {
 		t.Fatal(`Swapinfo is nil`)
 	}
-	if newState.NewReserveIn.Cmp(expectedResT0) != 0 {
+	if newState.NewReserveIn.Cmp(expectedResT0.Sub(expectedResT0, newState.FeeToAmount0)) != 0 {
 		t.Fatalf(`Invalid value = %d, expected: %d`, newState.NewReserveIn, expectedResT0)
 	}
 	if newState.NewReserveOut.Cmp(expectedResT1) != 0 {
@@ -309,8 +309,8 @@ func TestUpdateBalance(t *testing.T) {
 	})
 	assert.Equal(t, poolSimulator.FictiveReserve.FictiveReserve0.Cmp(expectedResFicT0), 0)
 	assert.Equal(t, poolSimulator.FictiveReserve.FictiveReserve1.Cmp(expectedResFicT1), 0)
-	assert.Equal(t, poolSimulator.Info.Reserves[0].Cmp(expectedResT0), 0)
-	assert.Equal(t, poolSimulator.Info.Reserves[1].Cmp(expectedResT1), 0)
+	assert.Equal(t, poolSimulator.Info.Reserves[0].Cmp(expectedResT0.Sub(expectedResT0, poolSimulator.FeeToAmount.Fees0)), 0)
+	assert.Equal(t, poolSimulator.Info.Reserves[1].Cmp(expectedResT1.Sub(expectedResT1, poolSimulator.FeeToAmount.Fees1)), 0)
 	assert.Equal(t, poolSimulator.PriceAverage.PriceAverage0.Cmp(priceAvT0), 0)
 	assert.Equal(t, poolSimulator.PriceAverage.PriceAverage1.Cmp(priceAvT1), 0)
 	assert.Equal(t, poolSimulator.PriceAverage.PriceAverageLastTimestamp.Cmp(big.NewInt(TIMESTAMP_JAN_2020)), 0)

--- a/pkg/source/smardex/pool_simulator_test.go
+++ b/pkg/source/smardex/pool_simulator_test.go
@@ -93,7 +93,7 @@ func TestCalcAmountOut(t *testing.T) {
 	if !ok {
 		t.Fatal(`Swapinfo is nil`)
 	}
-	if newState.NewReserveIn.Cmp(expectedResT0.Sub(expectedResT0, newState.FeeToAmount0)) != 0 {
+	if newState.NewReserveIn.Cmp(new(big.Int).Sub(expectedResT0, newState.FeeToAmount0)) != 0 {
 		t.Fatalf(`Invalid value = %d, expected: %d`, newState.NewReserveIn, expectedResT0)
 	}
 	if newState.NewReserveOut.Cmp(expectedResT1) != 0 {
@@ -309,8 +309,8 @@ func TestUpdateBalance(t *testing.T) {
 	})
 	assert.Equal(t, poolSimulator.FictiveReserve.FictiveReserve0.Cmp(expectedResFicT0), 0)
 	assert.Equal(t, poolSimulator.FictiveReserve.FictiveReserve1.Cmp(expectedResFicT1), 0)
-	assert.Equal(t, poolSimulator.Info.Reserves[0].Cmp(expectedResT0.Sub(expectedResT0, poolSimulator.FeeToAmount.Fees0)), 0)
-	assert.Equal(t, poolSimulator.Info.Reserves[1].Cmp(expectedResT1.Sub(expectedResT1, poolSimulator.FeeToAmount.Fees1)), 0)
+	assert.Equal(t, poolSimulator.Info.Reserves[0].Cmp(new(big.Int).Sub(expectedResT0, poolSimulator.FeeToAmount.Fees0)), 0)
+	assert.Equal(t, poolSimulator.Info.Reserves[1].Cmp(new(big.Int).Sub(expectedResT1, poolSimulator.FeeToAmount.Fees1)), 0)
 	assert.Equal(t, poolSimulator.PriceAverage.PriceAverage0.Cmp(priceAvT0), 0)
 	assert.Equal(t, poolSimulator.PriceAverage.PriceAverage1.Cmp(priceAvT1), 0)
 	assert.Equal(t, poolSimulator.PriceAverage.PriceAverageLastTimestamp.Cmp(big.NewInt(TIMESTAMP_JAN_2020)), 0)

--- a/pkg/source/smardex/type.go
+++ b/pkg/source/smardex/type.go
@@ -87,4 +87,6 @@ type SwapInfo struct {
 	NewPriceAverageIn         *big.Int
 	NewPriceAverageOut        *big.Int
 	PriceAverageLastTimestamp *big.Int
+	FeeToAmount0              *big.Int
+	FeeToAmount1              *big.Int
 }


### PR DESCRIPTION
FeeToAmount and priceAverage1 is updated wrong, link to sc, [priceAverage](https://basescan.org/address/0xdd4536dD9636564D891c919416880a3e250f975A#code#F27#L212) and [feeToAmount](https://basescan.org/address/0xdd4536dD9636564D891c919416880a3e250f975A#code#F27#L306).
When UpdateBalance func miss some values, it can cause getRoute return bad result.

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
https://team-kyber.atlassian.net/browse/AG-1222

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
- Make price local storage, local pool state storage are up to date with staging.
- Follow step by step from the [ticket](https://team-kyber.atlassian.net/browse/AG-1222).
- Result: 2 APIs must return the same result despite alien-base-stableswap is include or exclude.

## Screenshots (if appropriate):
