### PR TITLE
fix: cast uint64 to string in swap info

### DIFF
--- a/pkg/liquidity-source/clipper/pool_simulator.go
+++ b/pkg/liquidity-source/clipper/pool_simulator.go
@@ -153,7 +153,7 @@ func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		SwapInfo: SwapInfo{
 			ChainID:           p.extra.ChainID,
 			TimeInSeconds:     p.extra.TimeInSeconds,
-			InputAmount:       params.TokenAmountIn.Amount,
+			InputAmount:       params.TokenAmountIn.Amount.String(),
 			InputAssetSymbol:  assetIn.Symbol,
 			OutputAssetSymbol: assetOut.Symbol,
 		},

--- a/pkg/liquidity-source/clipper/rfq.go
+++ b/pkg/liquidity-source/clipper/rfq.go
@@ -44,7 +44,7 @@ func (h *RFQHandler) RFQ(ctx context.Context, params pool.RFQParams) (*pool.RFQR
 	result, err := h.client.RFQ(ctx, QuoteParams{
 		ChainID:           swapInfo.ChainID,
 		TimeInSeconds:     swapInfo.TimeInSeconds,
-		InputAmount:       swapInfo.InputAmount.String(),
+		InputAmount:       swapInfo.InputAmount,
 		InputAssetSymbol:  swapInfo.InputAssetSymbol,
 		OutputAssetSymbol: swapInfo.OutputAssetSymbol,
 

--- a/pkg/liquidity-source/clipper/type.go
+++ b/pkg/liquidity-source/clipper/type.go
@@ -28,7 +28,7 @@ type PoolPair struct {
 type SwapInfo struct {
 	ChainID           uint
 	TimeInSeconds     int
-	InputAmount       *big.Int
+	InputAmount       string
 	InputAssetSymbol  string
 	OutputAssetSymbol string
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
Javascript will cast incorrectly when the number is too large. To avoid it, when returning int64 data to the client (in this case, the `InputAmount`), we will return the string form instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
