### PR TITLE
fix: ignore meta when query pools from subgraph

### DIFF
--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	graphqlPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 type PoolTracker struct {
@@ -272,8 +271,7 @@ func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]T
 		req := graphql.NewRequest(getPoolTicksQuery(allowSubgraphError, poolAddress, lastTickIdx))
 
 		var resp struct {
-			Pool *SubgraphPoolTicks        `json:"pool"`
-			Meta *valueobject.SubgraphMeta `json:"_meta"`
+			Pool *SubgraphPoolTicks `json:"pool"`
 		}
 
 		if err := d.graphqlClient.Run(ctx, req, &resp); err != nil {
@@ -296,8 +294,6 @@ func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]T
 				return nil, err
 			}
 		}
-
-		resp.Meta.CheckIsLagging(d.config.DexID, poolAddress)
 
 		if resp.Pool == nil || len(resp.Pool.Ticks) == 0 {
 			break

--- a/pkg/source/uniswapv3/queries.go
+++ b/pkg/source/uniswapv3/queries.go
@@ -102,7 +102,6 @@ func getPoolTicksQuery(allowSubgraphError bool, poolAddress string, lastTickIdx 
 				liquidityGross
 			}
 		}
-		_meta { block { timestamp }}
 	}`)
 
 	if err != nil {

--- a/pkg/source/uniswapv3/queries_test.go
+++ b/pkg/source/uniswapv3/queries_test.go
@@ -112,7 +112,6 @@ func TestQueriesUniswapV3_GetPoolTicksQuery(t *testing.T) {
 				liquidityGross
 			}
 		}
-		_meta { block { timestamp }}
 	}`, "abc", "0")
 
 		actual := getPoolTicksQuery(true, "abc", "0")
@@ -141,7 +140,6 @@ func TestQueriesUniswapV3_GetPoolTicksQuery(t *testing.T) {
 				liquidityGross
 			}
 		}
-		_meta { block { timestamp }}
 	}`, "abc", "0")
 
 		actual := getPoolTicksQuery(false, "abc", "0")


### PR DESCRIPTION
Include `_meta` will fail the query, even with `subgraphError: "allow"` in the query. This commit fixes this by removing the `meta` field, to support uniswap-v3 polygon which currently has indexing error.

Reference:
- Query with `_meta`: [Link](https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-polygon/graphql?query=%7B%0A++pool%28subgraphError%3A+allow%2C+id%3A+%220x6bad0f9a89ca403bb91d253d385cec1a2b6eca97%22%29+%7B%0A++++id%0A++++feeTier%0A++++ticks%28%0A++++++where%3A+%7BliquidityGross_not%3A+0%7D%0A++++++orderBy%3A+tickIdx%0A++++++orderDirection%3A+asc%0A++++++first%3A+1000%0A++++%29+%7B%0A++++++tickIdx%0A++++++liquidityNet%0A++++++liquidityGross%0A++++%7D%0A++%7D%0A++_meta%7Bblock%7Bnumber%7D%7D%0A%7D#)
- Query without `_meta`: [Link](https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-polygon/graphql?query=%7B%0A++pool%28subgraphError%3A+allow%2C+id%3A+%220x6bad0f9a89ca403bb91d253d385cec1a2b6eca97%22%29+%7B%0A++++id%0A++++feeTier%0A++++ticks%28%0A++++++where%3A+%7BliquidityGross_not%3A+0%7D%0A++++++orderBy%3A+tickIdx%0A++++++orderDirection%3A+asc%0A++++++first%3A+1000%0A++++%29+%7B%0A++++++tickIdx%0A++++++liquidityNet%0A++++++liquidityGross%0A++++%7D%0A++%7D%0A%7D#)
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
