### PR TITLE
fix: uniswap-v2 safe math

### DIFF
--- a/pkg/liquidity-source/uniswap-v2/safe_math.go
+++ b/pkg/liquidity-source/uniswap-v2/safe_math.go
@@ -1,0 +1,56 @@
+package uniswapv2
+
+import (
+	"errors"
+
+	"github.com/holiman/uint256"
+)
+
+// a library for performing overflow-safe math, courtesy of DappHub (https://github.com/dapphub/ds-math)
+
+// library SafeMathUniswap {
+//     function add(uint x, uint y) internal pure returns (uint z) {
+//         require((z = x + y) >= x, 'ds-math-add-overflow');
+//     }
+
+//     function sub(uint x, uint y) internal pure returns (uint z) {
+//         require((z = x - y) <= x, 'ds-math-sub-underflow');
+//     }
+
+//     function mul(uint x, uint y) internal pure returns (uint z) {
+//         require(y == 0 || (z = x * y) / y == x, 'ds-math-mul-overflow');
+//     }
+// }
+
+var (
+	ErrDSMathAddOverflow  = errors.New("ds-math-add-overflow")
+	ErrDSMathSubUnderflow = errors.New("ds-math-sub-underflow")
+	ErrDSMathMulOverflow  = errors.New("ds-math-mul-overflow")
+)
+
+func SafeAdd(x, y *uint256.Int) *uint256.Int {
+	z := new(uint256.Int).Add(x, y)
+	if z.Cmp(x) >= 0 {
+		return z
+	}
+
+	panic(ErrDSMathAddOverflow)
+}
+
+func SafeSub(x, y *uint256.Int) *uint256.Int {
+	z := new(uint256.Int).Sub(x, y)
+	if z.Cmp(x) <= 0 {
+		return z
+	}
+
+	panic(ErrDSMathSubUnderflow)
+}
+
+func SafeMul(x, y *uint256.Int) *uint256.Int {
+	z := new(uint256.Int).Mul(x, y)
+	if y.CmpUint64(0) == 0 || new(uint256.Int).Div(z, y).Cmp(x) == 0 {
+		return z
+	}
+
+	panic(ErrDSMathMulOverflow)
+}

--- a/pkg/liquidity-source/uniswap-v2/safe_math_test.go
+++ b/pkg/liquidity-source/uniswap-v2/safe_math_test.go
@@ -1,0 +1,141 @@
+package uniswapv2
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	MaxUInt256 = new(uint256.Int).Sub(new(uint256.Int).Lsh(uint256.NewInt(1), 256), uint256.NewInt(1))
+)
+
+func TestSafeAdd(t *testing.T) {
+	type args struct {
+		x *uint256.Int
+		y *uint256.Int
+	}
+	tests := []struct {
+		name        string
+		args        args
+		want        *uint256.Int
+		shouldPanic bool
+	}{
+		{
+			name: "normal case",
+			args: args{
+				x: uint256.NewInt(10),
+				y: uint256.NewInt(5),
+			},
+			want: uint256.NewInt(15),
+		},
+		{
+			name: "overflow case",
+			args: args{
+				x: new(uint256.Int).Set(MaxUInt256),
+				y: uint256.NewInt(10),
+			},
+			want:        nil,
+			shouldPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assert.PanicsWithError(t, ErrDSMathAddOverflow.Error(), func() {
+					SafeAdd(tt.args.x, tt.args.y)
+				})
+			} else {
+				got := SafeAdd(tt.args.x, tt.args.y)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSafeSub(t *testing.T) {
+	type args struct {
+		x *uint256.Int
+		y *uint256.Int
+	}
+	tests := []struct {
+		name        string
+		args        args
+		want        *uint256.Int
+		shouldPanic bool
+	}{
+		{
+			name: "normal case",
+			args: args{
+				x: uint256.NewInt(10),
+				y: uint256.NewInt(5),
+			},
+			want: uint256.NewInt(5),
+		},
+		{
+			name: "underflow case",
+			args: args{
+				x: uint256.NewInt(10),
+				y: uint256.NewInt(15),
+			},
+			want:        nil,
+			shouldPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assert.PanicsWithError(t, ErrDSMathSubUnderflow.Error(), func() {
+					SafeSub(tt.args.x, tt.args.y)
+				})
+			} else {
+				got := SafeSub(tt.args.x, tt.args.y)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSafeMul(t *testing.T) {
+	type args struct {
+		x *uint256.Int
+		y *uint256.Int
+	}
+	tests := []struct {
+		name        string
+		args        args
+		want        *uint256.Int
+		shouldPanic bool
+	}{
+		{
+			name: "normal case",
+			args: args{
+				x: uint256.NewInt(10),
+				y: uint256.NewInt(5),
+			},
+			want: uint256.NewInt(50),
+		},
+		{
+			name: "overflow case",
+			args: args{
+				x: new(uint256.Int).Set(MaxUInt256),
+				y: uint256.NewInt(10),
+			},
+			want:        nil,
+			shouldPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assert.PanicsWithError(t, ErrDSMathMulOverflow.Error(), func() {
+					SafeMul(tt.args.x, tt.args.y)
+				})
+			} else {
+				got := SafeMul(tt.args.x, tt.args.y)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

Without SafeMath implementation, this pool https://polygonscan.com/address/0x96c7fc08d8cdacdb95a8613b19fffe4d54307263#code still gives a valid amount in = `1` for getAmountin() function with params:

```
reserveIn:        number.NewUint256("1160689189059097452"),
reserveOut:       number.NewUint256("1161607"),
amountOut:        number.NewUint256("500000000"),
```

But in reality, it should revert with the error `ds-math-sub-underflow`

This incorrect behavior breaks the CalcAmountIn function in onchain-price-service

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
