### PR TITLE
chore: update fetch ticks in uniswapv3

### DIFF
--- a/pkg/source/uniswapv3/constant.go
+++ b/pkg/source/uniswapv3/constant.go
@@ -13,7 +13,7 @@ const (
 	defaultTokenWeight    = 50
 	zeroString            = "0"
 	emptyString           = ""
-	graphQLRequestTimeout = 20 * time.Second
+	graphQLRequestTimeout = 60 * time.Second
 )
 
 const (

--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -271,13 +271,13 @@ func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]T
 		req := graphql.NewRequest(getPoolTicksQuery(allowSubgraphError, poolAddress, lastTickIdx))
 
 		var resp struct {
-			Pool *SubgraphPoolTicks `json:"pool"`
+			Ticks []TickResp `json:"ticks"`
 		}
 
 		if err := d.graphqlClient.Run(ctx, req, &resp); err != nil {
 			// Workaround at the moment to live with the error subgraph on Arbitrum
 			if allowSubgraphError {
-				if resp.Pool == nil {
+				if resp.Ticks == nil {
 					l.WithFields(logger.Fields{
 						"error":              err,
 						"allowSubgraphError": allowSubgraphError,
@@ -295,17 +295,17 @@ func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]T
 			}
 		}
 
-		if resp.Pool == nil || len(resp.Pool.Ticks) == 0 {
+		if resp.Ticks == nil || len(resp.Ticks) == 0 {
 			break
 		}
 
-		ticks = append(ticks, resp.Pool.Ticks...)
+		ticks = append(ticks, resp.Ticks...)
 
-		if len(resp.Pool.Ticks) < graphFirstLimit {
+		if len(resp.Ticks) < graphFirstLimit {
 			break
 		}
 
-		lastTickIdx = resp.Pool.Ticks[len(resp.Pool.Ticks)-1].TickIdx
+		lastTickIdx = resp.Ticks[len(resp.Ticks)-1].TickIdx
 	}
 
 	return ticks, nil

--- a/pkg/source/uniswapv3/queries.go
+++ b/pkg/source/uniswapv3/queries.go
@@ -83,24 +83,20 @@ func getPoolTicksQuery(allowSubgraphError bool, poolAddress string, lastTickIdx 
 	}
 
 	t, err := template.New("poolTicksQuery").Parse(`{
-		pool(
+		ticks(
 			{{ if .AllowSubgraphError }}subgraphError: allow,{{ end }}
-			id: "{{.PoolAddress}}"
+			where: {
+				pool: "{{.PoolAddress}}"
+				{{ if .LastTickIdx }}tickIdx_gt: {{.LastTickIdx}},{{ end }}
+				liquidityGross_not: 0
+			},
+			orderBy: tickIdx,
+			orderDirection: asc,
+			first: 1000
 		) {
-			id
-			ticks(
-				where: {
-					{{ if .LastTickIdx }}tickIdx_gt: {{.LastTickIdx}},{{ end }}
-					liquidityGross_not: 0
-				},
-				orderBy: tickIdx,
-				orderDirection: asc,
-				first: 1000
-			) {
-				tickIdx
-				liquidityNet
-				liquidityGross
-			}
+			tickIdx
+			liquidityNet
+			liquidityGross
 		}
 	}`)
 

--- a/pkg/source/uniswapv3/queries_test.go
+++ b/pkg/source/uniswapv3/queries_test.go
@@ -93,24 +93,20 @@ func TestQueriesUniswapV3_GetPoolTicksQuery(t *testing.T) {
 
 	t.Run("it should return correct query when allowing subgraph error", func(t *testing.T) {
 		expect := fmt.Sprintf(`{
-		pool(
+		ticks(
 			subgraphError: allow,
-			id: "%v"
+			where: {
+				pool: "%v"
+				tickIdx_gt: %v,
+				liquidityGross_not: 0
+			},
+			orderBy: tickIdx,
+			orderDirection: asc,
+			first: 1000
 		) {
-			id
-			ticks(
-				where: {
-					tickIdx_gt: %v,
-					liquidityGross_not: 0
-				},
-				orderBy: tickIdx,
-				orderDirection: asc,
-				first: 1000
-			) {
-				tickIdx
-				liquidityNet
-				liquidityGross
-			}
+			tickIdx
+			liquidityNet
+			liquidityGross
 		}
 	}`, "abc", "0")
 
@@ -121,24 +117,20 @@ func TestQueriesUniswapV3_GetPoolTicksQuery(t *testing.T) {
 
 	t.Run("it should return correct query when subgraph error is not allowed", func(t *testing.T) {
 		expect := fmt.Sprintf(`{
-		pool(
+		ticks(
 			
-			id: "%v"
+			where: {
+				pool: "%v"
+				tickIdx_gt: %v,
+				liquidityGross_not: 0
+			},
+			orderBy: tickIdx,
+			orderDirection: asc,
+			first: 1000
 		) {
-			id
-			ticks(
-				where: {
-					tickIdx_gt: %v,
-					liquidityGross_not: 0
-				},
-				orderBy: tickIdx,
-				orderDirection: asc,
-				first: 1000
-			) {
-				tickIdx
-				liquidityNet
-				liquidityGross
-			}
+			tickIdx
+			liquidityNet
+			liquidityGross
 		}
 	}`, "abc", "0")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
Change the fetch ticks query to be compatible with the new Polygon UniswapV3 error-fixed subgraph.
The logic also compatible with previous subgraphs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
