### PR TITLE
implement missing CanSwapFrom for ambient.NTokenPool

### DIFF
--- a/pkg/liquidity-source/ambient/types.go
+++ b/pkg/liquidity-source/ambient/types.go
@@ -110,6 +110,8 @@ func (p *NTokenPool) CanSwapTo(address string) []string {
 	return adjs
 }
 
+func (p *NTokenPool) CanSwapFrom(address string) []string { return p.CanSwapTo(address) }
+
 func (p *NTokenPool) GetPair(tokenIn, tokenOut common.Address) (TokenPair, bool) {
 	base, quote := tokenIn, tokenOut
 	if base == p.nativeTokenAddress {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
