### PR TITLE
improvement: uniswapv3 ticks

### DIFF
--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -2,7 +2,6 @@ package uniswapv3
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"math/big"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
 	"github.com/machinebox/graphql"
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"

--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -233,11 +233,11 @@ func (d *PoolTracker) fetchRPCData(ctx context.Context, p entity.Pool) (FetchRPC
 
 func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]TickResp, error) {
 	allowSubgraphError := d.config.IsAllowSubgraphError()
-	skip := 0
+	lastTickIdx := ""
 	var ticks []TickResp
 
 	for {
-		req := graphql.NewRequest(getPoolTicksQuery(allowSubgraphError, poolAddress, skip))
+		req := graphql.NewRequest(getPoolTicksQuery(allowSubgraphError, poolAddress, lastTickIdx))
 
 		var resp struct {
 			Pool *SubgraphPoolTicks        `json:"pool"`
@@ -279,11 +279,7 @@ func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]T
 			break
 		}
 
-		skip += len(resp.Pool.Ticks)
-		if skip > graphSkipLimit {
-			logger.Infoln("hit skip limit, continue in next cycle")
-			break
-		}
+		lastTickIdx = resp.Pool.Ticks[len(resp.Pool.Ticks)-1].TickIdx
 	}
 
 	return ticks, nil

--- a/pkg/source/uniswapv3/queries.go
+++ b/pkg/source/uniswapv3/queries.go
@@ -88,7 +88,13 @@ func getPoolTicksQuery(allowSubgraphError bool, poolAddress string, skip int) st
 			id: "{{.PoolAddress}}"
 		) {
 			id
-			ticks(orderBy: tickIdx, orderDirection: asc, first: 1000, skip: {{.Skip}}) {
+			ticks(
+				where: { liquidityGross_not: 0 }
+				orderBy: tickIdx,
+				orderDirection: asc,
+				first: 1000,
+				skip: {{.Skip}}
+			) {
 				tickIdx
 				liquidityNet
 				liquidityGross

--- a/pkg/source/uniswapv3/queries.go
+++ b/pkg/source/uniswapv3/queries.go
@@ -16,7 +16,7 @@ type PoolsListQueryParams struct {
 type PoolTicksQueryParams struct {
 	AllowSubgraphError bool
 	PoolAddress        string
-	Skip               int
+	LastTickIdx        string
 }
 
 func getPoolsListQuery(allowSubgraphError bool, lastCreatedAtTimestamp *big.Int, first, skip int) string {
@@ -74,12 +74,12 @@ func getPoolsListQuery(allowSubgraphError bool, lastCreatedAtTimestamp *big.Int,
 	return tpl.String()
 }
 
-func getPoolTicksQuery(allowSubgraphError bool, poolAddress string, skip int) string {
+func getPoolTicksQuery(allowSubgraphError bool, poolAddress string, lastTickIdx string) string {
 	var tpl bytes.Buffer
 	td := PoolTicksQueryParams{
 		allowSubgraphError,
 		poolAddress,
-		skip,
+		lastTickIdx,
 	}
 
 	t, err := template.New("poolTicksQuery").Parse(`{
@@ -89,11 +89,13 @@ func getPoolTicksQuery(allowSubgraphError bool, poolAddress string, skip int) st
 		) {
 			id
 			ticks(
-				where: { liquidityGross_not: 0 }
+				where: {
+					{{ if .LastTickIdx }}tickIdx_gt: {{.LastTickIdx}},{{ end }}
+					liquidityGross_not: 0
+				},
 				orderBy: tickIdx,
 				orderDirection: asc,
-				first: 1000,
-				skip: {{.Skip}}
+				first: 1000
 			) {
 				tickIdx
 				liquidityNet

--- a/pkg/source/uniswapv3/queries_test.go
+++ b/pkg/source/uniswapv3/queries_test.go
@@ -98,16 +98,24 @@ func TestQueriesUniswapV3_GetPoolTicksQuery(t *testing.T) {
 			id: "%v"
 		) {
 			id
-			ticks(orderBy: tickIdx, orderDirection: asc, first: 1000, skip: %v) {
+			ticks(
+				where: {
+					tickIdx_gt: %v,
+					liquidityGross_not: 0
+				},
+				orderBy: tickIdx,
+				orderDirection: asc,
+				first: 1000
+			) {
 				tickIdx
 				liquidityNet
 				liquidityGross
 			}
 		}
 		_meta { block { timestamp }}
-	}`, "abc", 0)
+	}`, "abc", "0")
 
-		actual := getPoolTicksQuery(true, "abc", 0)
+		actual := getPoolTicksQuery(true, "abc", "0")
 
 		assert.Equal(t, expect, actual)
 	})
@@ -119,16 +127,24 @@ func TestQueriesUniswapV3_GetPoolTicksQuery(t *testing.T) {
 			id: "%v"
 		) {
 			id
-			ticks(orderBy: tickIdx, orderDirection: asc, first: 1000, skip: %v) {
+			ticks(
+				where: {
+					tickIdx_gt: %v,
+					liquidityGross_not: 0
+				},
+				orderBy: tickIdx,
+				orderDirection: asc,
+				first: 1000
+			) {
 				tickIdx
 				liquidityNet
 				liquidityGross
 			}
 		}
 		_meta { block { timestamp }}
-	}`, "abc", 0)
+	}`, "abc", "0")
 
-		actual := getPoolTicksQuery(false, "abc", 0)
+		actual := getPoolTicksQuery(false, "abc", "0")
 
 		assert.Equal(t, expect, actual)
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
- Skip tracking empty ticks.
- Fetch all ticks instead of limit by subgraph 6000 ticks.
- Use `go-json` lib.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
