### PR TITLE
reuse D and vPrice in curve-meta instead of re-calculating

### DIFF
--- a/pkg/source/curve/aave/math.go
+++ b/pkg/source/curve/aave/math.go
@@ -161,6 +161,7 @@ func getY(
 	tokenIndexTo int,
 	x *big.Int,
 	xp []*big.Int,
+	dCached *big.Int,
 ) (*big.Int, error) {
 	var numTokens = len(xp)
 	if tokenIndexFrom == tokenIndexTo {
@@ -171,9 +172,13 @@ func getY(
 	}
 	var numTokensBI = big.NewInt(int64(numTokens))
 	var a = _getAPrecise(futureATime, futureA, initialATime, initialA)
-	var d, err = getD(xp, a)
-	if err != nil {
-		return nil, err
+	d := dCached
+	if d == nil {
+		var err error
+		d, err = getD(xp, a)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var c = new(big.Int).Set(d)
 	var s = big.NewInt(0)
@@ -253,7 +258,7 @@ func _calculateSwap(
 		return nil, nil, err
 	}
 	var x = new(big.Int).Add(new(big.Int).Mul(dx, tokenPrecisionMultipliers[tokenIndexFrom]), xp[tokenIndexFrom])
-	y, err := getY(futureATime, futureA, initialATime, initialA, tokenIndexFrom, tokenIndexTo, x, xp)
+	y, err := getY(futureATime, futureA, initialATime, initialA, tokenIndexFrom, tokenIndexTo, x, xp, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -712,6 +717,7 @@ func GetDyUnderlying(
 		tokenIndexTo,
 		x,
 		xp,
+		nil,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/source/curve/aave/pool_simulator.go
+++ b/pkg/source/curve/aave/pool_simulator.go
@@ -264,7 +264,7 @@ func (t *AavePool) RemoveLiquidityOneCoin(tokenAmount *big.Int, i int) (*big.Int
 	return dy, nil
 }
 
-func (t *AavePool) GetDy(i int, j int, dx *big.Int) (*big.Int, *big.Int, error) {
+func (t *AavePool) GetDy(i int, j int, dx *big.Int, dCached *big.Int) (*big.Int, *big.Int, error) {
 	var nTokens = len(t.Info.Tokens)
 	xp := make([]*big.Int, nTokens)
 	for _i := 0; _i < nTokens; _i += 1 {
@@ -275,7 +275,7 @@ func (t *AavePool) GetDy(i int, j int, dx *big.Int) (*big.Int, *big.Int, error) 
 	var x = new(big.Int).Add(xp[i], new(big.Int).Mul(dx, t.Multipliers[i]))
 
 	// y: uint256 = self.get_y(i, j, x, xp)
-	var y, err = getY(t.FutureATime, t.FutureA, t.InitialATime, t.InitialA, i, j, x, xp)
+	var y, err = getY(t.FutureATime, t.FutureA, t.InitialATime, t.InitialA, i, j, x, xp, dCached)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -299,14 +299,14 @@ func (t *AavePool) GetDy(i int, j int, dx *big.Int) (*big.Int, *big.Int, error) 
 	return dy, fee, nil
 }
 
-func (t *AavePool) GetVirtualPrice() (*big.Int, error) {
+func (t *AavePool) GetVirtualPrice() (*big.Int, *big.Int, error) {
 	var A = _getAPrecise(t.FutureATime, t.FutureA, t.InitialATime, t.InitialA)
 	D, err := t.getDPrecision(t.Info.Reserves, A)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if t.LpSupply.Cmp(bignumber.ZeroBI) == 0 {
-		return nil, ErrDenominatorZero
+		return nil, nil, ErrDenominatorZero
 	}
-	return new(big.Int).Div(new(big.Int).Mul(D, Precision), t.LpSupply), nil
+	return new(big.Int).Div(new(big.Int).Mul(D, Precision), t.LpSupply), D, nil
 }

--- a/pkg/source/curve/aave/pool_simulator_test.go
+++ b/pkg/source/curve/aave/pool_simulator_test.go
@@ -127,13 +127,18 @@ func TestGetDyVirtualPrice(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	v, err := p.GetVirtualPrice()
+	v, dCached, err := p.GetVirtualPrice()
 	require.Nil(t, err)
 	assert.Equal(t, utils.NewBig10("1077638023314146944"), v)
 
 	for idx, tc := range testcases {
 		t.Run(fmt.Sprintf("test %d", idx), func(t *testing.T) {
-			dy, _, err := p.GetDy(tc.i, tc.j, utils.NewBig10(tc.dx))
+			dy, _, err := p.GetDy(tc.i, tc.j, utils.NewBig10(tc.dx), nil)
+			require.Nil(t, err)
+			assert.Equal(t, utils.NewBig10(tc.expOut), dy)
+
+			// test using cached D
+			dy, _, err = p.GetDy(tc.i, tc.j, utils.NewBig10(tc.dx), dCached)
 			require.Nil(t, err)
 			assert.Equal(t, utils.NewBig10(tc.expOut), dy)
 		})

--- a/pkg/source/curve/base/pool_simulator.go
+++ b/pkg/source/curve/base/pool_simulator.go
@@ -106,6 +106,7 @@ func (t *PoolBaseSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool
 			tokenIndexFrom,
 			tokenIndexTo,
 			tokenAmountIn.Amount,
+			nil,
 		)
 		if err != nil {
 			return &pool.CalcAmountOutResult{}, err

--- a/pkg/source/curve/base/pool_simulator_test.go
+++ b/pkg/source/curve/base/pool_simulator_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
 func TestCalcAmountOut(t *testing.T) {
@@ -118,5 +120,61 @@ func BenchmarkCalcAmountOut(b *testing.B) {
 			Limit:         nil,
 		})
 		require.Nil(b, err)
+	}
+}
+
+func TestGetDyVirtualPrice(t *testing.T) {
+	// test data from https://etherscan.io/address/0x1005f7406f32a61bd760cfa14accd2737913d546#readContract
+	testcases := []struct {
+		i      int
+		j      int
+		dx     string
+		expOut string
+	}{
+		{0, 1, "100000000000000", "140254485"},
+		{0, 1, "1000000000000", "140254485"},
+		{0, 1, "100000000", "99936588"},
+		{0, 1, "100002233", "99938816"},
+		{1, 0, "20000", "19982"},
+		{1, 0, "3000200", "2997456"},
+		{1, 0, "88001800", "69067695"},
+		{1, 0, "100000000000000", "69244498"},
+	}
+	poolRedis := `{
+		"address": "0x1005f7406f32a61bd760cfa14accd2737913d546",
+		"reserveUsd": 209.42969262729198,
+		"amplifiedTvl": 209.42969262729198,
+		"exchange": "curve",
+		"type": "curve-base",
+		"timestamp": 1705393976,
+		"reserves": ["69265278", "140296574", "208111994100559113335"],
+		"tokens": [
+			{ "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "weight": 1, "swappable": true },
+			{ "address": "0xdac17f958d2ee523a2206206994597c13d831ec7", "weight": 1, "swappable": true }
+		],
+		"extra": "{\"initialA\":\"150000\",\"futureA\":\"150000\",\"initialATime\":0,\"futureATime\":0,\"swapFee\":\"3000000\",\"adminFee\":\"5000000000\"}",
+		"staticExtra": "{\"lpToken\":\"0x1005f7406f32a61bd760cfa14accd2737913d546\",\"aPrecision\":\"100\",\"precisionMultipliers\":[\"1000000000000\",\"1000000000000\"],\"rates\":[\"1000000000000000000000000000000\",\"1000000000000000000000000000000\"]}"
+	}`
+	var poolEntity entity.Pool
+	err := json.Unmarshal([]byte(poolRedis), &poolEntity)
+	require.Nil(t, err)
+	p, err := NewPoolSimulator(poolEntity)
+	require.Nil(t, err)
+
+	v, dCached, err := p.GetVirtualPrice()
+	require.Nil(t, err)
+	assert.Equal(t, bignumber.NewBig10("1006923185919753102"), v)
+
+	for idx, tc := range testcases {
+		t.Run(fmt.Sprintf("test %d", idx), func(t *testing.T) {
+			dy, _, err := p.GetDy(tc.i, tc.j, bignumber.NewBig10(tc.dx), nil)
+			require.Nil(t, err)
+			assert.Equal(t, bignumber.NewBig10(tc.expOut), dy)
+
+			// test using cached D
+			dy, _, err = p.GetDy(tc.i, tc.j, bignumber.NewBig10(tc.dx), dCached)
+			require.Nil(t, err)
+			assert.Equal(t, bignumber.NewBig10(tc.expOut), dy)
+		})
 	}
 }

--- a/pkg/source/curve/meta/pool_simulator.go
+++ b/pkg/source/curve/meta/pool_simulator.go
@@ -24,7 +24,7 @@ type ICurveBasePool interface {
 	GetInfo() pool.PoolInfo
 	GetTokenIndex(address string) int
 	// return both vPrice and D
-	GetVirtualPrice() (*big.Int, *big.Int, error)
+	GetVirtualPrice() (vPrice *big.Int, D *big.Int, err error)
 	// if `dCached` is nil then will be recalculated
 	GetDy(i int, j int, dx *big.Int, dCached *big.Int) (*big.Int, *big.Int, error)
 	CalculateTokenAmount(amounts []*big.Int, deposit bool) (*big.Int, error)

--- a/pkg/source/curve/meta/pool_simulator.go
+++ b/pkg/source/curve/meta/pool_simulator.go
@@ -23,8 +23,10 @@ import (
 type ICurveBasePool interface {
 	GetInfo() pool.PoolInfo
 	GetTokenIndex(address string) int
-	GetVirtualPrice() (*big.Int, error)
-	GetDy(i int, j int, dx *big.Int) (*big.Int, *big.Int, error)
+	// return both vPrice and D
+	GetVirtualPrice() (*big.Int, *big.Int, error)
+	// if `dCached` is nil then will be recalculated
+	GetDy(i int, j int, dx *big.Int, dCached *big.Int) (*big.Int, *big.Int, error)
 	CalculateTokenAmount(amounts []*big.Int, deposit bool) (*big.Int, error)
 	CalculateWithdrawOneCoin(tokenAmount *big.Int, i int) (*big.Int, *big.Int, error)
 	AddLiquidity(amounts []*big.Int) (*big.Int, error)

--- a/pkg/source/curve/meta/pool_simulator_test.go
+++ b/pkg/source/curve/meta/pool_simulator_test.go
@@ -206,3 +206,36 @@ func TestUpdateBalance(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkGetDyUnderlying(b *testing.B) {
+
+	// {"Am", 1000, "A", 31},
+	base, err := base.NewPoolSimulator(entity.Pool{
+		Exchange:    "",
+		Type:        "",
+		Reserves:    entity.PoolReserves{"93649867132724477811796755", "92440712316473", "175421309630243", "352290453972395231054279357"},
+		Tokens:      []*entity.PoolToken{{Address: "A"}, {Address: "B"}, {Address: "C"}},
+		Extra:       "{\"initialA\":\"5000\",\"futureA\":\"2000\",\"initialATime\":1653559305,\"futureATime\":1654158027,\"swapFee\":\"1000000\",\"adminFee\":\"5000000000\"}",
+		StaticExtra: "{\"lpToken\":\"LPBase\",\"aPrecision\":\"1\",\"precisionMultipliers\":[\"1\",\"1000000000000\",\"1000000000000\"],\"rates\":[\"1000000000000000000\",\"1000000000000000000000000000000\",\"1000000000000000000000000000000\"]}",
+	})
+	require.Nil(b, err)
+
+	p, err := NewPoolSimulator(entity.Pool{
+		Exchange:    "",
+		Type:        "",
+		Reserves:    entity.PoolReserves{"4763102571534863472313821", "15272752439110430673281", "0"},
+		Tokens:      []*entity.PoolToken{{Address: "Am"}, {Address: "Bm"}},
+		Extra:       "{\"initialA\":\"10000\",\"futureA\":\"25000\",\"initialATime\":1649327847,\"futureATime\":1649925962,\"swapFee\":\"4000000\",\"adminFee\":\"0\"}",
+		StaticExtra: "{\"lpToken\":\"LPMeta\",\"basePool\":\"0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7\",\"rateMultiplier\":\"1000000000000000000\",\"aPrecision\":\"100\",\"underlyingTokens\":[\"0x674c6ad92fd080e4004b2312b45f796a192d27a0\",\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"0xdac17f958d2ee523a2206206994597c13d831ec7\"],\"precisionMultipliers\":[\"1\",\"1\"],\"rates\":[\"\",\"\"]}",
+	}, base)
+	require.Nil(b, err)
+
+	for i := 0; i < b.N; i++ {
+		_, err = p.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: "B", Amount: big.NewInt(10)},
+			TokenOut:      "A",
+			Limit:         nil,
+		})
+		require.Nil(b, err)
+	}
+}

--- a/pkg/source/curve/plain-oracle/pool_simulator.go
+++ b/pkg/source/curve/plain-oracle/pool_simulator.go
@@ -101,6 +101,7 @@ func (t *Pool) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOu
 			tokenIndexFrom,
 			tokenIndexTo,
 			tokenAmountIn.Amount,
+			nil,
 		)
 		if err != nil {
 			return &pool.CalcAmountOutResult{}, err

--- a/pkg/source/curve/plain-oracle/pool_simulator_test.go
+++ b/pkg/source/curve/plain-oracle/pool_simulator_test.go
@@ -1,6 +1,7 @@
 package plainoracle
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
 func TestCalcAmountOut(t *testing.T) {
@@ -54,6 +56,63 @@ func TestCalcAmountOut(t *testing.T) {
 			require.Nil(t, err)
 			assert.Equal(t, big.NewInt(tc.expectedOutAmount), out.TokenAmountOut.Amount)
 			assert.Equal(t, tc.out, out.TokenAmountOut.Token)
+		})
+	}
+}
+
+func TestGetDyVirtualPrice(t *testing.T) {
+	// test data from https://optimistic.etherscan.io/address/0xb90b9b1f91a01ea22a182cd84c1e22222e39b415#readContract
+	testcases := []struct {
+		i      int
+		j      int
+		dx     string
+		expOut string
+	}{
+		{0, 1, "100000000000000", "86818314418062"},
+		{0, 1, "1000000000000", "868183154558"},
+		{0, 1, "100000000", "86818316"},
+		{0, 1, "100002233", "86820254"},
+		{1, 0, "20000", "23018"},
+		{1, 0, "3000200", "3452958"},
+		{1, 0, "88001800", "101282099"},
+		{1, 0, "100000000000000", "115090939134446"},
+	}
+	poolRedis := `{
+		"address": "0xb90b9b1f91a01ea22a182cd84c1e22222e39b415",
+		"reserveUsd": 834336.0036396985,
+		"amplifiedTvl": 834336.0036396985,
+		"exchange": "curve",
+		"type": "curve-plain-oracle",
+		"timestamp": 1705393864,
+		"reserves": ["156463394192707746175", "150781038654005989858", "316970452569291468507"],
+		"tokens": [
+			{ "address": "0x4200000000000000000000000000000000000006", "weight": 1, "swappable": true },
+			{ "address": "0x1f32b1c2345538c0c6f582fcb022739c4a194ebb", "weight": 1, "swappable": true }
+		],
+		"extra": "{\"rates\":[1000000000000000000,1153777372655731291],\"initialA\":\"5000\",\"futureA\":\"5000\",\"initialATime\":0,\"futureATime\":0,\"swapFee\":\"4000000\",\"adminFee\":\"5000000000\"}",
+		"staticExtra": "{\"lpToken\":\"0xefde221f306152971d8e9f181bfe998447975810\",\"aPrecision\":\"100\",\"precisionMultipliers\":[\"1\",\"1\"],\"oracle\":\"0xe59EBa0D492cA53C6f46015EEa00517F2707dc77\"}"
+	}
+	`
+	var poolEntity entity.Pool
+	err := json.Unmarshal([]byte(poolRedis), &poolEntity)
+	require.Nil(t, err)
+	p, err := NewPoolSimulator(poolEntity)
+	require.Nil(t, err)
+
+	v, dCached, err := p.GetVirtualPrice()
+	require.Nil(t, err)
+	assert.Equal(t, bignumber.NewBig10("1042437950645007280"), v)
+
+	for idx, tc := range testcases {
+		t.Run(fmt.Sprintf("test %d", idx), func(t *testing.T) {
+			dy, _, err := p.GetDy(tc.i, tc.j, bignumber.NewBig10(tc.dx), nil)
+			require.Nil(t, err)
+			assert.Equal(t, bignumber.NewBig10(tc.expOut), dy)
+
+			// test using cached D
+			dy, _, err = p.GetDy(tc.i, tc.j, bignumber.NewBig10(tc.dx), dCached)
+			require.Nil(t, err)
+			assert.Equal(t, bignumber.NewBig10(tc.expOut), dy)
 		})
 	}
 }


### PR DESCRIPTION
Issue 1:
Curve-meta is calling `t.BasePool.GetVirtualPrice()` inside `_xp_mem` (https://github.com/KyberNetwork/kyberswap-dex-lib/pull/313/files#diff-9a159db6433983dec62bd91411fbf325a97bd332f85a4be258f0e6024303a39dR10)
But its caller always have `vPrice` calculated already, and the calculation is expensive, so we should pass from the caller instead

Issue 2:
In `GetDyUnderlying`, curve-meta will call `t.BasePool.GetVirtualPrice` then `t.BasePool.GetDy`
`t.BasePool.GetVirtualPrice` has calculated `D` already, and it's expensive, so we should return `D` in `t.BasePool.GetVirtualPrice` then pass it to `t.BasePool.GetDy` to be re-used

Benchmark:
Before
`BenchmarkGetDyUnderlying-8   	   80980	     14481 ns/op	   11297 B/op	     224 allocs/op`

After
`BenchmarkGetDyUnderlying-8   	  141639	      8081 ns/op	    6645 B/op	     136 allocs/op`

Staging:
Before
<img width="1036" alt="Screenshot 2024-01-16 at 16 06 35" src="https://github.com/KyberNetwork/kyberswap-dex-lib/assets/4106200/f82c0067-7871-414a-acd7-4dba66720ebe">

After
<img width="1003" alt="Screenshot 2024-01-16 at 16 06 55" src="https://github.com/KyberNetwork/kyberswap-dex-lib/assets/4106200/6f4803ce-3b7f-43e6-801e-4f323157e089">

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
