### PR TITLE
check maverick minmax binindex to reduce loop

### DIFF
--- a/pkg/source/maverickv1/errors.go
+++ b/pkg/source/maverickv1/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrDividedByZero     = errors.New("divided by zero")
 	ErrInvalidLiquidity  = errors.New("invalid liquidity")
 	ErrEmptyBins         = errors.New("maverick pool has no bin")
+	ErrEmptyBinMap       = errors.New("maverick pool has no bin map")
 )

--- a/pkg/source/maverickv1/math_test.go
+++ b/pkg/source/maverickv1/math_test.go
@@ -1,18 +1,17 @@
-package maverickv1_test
+package maverickv1
 
 import (
 	"math/big"
 	"testing"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/elastic"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/maverickv1"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSwapAForBWithoutExactOut(t *testing.T) {
-	var bins = map[string]maverickv1.Bin{
+	var bins = map[string]Bin{
 		"1": {
 			ReserveA:  bignumber.NewBig10("497483862887020288"),
 			ReserveB:  bignumber.NewBig10("0"),
@@ -174,7 +173,7 @@ func TestSwapAForBWithoutExactOut(t *testing.T) {
 		"-1": bignumber.NewBig10("7463162598112715418867754100145796611164620634624434827815830738677402697728"),
 	}
 
-	var state = &maverickv1.MaverickPoolState{
+	var state = &MaverickPoolState{
 		Bins:             bins,
 		TickSpacing:      big.NewInt(953),
 		Fee:              big.NewInt(int64((0.3 / 100) * 1e18)),
@@ -183,33 +182,35 @@ func TestSwapAForBWithoutExactOut(t *testing.T) {
 		ProtocolFeeRatio: big.NewInt(0),
 		BinPositions:     binPositions,
 		BinMap:           binMap,
+		minBinMapIndex:   big.NewInt(-1),
+		maxBinMapIndex:   big.NewInt(0),
 	}
-	orgState, err := maverickv1.DeepcopyState(state)
+	orgState, err := DeepcopyState(state)
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("1850163333337788672")
-	_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, true, false, false)
+	_, amountOut, err := GetAmountOut(state, amountIn, true, false, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "1676945827577881677", amountOut.String())
 
 	// should work with both binMap and binMapHex
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, true, false, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, true, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1676945827577881677", amountOut.String())
 	}
 	// should work with binMapHex only
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, true, false, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, true, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1676945827577881677", amountOut.String())
@@ -217,7 +218,7 @@ func TestSwapAForBWithoutExactOut(t *testing.T) {
 }
 
 func TestSwapAForBExactOut(t *testing.T) {
-	var bins = map[string]maverickv1.Bin{
+	var bins = map[string]Bin{
 		"1": {
 			ReserveA:  bignumber.NewBig10("497483862887020288"),
 			ReserveB:  bignumber.NewBig10("0"),
@@ -379,7 +380,7 @@ func TestSwapAForBExactOut(t *testing.T) {
 		"-1": bignumber.NewBig10("7463162598112715418867754100145796611164620634624434827815830738677402697728"),
 	}
 
-	var state = &maverickv1.MaverickPoolState{
+	var state = &MaverickPoolState{
 		Bins:             bins,
 		TickSpacing:      big.NewInt(953),
 		Fee:              big.NewInt(int64((0.3 / 100) * 1e18)),
@@ -388,33 +389,35 @@ func TestSwapAForBExactOut(t *testing.T) {
 		ProtocolFeeRatio: big.NewInt(0),
 		BinPositions:     binPositions,
 		BinMap:           binMap,
+		minBinMapIndex:   big.NewInt(-1),
+		maxBinMapIndex:   big.NewInt(0),
 	}
-	orgState, err := maverickv1.DeepcopyState(state)
+	orgState, err := DeepcopyState(state)
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("2963297000000000000")
-	_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, true, true, false)
+	_, amountOut, err := GetAmountOut(state, amountIn, true, true, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "2963297000000000000", amountOut.String())
 
 	// should work with both binMap and binMapHex
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, true, true, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, true, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "2963297000000000000", amountOut.String())
 	}
 	// should work with binMapHex only
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, true, true, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, true, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "2963297000000000000", amountOut.String())
@@ -428,7 +431,7 @@ func TestSwapAForBExactOut(t *testing.T) {
 }
 
 func TestSwapBForAExactOut(t *testing.T) {
-	var bins = map[string]maverickv1.Bin{
+	var bins = map[string]Bin{
 		"1": {
 			ReserveA:  bignumber.NewBig10("497483862887020288"),
 			ReserveB:  bignumber.NewBig10("0"),
@@ -590,7 +593,7 @@ func TestSwapBForAExactOut(t *testing.T) {
 		"-1": bignumber.NewBig10("7463162598112715418867754100145796611164620634624434827815830738677402697728"),
 	}
 
-	var state = &maverickv1.MaverickPoolState{
+	var state = &MaverickPoolState{
 		Bins:             bins,
 		TickSpacing:      big.NewInt(953),
 		Fee:              big.NewInt(int64((0.3 / 100) * 1e18)),
@@ -599,33 +602,35 @@ func TestSwapBForAExactOut(t *testing.T) {
 		ProtocolFeeRatio: big.NewInt(0),
 		BinPositions:     binPositions,
 		BinMap:           binMap,
+		minBinMapIndex:   big.NewInt(-1),
+		maxBinMapIndex:   big.NewInt(0),
 	}
-	orgState, err := maverickv1.DeepcopyState(state)
+	orgState, err := DeepcopyState(state)
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("1894736241169897472")
-	_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, false, true, false)
+	_, amountOut, err := GetAmountOut(state, amountIn, false, true, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "1894736241169897472", amountOut.String())
 
 	// should work with both binMap and binMapHex
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, false, true, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, false, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1894736241169897472", amountOut.String())
 	}
 	// should work with binMapHex only
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, false, true, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, false, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1894736241169897472", amountOut.String())
@@ -633,7 +638,7 @@ func TestSwapBForAExactOut(t *testing.T) {
 }
 
 func TestSwapBForAWithoutExactOut(t *testing.T) {
-	bins := map[string]maverickv1.Bin{
+	bins := map[string]Bin{
 		"1": {
 			ReserveA:  bignumber.NewBig10("36455272596522751"),
 			ReserveB:  bignumber.NewBig10("0"),
@@ -814,7 +819,7 @@ func TestSwapBForAWithoutExactOut(t *testing.T) {
 		"-1": bignumber.NewBig10("7463166048985888814149647817523727749677346860178920913009108319939514597376"),
 	}
 
-	var state = &maverickv1.MaverickPoolState{
+	var state = &MaverickPoolState{
 		Bins:             bins,
 		TickSpacing:      big.NewInt(953),
 		Fee:              big.NewInt(int64((0.3 / 100) * 1e18)),
@@ -823,33 +828,35 @@ func TestSwapBForAWithoutExactOut(t *testing.T) {
 		ProtocolFeeRatio: big.NewInt(0),
 		BinPositions:     binPositions,
 		BinMap:           binMap,
+		minBinMapIndex:   big.NewInt(-1),
+		maxBinMapIndex:   big.NewInt(0),
 	}
-	orgState, err := maverickv1.DeepcopyState(state)
+	orgState, err := DeepcopyState(state)
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("4221332000000000000")
-	_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, false, false, false)
+	_, amountOut, err := GetAmountOut(state, amountIn, false, false, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "4629465618898435945", amountOut.String())
 
 	// should work with both binMap and binMapHex
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, false, false, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, false, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "4629465618898435945", amountOut.String())
 	}
 	// should work with binMapHex only
 	{
-		state, err = maverickv1.DeepcopyState(orgState)
+		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := maverickv1.GetAmountOut(state, amountIn, false, false, false)
+		_, amountOut, err := GetAmountOut(state, amountIn, false, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "4629465618898435945", amountOut.String())

--- a/pkg/source/maverickv1/pool_simulator_test.go
+++ b/pkg/source/maverickv1/pool_simulator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,10 @@ var maverickPool, err = NewPoolSimulator(entity.Pool{
 
 func TestPoolCalcAmountOut(t *testing.T) {
 	assert.Nil(t, err)
+
+	// make sure that we can calculate min/max index if pool-service hasn't done that yet
+	assert.Equal(t, big.NewInt(5), maverickPool.state.minBinMapIndex)
+	assert.Equal(t, big.NewInt(6), maverickPool.state.maxBinMapIndex)
 
 	result, err := maverickPool.CalcAmountOut(pool.CalcAmountOutParams{
 		TokenAmountIn: pool.TokenAmount{
@@ -331,7 +336,7 @@ func BenchmarkCalcAmountOut(b *testing.B) {
 }
 
 func BenchmarkNextActive(b *testing.B) {
-	poolRedis := "{\"address\":\"0x012245db1919bbb6d727b9ce787c3169f963a898\",\"reserveUsd\":1.3045263641356901,\"amplifiedTvl\":8.068244485638408e+40,\"swapFee\":0.00008,\"exchange\":\"maverick-v1\",\"type\":\"maverick-v1\",\"timestamp\":1704265258,\"reserves\":[\"1171608824435142257\",\"76716840233381\"],\"tokens\":[{\"address\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"decimals\":6,\"weight\":50,\"swappable\":true},{\"address\":\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\"decimals\":18,\"weight\":50,\"swappable\":true}],\"extra\":\"{\\\"fee\\\":80000000000000,\\\"protocolFeeRatio\\\":0,\\\"activeTick\\\":1502,\\\"binCounter\\\":36,\\\"bins\\\":{\\\"1\\\":{\\\"reserveA\\\":314516285521548227,\\\"reserveB\\\":0,\\\"lowerTick\\\":1500,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"2\\\":{\\\"reserveA\\\":191245215895503843,\\\"reserveB\\\":0,\\\"lowerTick\\\":1501,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"3\\\":{\\\"reserveA\\\":114504301688631519,\\\"reserveB\\\":963774576010,\\\"lowerTick\\\":1502,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"31\\\":{\\\"reserveA\\\":108753991059500386,\\\"reserveB\\\":0,\\\"lowerTick\\\":1500,\\\"kind\\\":2,\\\"mergeId\\\":0},\\\"32\\\":{\\\"reserveA\\\":25486000000000000,\\\"reserveB\\\":0,\\\"lowerTick\\\":1495,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"33\\\":{\\\"reserveA\\\":42126000000000000,\\\"reserveB\\\":0,\\\"lowerTick\\\":1496,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"34\\\":{\\\"reserveA\\\":69628000000000000,\\\"reserveB\\\":0,\\\"lowerTick\\\":1497,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"35\\\":{\\\"reserveA\\\":115099589497454909,\\\"reserveB\\\":0,\\\"lowerTick\\\":1498,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"36\\\":{\\\"reserveA\\\":190249440772503320,\\\"reserveB\\\":0,\\\"lowerTick\\\":1499,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"4\\\":{\\\"reserveA\\\":0,\\\"reserveB\\\":38435140947772,\\\"lowerTick\\\":1503,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"5\\\":{\\\"reserveA\\\":0,\\\"reserveB\\\":23251195184809,\\\"lowerTick\\\":1504,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"6\\\":{\\\"reserveA\\\":0,\\\"reserveB\\\":14066729524731,\\\"lowerTick\\\":1505,\\\"kind\\\":0,\\\"mergeId\\\":0}},\\\"binPositions\\\":{\\\"1495\\\":{\\\"0\\\":32},\\\"1496\\\":{\\\"0\\\":33},\\\"1497\\\":{\\\"0\\\":34},\\\"1498\\\":{\\\"0\\\":35},\\\"1499\\\":{\\\"0\\\":36},\\\"1500\\\":{\\\"0\\\":1,\\\"2\\\":31},\\\"1501\\\":{\\\"0\\\":2},\\\"1502\\\":{\\\"0\\\":3},\\\"1503\\\":{\\\"0\\\":4},\\\"1504\\\":{\\\"0\\\":5},\\\"1505\\\":{\\\"0\\\":6}},\\\"binMap\\\":{\\\"23\\\":5807506497971120465074964654080854589440},\\\"binMapHex\\\":{\\\"17\\\":5807506497971120465074964654080854589440},\\\"liquidity\\\":1087229757983496926,\\\"sqrtPriceX96\\\":42831515231783862772}\",\"staticExtra\":\"{\\\"tickSpacing\\\":50}\"}"
+	poolRedis := "{\"address\":\"0x012245db1919bbb6d727b9ce787c3169f963a898\",\"reserveUsd\":1.3045263641356901,\"amplifiedTvl\":8.068244485638408e+40,\"swapFee\":0.00008,\"exchange\":\"maverick-v1\",\"type\":\"maverick-v1\",\"timestamp\":1704265258,\"reserves\":[\"1171608824435142257\",\"76716840233381\"],\"tokens\":[{\"address\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"decimals\":6,\"weight\":50,\"swappable\":true},{\"address\":\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\"decimals\":18,\"weight\":50,\"swappable\":true}],\"extra\":\"{\\\"minBinMapIndex\\\":23,\\\"maxBinMapIndex\\\":23,\\\"fee\\\":80000000000000,\\\"protocolFeeRatio\\\":0,\\\"activeTick\\\":1502,\\\"binCounter\\\":36,\\\"bins\\\":{\\\"1\\\":{\\\"reserveA\\\":314516285521548227,\\\"reserveB\\\":0,\\\"lowerTick\\\":1500,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"2\\\":{\\\"reserveA\\\":191245215895503843,\\\"reserveB\\\":0,\\\"lowerTick\\\":1501,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"3\\\":{\\\"reserveA\\\":114504301688631519,\\\"reserveB\\\":963774576010,\\\"lowerTick\\\":1502,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"31\\\":{\\\"reserveA\\\":108753991059500386,\\\"reserveB\\\":0,\\\"lowerTick\\\":1500,\\\"kind\\\":2,\\\"mergeId\\\":0},\\\"32\\\":{\\\"reserveA\\\":25486000000000000,\\\"reserveB\\\":0,\\\"lowerTick\\\":1495,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"33\\\":{\\\"reserveA\\\":42126000000000000,\\\"reserveB\\\":0,\\\"lowerTick\\\":1496,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"34\\\":{\\\"reserveA\\\":69628000000000000,\\\"reserveB\\\":0,\\\"lowerTick\\\":1497,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"35\\\":{\\\"reserveA\\\":115099589497454909,\\\"reserveB\\\":0,\\\"lowerTick\\\":1498,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"36\\\":{\\\"reserveA\\\":190249440772503320,\\\"reserveB\\\":0,\\\"lowerTick\\\":1499,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"4\\\":{\\\"reserveA\\\":0,\\\"reserveB\\\":38435140947772,\\\"lowerTick\\\":1503,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"5\\\":{\\\"reserveA\\\":0,\\\"reserveB\\\":23251195184809,\\\"lowerTick\\\":1504,\\\"kind\\\":0,\\\"mergeId\\\":0},\\\"6\\\":{\\\"reserveA\\\":0,\\\"reserveB\\\":14066729524731,\\\"lowerTick\\\":1505,\\\"kind\\\":0,\\\"mergeId\\\":0}},\\\"binPositions\\\":{\\\"1495\\\":{\\\"0\\\":32},\\\"1496\\\":{\\\"0\\\":33},\\\"1497\\\":{\\\"0\\\":34},\\\"1498\\\":{\\\"0\\\":35},\\\"1499\\\":{\\\"0\\\":36},\\\"1500\\\":{\\\"0\\\":1,\\\"2\\\":31},\\\"1501\\\":{\\\"0\\\":2},\\\"1502\\\":{\\\"0\\\":3},\\\"1503\\\":{\\\"0\\\":4},\\\"1504\\\":{\\\"0\\\":5},\\\"1505\\\":{\\\"0\\\":6}},\\\"binMap\\\":{\\\"23\\\":5807506497971120465074964654080854589440},\\\"binMapHex\\\":{\\\"17\\\":5807506497971120465074964654080854589440},\\\"liquidity\\\":1087229757983496926,\\\"sqrtPriceX96\\\":42831515231783862772}\",\"staticExtra\":\"{\\\"tickSpacing\\\":50}\"}"
 	var poolEnt entity.Pool
 	err := json.Unmarshal([]byte(poolRedis), &poolEnt)
 	require.Nil(b, err)
@@ -383,6 +388,9 @@ func TestUpdateBalance(t *testing.T) {
 	sim, err := NewPoolSimulator(poolEnt)
 	require.Nil(t, err)
 
+	assert.Equal(t, int64(-1), sim.state.minBinMapIndex.Int64())
+	assert.Equal(t, int64(0), sim.state.maxBinMapIndex.Int64())
+
 	testCases := []struct {
 		tokenIn      string
 		tokenOut     string
@@ -428,6 +436,9 @@ func TestUpdateBalanceNextTick(t *testing.T) {
 
 	sim, err := NewPoolSimulator(poolEnt)
 	require.Nil(t, err)
+
+	assert.Equal(t, big.NewInt(6), sim.state.minBinMapIndex)
+	assert.Equal(t, big.NewInt(7), sim.state.maxBinMapIndex)
 
 	testCases := []struct {
 		tokenIn      string

--- a/pkg/source/maverickv1/type.go
+++ b/pkg/source/maverickv1/type.go
@@ -37,6 +37,9 @@ type Extra struct {
 	// State to calculate TVL
 	Liquidity    *big.Int `json:"liquidity"`
 	SqrtPriceX96 *big.Int `json:"sqrtPriceX96"`
+
+	MinBinMapIndex *big.Int `json:"minBinMapIndex"`
+	MaxBinMapIndex *big.Int `json:"maxBinMapIndex"`
 }
 
 type MaverickPoolState struct {
@@ -49,6 +52,9 @@ type MaverickPoolState struct {
 	BinPositions     map[string]map[string]*big.Int `json:"binPositions"`
 	BinMap           map[string]*big.Int            `json:"binMap"`
 	BinMapHex        map[string]*big.Int            `json:"binMapHex"`
+
+	minBinMapIndex *big.Int
+	maxBinMapIndex *big.Int
 }
 
 // maverickSwapInfo present the after state of a swap


### PR DESCRIPTION
Before:
`BenchmarkNextActive-8   	    6309	    189167 ns/op	   57862 B/op	    5062 allocs/op`

After:
`BenchmarkNextActive-8   	   31614	     37237 ns/op	   43612 B/op	    1063 allocs/op`

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
