### PR TITLE
optimize univ3 logic and alloc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 )
 
 replace (
-	github.com/KyberNetwork/uniswapv3-sdk-uint256 => github.com/KyberNetwork/uniswapv3-sdk v0.4.6-0.20240315085941-293573613c6a
+	github.com/KyberNetwork/uniswapv3-sdk-uint256 => github.com/KyberNetwork/uniswapv3-sdk v0.4.6-0.20240315094947-b9b1e1d0c671
 	github.com/daoleno/uniswap-sdk-core v0.1.5 => github.com/KyberNetwork/uniswap-sdk-core v0.1.5
 	github.com/daoleno/uniswapv3-sdk v0.4.0 => github.com/KyberNetwork/uniswapv3-sdk v0.4.5
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/KyberNetwork/pancake-v3-sdk v0.1.0 h1:HVUD13Qbwl4kiU1uSprQVpkis6fYYp3
 github.com/KyberNetwork/pancake-v3-sdk v0.1.0/go.mod h1:AhHu1v2KZAXKFZ9AnjwYPPx1+dDFHBqmSpSeg4fnvzg=
 github.com/KyberNetwork/uniswapv3-sdk v0.4.5 h1:/CBvZymypq6g3XzNpOAyhK7vfg7Mj1EJA5sAy+C7BoE=
 github.com/KyberNetwork/uniswapv3-sdk v0.4.5/go.mod h1:XFySgQXZ+dl0yRze6Rj8jloILcFP8FbXJjcyk/1RmSU=
-github.com/KyberNetwork/uniswapv3-sdk v0.4.6-0.20240315085941-293573613c6a h1:ADructSNn3mfquTuSuxaasUrqbUgi1Xtm/kRHDyU1ss=
-github.com/KyberNetwork/uniswapv3-sdk v0.4.6-0.20240315085941-293573613c6a/go.mod h1:VQNKmTwlX6gyW1gzaSQjYG+xCBpqmgH0VQslYMtqzAg=
+github.com/KyberNetwork/uniswapv3-sdk v0.4.6-0.20240315094947-b9b1e1d0c671 h1:yfP0PlZ9WDFGIVnHrnZQI1YQcxxnhdex4U9JaRSOLzc=
+github.com/KyberNetwork/uniswapv3-sdk v0.4.6-0.20240315094947-b9b1e1d0c671/go.mod h1:VQNKmTwlX6gyW1gzaSQjYG+xCBpqmgH0VQslYMtqzAg=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=

--- a/pkg/source/uniswapv3/pool_simulator_test.go
+++ b/pkg/source/uniswapv3/pool_simulator_test.go
@@ -116,6 +116,7 @@ func TestComparePoolSimulatorV2(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, result.TokenAmountOut, resultV2.TokenAmountOut)
 				assert.Equal(t, result.Fee, resultV2.Fee)
+				assert.Equal(t, result.RemainingTokenAmountIn.Amount.String(), resultV2.RemainingTokenAmountIn.Amount.String())
 
 				poolSim.UpdateBalance(pool.UpdateBalanceParams{
 					TokenAmountIn:  in.TokenAmountIn,
@@ -177,6 +178,7 @@ func TestComparePoolSimulatorV2(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, result.TokenAmountOut, resultV2.TokenAmountOut)
 				assert.Equal(t, result.Fee, resultV2.Fee)
+				assert.Equal(t, result.RemainingTokenAmountIn.Amount.String(), resultV2.RemainingTokenAmountIn.Amount.String())
 
 				poolSim.UpdateBalance(pool.UpdateBalanceParams{
 					TokenAmountIn:  in.TokenAmountIn,

--- a/pkg/source/uniswapv3/pool_simulator_test.go
+++ b/pkg/source/uniswapv3/pool_simulator_test.go
@@ -84,6 +84,27 @@ func TestCalcAmountOutConcurrentSafe(t *testing.T) {
 			require.NoError(t, err)
 			_ = result
 		})
+
+		t.Run(tc.name+"new sim", func(t *testing.T) {
+			poolEntity := new(entity.Pool)
+			err := json.Unmarshal([]byte(poolEncoded), poolEntity)
+			require.NoError(t, err)
+
+			poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainIDEthereum)
+			require.NoError(t, err)
+
+			result, err := testutil.MustConcurrentSafe[*pool.CalcAmountOutResult](t, func() (any, error) {
+				return poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+					TokenAmountIn: pool.TokenAmount{
+						Token:  tc.tokenIn,
+						Amount: bignumber.NewBig10(tc.amountIn),
+					},
+					TokenOut: tc.tokenOut,
+				})
+			})
+			require.NoError(t, err)
+			_ = result
+		})
 	}
 }
 


### PR DESCRIPTION
Benchmark:
Before (after part1 https://github.com/KyberNetwork/kyberswap-dex-lib/pull/322)
```
BenchmarkCalcAmountOutV2-8                	  112780	     10659 ns/op	   11472 B/op	     180 allocs/op
BenchmarkCalcAmountOutCrossFewTickV2-8    	   67615	     17725 ns/op	   17877 B/op	     334 allocs/op
BenchmarkCalcAmountOutCrossManyTickV2-8   	   10000	    104921 ns/op	   96741 B/op	    2285 allocs/op
```

After (after this PR)
```
BenchmarkCalcAmountOutV2-8                	  240918	      4977 ns/op	    3088 B/op	      40 allocs/op
BenchmarkCalcAmountOutCrossFewTickV2-8    	  112432	     10670 ns/op	    3088 B/op	      40 allocs/op
BenchmarkCalcAmountOutCrossManyTickV2-8   	   16384	     73133 ns/op	    3089 B/op	      40 allocs/op
```

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
