### PR TITLE
fixed ambient.PoolListUpdater.GetNewPools() returns error when metadataBytes=nil

### DIFF
--- a/pkg/liquidity-source/ambient/pool_list_updater.go
+++ b/pkg/liquidity-source/ambient/pool_list_updater.go
@@ -40,11 +40,13 @@ func (u *PoolListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte)
 
 	ctx = util.NewContextWithTimestamp(ctx)
 
-	if err := json.Unmarshal(metadataBytes, &meta); err != nil {
-		logger.
-			WithFields(logger.Fields{"dex_id": dexID, "err": err}).
-			Error("unmarshal metadata failed")
-		return nil, nil, err
+	if len(metadataBytes) != 0 {
+		if err := json.Unmarshal(metadataBytes, &meta); err != nil {
+			logger.
+				WithFields(logger.Fields{"dex_id": dexID, "err": err}).
+				Error("unmarshal metadata failed")
+			return nil, nil, err
+		}
 	}
 
 	sPools, err := u.fetchSubgraph(ctx, meta.LastCreateTime)

--- a/pkg/liquidity-source/ambient/pool_list_updater_test.go
+++ b/pkg/liquidity-source/ambient/pool_list_updater_test.go
@@ -14,20 +14,31 @@ import (
 func TestPoolListUpdater(t *testing.T) {
 	t.Skip()
 
-	var (
-		metadataBytes, _ = json.Marshal(ambient.PoolListUpdaterMetadata{LastCreateTime: 0})
-	)
-
 	pu := ambient.NewPoolsListUpdater(ambient.Config{
 		DexID:                  "ambient",
 		SubgraphURL:            "https://api.studio.thegraph.com/query/47610/croc-mainnet/version/latest",
 		SubgraphRequestTimeout: durationjson.Duration{Duration: time.Second * 10},
 	})
-	pools, meta, err := pu.GetNewPools(context.Background(), metadataBytes)
-	require.NoError(t, err)
 
-	t.Logf("%s\n", string(meta))
-	for i := range pools {
-		t.Logf("%+v\n", pools[i])
-	}
+	t.Run("nil metadataBytes, default config", func(t *testing.T) {
+		pools, meta, err := pu.GetNewPools(context.Background(), nil)
+		require.NoError(t, err)
+
+		t.Logf("%s\n", string(meta))
+		for i := range pools {
+			t.Logf("%+v\n", pools[i])
+		}
+	})
+
+	t.Run("with metadataBytes, specified lastCreateTime", func(t *testing.T) {
+		metadataBytes, _ := json.Marshal(ambient.PoolListUpdaterMetadata{LastCreateTime: 1697392211})
+
+		pools, meta, err := pu.GetNewPools(context.Background(), metadataBytes)
+		require.NoError(t, err)
+
+		t.Logf("%s\n", string(meta))
+		for i := range pools {
+			t.Logf("%+v\n", pools[i])
+		}
+	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
