### PR TITLE
EX-2253: disallow swapping through underlaying tokens in curve-meta

### DIFF
--- a/pkg/liquidity-source/curve/stable-meta-ng/pool_simulator.go
+++ b/pkg/liquidity-source/curve/stable-meta-ng/pool_simulator.go
@@ -184,12 +184,9 @@ func (t *PoolSimulator) CanSwapTo(address string) []string {
 			for i := 0; i < t.NumTokens-1; i += 1 {
 				ret = append(ret, t.Info.Tokens[i])
 			}
-			underlyingTokens := t.basePool.GetInfo().Tokens
-			for i := 0; i < len(underlyingTokens); i += 1 {
-				if i != tokenIndex {
-					ret = append(ret, underlyingTokens[i])
-				}
-			}
+
+			// We don't allow swapping between underlying tokens here.
+			// Swap between underlying tokens must go directly through the base pool.
 		}
 		return ret
 	}

--- a/pkg/liquidity-source/curve/stable-meta-ng/pool_simulator_test.go
+++ b/pkg/liquidity-source/curve/stable-meta-ng/pool_simulator_test.go
@@ -146,9 +146,8 @@ func TestCalcAmountOut(t *testing.T) {
 		assert.Equal(t, []string{p.Info.Tokens[0]}, p.CanSwapTo(p.Info.Tokens[1]))
 
 		// base token can be swapped to anything other than the last meta token and itself
-		for i, baseToken := range p.GetBasePoolTokens() {
-			baseExcluded := lo.Filter(p.GetBasePoolTokens(), func(_ string, ii int) bool { return ii != i })
-			assert.Equal(t, append([]string{p.Info.Tokens[0]}, baseExcluded...), p.CanSwapTo(baseToken))
+		for _, baseToken := range p.GetBasePoolTokens() {
+			assert.Equal(t, []string{p.Info.Tokens[0]}, p.CanSwapTo(baseToken))
 		}
 
 		return p

--- a/pkg/source/curve/meta/pool_simulator.go
+++ b/pkg/source/curve/meta/pool_simulator.go
@@ -220,12 +220,9 @@ func (t *Pool) CanSwapTo(address string) []string {
 			for i := 0; i < len(t.Info.Tokens)-1; i += 1 {
 				ret = append(ret, t.Info.Tokens[i])
 			}
-			underlyingTokens := t.BasePool.GetInfo().Tokens
-			for i := 0; i < len(underlyingTokens); i += 1 {
-				if i != tokenIndex {
-					ret = append(ret, underlyingTokens[i])
-				}
-			}
+
+			// We don't allow swapping between underlying tokens here.
+			// Swap between underlying tokens must go directly through the base pool.
 		}
 		return ret
 	}

--- a/pkg/source/curve/meta/pool_simulator_test.go
+++ b/pkg/source/curve/meta/pool_simulator_test.go
@@ -120,9 +120,9 @@ func TestSwappable(t *testing.T) {
 	assert.Equal(t, []string{"Am"}, p.CanSwapTo("Bm"))
 
 	// base token can be swapped to anything other than the last meta token
-	assert.Equal(t, []string{"Am", "B", "C"}, p.CanSwapTo("A"))
-	assert.Equal(t, []string{"Am", "A", "C"}, p.CanSwapTo("B"))
-	assert.Equal(t, []string{"Am", "A", "B"}, p.CanSwapTo("C"))
+	assert.Equal(t, []string{"Am"}, p.CanSwapTo("A"))
+	assert.Equal(t, []string{"Am"}, p.CanSwapTo("B"))
+	assert.Equal(t, []string{"Am"}, p.CanSwapTo("C"))
 
 	errorcases := []struct {
 		in  string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
