### PR TITLE
use maverick tick crossed to estimate gas

### DIFF
--- a/pkg/source/maverickv1/constant.go
+++ b/pkg/source/maverickv1/constant.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	DefaultGas              = Gas{Swap: 125000}
+	DefaultGas              = Gas{Swap: 125000, CrossBin: 20000}
 	zeroBI                  = big.NewInt(0)
 	zeroString              = "0"
 	defaultTokenWeight uint = 50

--- a/pkg/source/maverickv1/math.go
+++ b/pkg/source/maverickv1/math.go
@@ -12,7 +12,7 @@ func GetAmountOut(
 	tokenAIn bool,
 	exactOutput bool,
 	isForPricing bool,
-) (*big.Int, *big.Int, error) {
+) (*big.Int, *big.Int, int, error) {
 	delta := &Delta{
 		DeltaInBinInternal: big.NewInt(0),
 		DeltaInErc:         big.NewInt(0),
@@ -34,7 +34,7 @@ func GetAmountOut(
 	for delta.Excess.Cmp(zeroBI) > 0 {
 		newDelta, err := swapTick(delta, state)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 		combine(delta, newDelta)
 
@@ -42,13 +42,13 @@ func GetAmountOut(
 		// as reasonable threshold
 		counter += 1
 		if isForPricing && counter > MaxSwapIterationCalculation {
-			return zeroBI, zeroBI, nil
+			return zeroBI, zeroBI, counter, nil
 		}
 	}
 	var amountIn = delta.DeltaInErc
 	var amountOut = delta.DeltaOutErc
 
-	return amountIn, amountOut, nil
+	return amountIn, amountOut, counter, nil
 }
 
 func swapTick(delta *Delta, state *MaverickPoolState) (*Delta, error) {

--- a/pkg/source/maverickv1/math_test.go
+++ b/pkg/source/maverickv1/math_test.go
@@ -189,7 +189,7 @@ func TestSwapAForBWithoutExactOut(t *testing.T) {
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("1850163333337788672")
-	_, amountOut, err := GetAmountOut(state, amountIn, true, false, false)
+	_, amountOut, _, err := GetAmountOut(state, amountIn, true, false, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "1676945827577881677", amountOut.String())
@@ -199,7 +199,7 @@ func TestSwapAForBWithoutExactOut(t *testing.T) {
 		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := GetAmountOut(state, amountIn, true, false, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, true, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1676945827577881677", amountOut.String())
@@ -210,7 +210,7 @@ func TestSwapAForBWithoutExactOut(t *testing.T) {
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := GetAmountOut(state, amountIn, true, false, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, true, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1676945827577881677", amountOut.String())
@@ -396,7 +396,7 @@ func TestSwapAForBExactOut(t *testing.T) {
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("2963297000000000000")
-	_, amountOut, err := GetAmountOut(state, amountIn, true, true, false)
+	_, amountOut, _, err := GetAmountOut(state, amountIn, true, true, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "2963297000000000000", amountOut.String())
@@ -406,7 +406,7 @@ func TestSwapAForBExactOut(t *testing.T) {
 		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := GetAmountOut(state, amountIn, true, true, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, true, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "2963297000000000000", amountOut.String())
@@ -417,7 +417,7 @@ func TestSwapAForBExactOut(t *testing.T) {
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := GetAmountOut(state, amountIn, true, true, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, true, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "2963297000000000000", amountOut.String())
@@ -609,7 +609,7 @@ func TestSwapBForAExactOut(t *testing.T) {
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("1894736241169897472")
-	_, amountOut, err := GetAmountOut(state, amountIn, false, true, false)
+	_, amountOut, _, err := GetAmountOut(state, amountIn, false, true, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "1894736241169897472", amountOut.String())
@@ -619,7 +619,7 @@ func TestSwapBForAExactOut(t *testing.T) {
 		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := GetAmountOut(state, amountIn, false, true, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, false, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1894736241169897472", amountOut.String())
@@ -630,7 +630,7 @@ func TestSwapBForAExactOut(t *testing.T) {
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := GetAmountOut(state, amountIn, false, true, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, false, true, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "1894736241169897472", amountOut.String())
@@ -835,7 +835,7 @@ func TestSwapBForAWithoutExactOut(t *testing.T) {
 	require.Nil(t, err)
 
 	var amountIn = elastic.NewBig10("4221332000000000000")
-	_, amountOut, err := GetAmountOut(state, amountIn, false, false, false)
+	_, amountOut, _, err := GetAmountOut(state, amountIn, false, false, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "4629465618898435945", amountOut.String())
@@ -845,7 +845,7 @@ func TestSwapBForAWithoutExactOut(t *testing.T) {
 		state, err = DeepcopyState(orgState)
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
-		_, amountOut, err := GetAmountOut(state, amountIn, false, false, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, false, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "4629465618898435945", amountOut.String())
@@ -856,7 +856,7 @@ func TestSwapBForAWithoutExactOut(t *testing.T) {
 		require.Nil(t, err)
 		state.BinMapHex = binMapHex
 		state.BinMap = nil
-		_, amountOut, err := GetAmountOut(state, amountIn, false, false, false)
+		_, amountOut, _, err := GetAmountOut(state, amountIn, false, false, false)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "4629465618898435945", amountOut.String())

--- a/pkg/source/maverickv1/type.go
+++ b/pkg/source/maverickv1/type.go
@@ -72,7 +72,8 @@ type Bin struct {
 }
 
 type Gas struct {
-	Swap int64
+	Swap     int64
+	CrossBin int64
 }
 
 type Delta struct {


### PR DESCRIPTION
Each bin crossed will cost some amount of gas, so we should take that into account as well, instead of just using flat constant (similar to univ3)

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
