### PR TITLE
Fixes to apply to release v0.27 (continue)

### DIFF
--- a/pkg/liquidity-source/velocore-v2/cpmm/pool_simulator.go
+++ b/pkg/liquidity-source/velocore-v2/cpmm/pool_simulator.go
@@ -422,8 +422,10 @@ func (p *PoolSimulator) velocoreExecute(tokens []string, r []*big.Int) (*velocor
 // https://github.com/velocore/velocore-contracts/blob/c29678e5acbe5e60fc018e08289b49e53e1492f3/src/pools/constant-product/ConstantProductLibrary.sol#L25
 func (p *PoolSimulator) velocoreExecuteFallback(tokens []string, r_ []*big.Int) (*velocoreExecuteResult, error) {
 	var (
-		t   = p.Info.Tokens
-		a   = p.Info.Reserves
+		t = p.Info.Tokens
+		// we have to clone p.Info.Reserves because we're going to assign its by index,
+		// shallow clone is enough since its elements are read-only in this method
+		a   = append(([]*big.Int)(nil), p.Info.Reserves...)
 		idx = make([]int, len(tokens))
 		w   = p.weights
 


### PR DESCRIPTION
* shallow clone `p.Info.Reserves` to avoid race condition since `a` is going to be assigned

* use append() instead of slices.Clone()


<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
