### PR TITLE
add univ2 InitPoolSimulator to allow caller to re-use sim instance

### DIFF
--- a/pkg/liquidity-source/uniswap-v2/pool_simulator.go
+++ b/pkg/liquidity-source/uniswap-v2/pool_simulator.go
@@ -76,6 +76,10 @@ func InitPoolSimulator(entityPool entity.Pool, sim *PoolSimulator) error {
 	if len(entityPool.Tokens) != NUM_TOKEN || len(entityPool.Reserves) != NUM_TOKEN {
 		return errors.New("Invalid number of token")
 	}
+	// in case the caller mess thing up
+	if sim == nil {
+		return errors.New("Invalid simulator instance")
+	}
 
 	var extra Extra
 	if err := json.Unmarshal([]byte(entityPool.Extra), &extra); err != nil {

--- a/pkg/liquidity-source/uniswap-v2/pool_simulator.go
+++ b/pkg/liquidity-source/uniswap-v2/pool_simulator.go
@@ -105,7 +105,10 @@ func InitPoolSimulator(entityPool entity.Pool, sim *PoolSimulator) error {
 	}
 	var tmp uint256.Int
 	for i := range entityPool.Reserves {
-		tmp.SetFromDecimal(entityPool.Reserves[i])
+		err := tmp.SetFromDecimal(entityPool.Reserves[i])
+		if err != nil {
+			return err
+		}
 		if sim.Pool.Info.Reserves[i] == nil {
 			sim.Pool.Info.Reserves[i] = new(big.Int)
 		}

--- a/pkg/util/bignumber/bignumber.go
+++ b/pkg/util/bignumber/bignumber.go
@@ -1,9 +1,15 @@
 package bignumber
 
 import (
+	"encoding/hex"
 	"math"
 	"math/big"
+	"math/bits"
+
+	"github.com/holiman/uint256"
 )
+
+const MaxWords = 256 / bits.UintSize
 
 var (
 	// TwoPow128 2^128
@@ -16,6 +22,8 @@ var (
 	Four   = big.NewInt(4)
 	Five   = big.NewInt(5)
 	Six    = big.NewInt(6)
+
+	MaxU256Hex, _ = hex.DecodeString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 )
 
 var BONE = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
@@ -38,4 +46,35 @@ func NewBig10(s string) (res *big.Int) {
 func NewBig(s string) (res *big.Int) {
 	res, _ = new(big.Int).SetString(s, 0)
 	return res
+}
+
+// similar to `z.ToBig()` but try to re-use space inside `b` instead of allocating
+func FillBig(z *uint256.Int, b *big.Int) {
+	switch MaxWords { // Compile-time check.
+	case 4: // 64-bit architectures.
+		if cap(b.Bits()) < 4 {
+			// this will resize b, we can be sure that b will only hold at most MaxU256
+			b.SetBytes(MaxU256Hex)
+		}
+		words := b.Bits()[:4]
+		words[0] = big.Word(z[0])
+		words[1] = big.Word(z[1])
+		words[2] = big.Word(z[2])
+		words[3] = big.Word(z[3])
+		b.SetBits(words)
+	case 8: // 32-bit architectures.
+		if cap(b.Bits()) < 8 {
+			b.SetBytes(MaxU256Hex)
+		}
+		words := b.Bits()[:8]
+		words[0] = big.Word(z[0])
+		words[1] = big.Word(z[0] >> 32)
+		words[2] = big.Word(z[1])
+		words[3] = big.Word(z[1] >> 32)
+		words[4] = big.Word(z[2])
+		words[5] = big.Word(z[2] >> 32)
+		words[6] = big.Word(z[3])
+		words[7] = big.Word(z[3] >> 32)
+		b.SetBits(words)
+	}
 }

--- a/pkg/util/bignumber/bignumber_test.go
+++ b/pkg/util/bignumber/bignumber_test.go
@@ -1,9 +1,12 @@
 package bignumber
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,4 +32,16 @@ func TestTenPowDecimals(t *testing.T) {
 		assert.Equal(t, 0, tc.expected.Cmp(actual))
 	}
 
+}
+
+func TestFillBig(t *testing.T) {
+	var bi big.Int
+	for i := 0; i < 500; i++ {
+		number := testutil.RandNumberHexString(64)
+		t.Run(fmt.Sprintf("test %s", number), func(t *testing.T) {
+			u := uint256.MustFromHex("0x" + number)
+			FillBig(u, &bi)
+			assert.Equal(t, u.Dec(), bi.Text(10))
+		})
+	}
 }

--- a/pkg/util/testutil/bignumber.go
+++ b/pkg/util/testutil/bignumber.go
@@ -1,0 +1,36 @@
+package testutil
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func RandNumberString(maxLen int) string {
+	sLen := rand.Intn(maxLen) + 1
+	var s string
+	for i := 0; i < sLen; i++ {
+		var c int
+		if i == 0 {
+			c = rand.Intn(9) + 1
+		} else {
+			c = rand.Intn(10)
+		}
+		s = fmt.Sprintf("%s%d", s, c)
+	}
+	return s
+}
+
+func RandNumberHexString(maxLen int) string {
+	sLen := rand.Intn(maxLen) + 1
+	var s string
+	for i := 0; i < sLen; i++ {
+		var c int
+		if i == 0 {
+			c = rand.Intn(15) + 1
+		} else {
+			c = rand.Intn(16)
+		}
+		s = fmt.Sprintf("%s%x", s, c)
+	}
+	return s
+}


### PR DESCRIPTION
`InitPoolSimulator` take in an instance of pool simulator and fill it instead of allocating new one

Benchmark:
Allocating new simulator every time:
`BenchmarkNewPoolSimulator-8     	 2421100	       485.7 ns/op	     464 B/op	      13 allocs/op`

Best case: always re-use the same simulator:
`BenchmarkNewPoolSimulatorV2-8   	 8776808	       135.8 ns/op	      48 B/op	       2 allocs/op`


## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
