### PR TITLE
[Fix] gmx-gpl race condition

### DIFF
--- a/pkg/source/gmx-glp/pool_simulator_unstake.go
+++ b/pkg/source/gmx-glp/pool_simulator_unstake.go
@@ -1,16 +1,17 @@
 package gmxglp
 
 import (
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	"math/big"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
-func (p *PoolSimulator) UnstakeAndRedeemGlp(tokenOut string, glpAmount *big.Int) (*big.Int, error) {
+func (p *PoolSimulator) UnstakeAndRedeemGlp(swapInfo *gmxGlpSwapInfo, tokenOut string, glpAmount *big.Int) (*big.Int, error) {
 	if glpAmount.Cmp(bignumber.ZeroBI) <= 0 {
 		return nil, ErrRewardRouterInvalidGlpAmount
 	}
 
-	amountOut, err := p.removeLiquidityForAccount(tokenOut, glpAmount)
+	amountOut, err := p.removeLiquidityForAccount(swapInfo, tokenOut, glpAmount)
 	if err != nil {
 		return nil, err
 	}
@@ -18,7 +19,7 @@ func (p *PoolSimulator) UnstakeAndRedeemGlp(tokenOut string, glpAmount *big.Int)
 	return amountOut, nil
 }
 
-func (p *PoolSimulator) removeLiquidityForAccount(tokenOut string, glpAmount *big.Int) (*big.Int, error) {
+func (p *PoolSimulator) removeLiquidityForAccount(swapInfo *gmxGlpSwapInfo, tokenOut string, glpAmount *big.Int) (*big.Int, error) {
 	if glpAmount.Cmp(bignumber.ZeroBI) <= 0 {
 		return nil, ErrGlpManagerInvalidAmount
 	}
@@ -42,7 +43,7 @@ func (p *PoolSimulator) removeLiquidityForAccount(tokenOut string, glpAmount *bi
 	//IMintable(glp).burn(_account, _glpAmount);
 	//IERC20(usdg).transfer(address(vault), usdgAmount);
 
-	amountOut, err := p.SellUSDG(tokenOut, usdgAmount)
+	amountOut, err := p.SellUSDG(swapInfo, tokenOut, usdgAmount)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +51,7 @@ func (p *PoolSimulator) removeLiquidityForAccount(tokenOut string, glpAmount *bi
 	return amountOut, nil
 }
 
-func (p *PoolSimulator) SellUSDG(token string, usdgAmount *big.Int) (*big.Int, error) {
+func (p *PoolSimulator) SellUSDG(swapInfo *gmxGlpSwapInfo, token string, usdgAmount *big.Int) (*big.Int, error) {
 	//_validate(whitelistedTokens[_token], 19);  // handled at canSwapTo
 	p.vault.UseSwapPricing = true
 
@@ -66,8 +67,8 @@ func (p *PoolSimulator) SellUSDG(token string, usdgAmount *big.Int) (*big.Int, e
 		return nil, ErrVaultNegativeRedemptionAmount
 	}
 
-	p.swapInfo.usdgAmount = new(big.Int).Set(usdgAmount)
-	p.swapInfo.redemptionAmount = new(big.Int).Set(redemptionAmount)
+	swapInfo.usdgAmount = new(big.Int).Set(usdgAmount)
+	swapInfo.redemptionAmount = new(big.Int).Set(redemptionAmount)
 	//p.vault.DecreaseUSDGAmount(token, usdgAmount)
 	//p.vault.DecreasePoolAmount(token, redemptionAmount)
 	if err = p.validateMinPoolAmount(token, redemptionAmount); err != nil {


### PR DESCRIPTION
gmx-glp: make a new `gmxGlpSwapInfo` per CalcAmountOut call instead of using the shared PoolSimulator.swapInfo field


<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
