### PR TITLE
support algebra ticklens

### DIFF
--- a/pkg/source/algebrav1/abis.go
+++ b/pkg/source/algebrav1/abis.go
@@ -12,6 +12,7 @@ var (
 	algebraV1DataStorageOperatorAPI       abi.ABI
 	algebraV1DirFeeDataStorageOperatorAPI abi.ABI
 	erc20ABI                              abi.ABI
+	ticklensABI                           abi.ABI
 )
 
 func init() {
@@ -24,6 +25,7 @@ func init() {
 		{&algebraV1DataStorageOperatorAPI, algebraV1DataStorageOperatorJson},
 		{&algebraV1DirFeeDataStorageOperatorAPI, algebraV1DirFeeDataStorageOperatorJson},
 		{&erc20ABI, erc20Json},
+		{&ticklensABI, ticklensJson},
 	}
 
 	for _, b := range builder {

--- a/pkg/source/algebrav1/abis/TickLens.json
+++ b/pkg/source/algebrav1/abis/TickLens.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "function",
+    "name": "getPopulatedTicksInWord",
+    "inputs": [
+      { "name": "pool", "type": "address", "internalType": "address" },
+      { "name": "wordPositions", "type": "int16[]", "internalType": "int16[]" }
+    ],
+    "outputs": [
+      {
+        "name": "populatedTicks",
+        "type": "tuple[]",
+        "internalType": "struct TickLens.PopulatedTick[]",
+        "components": [
+          { "name": "tick", "type": "int24", "internalType": "int24" },
+          { "name": "liquidityNet", "type": "int128", "internalType": "int128" },
+          { "name": "liquidityGross", "type": "uint128", "internalType": "uint128" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/pkg/source/algebrav1/config.go
+++ b/pkg/source/algebrav1/config.go
@@ -9,4 +9,7 @@ type Config struct {
 	AllowSubgraphError bool        `json:"allowSubgraphError"`
 	SkipFeeCalculating bool        `json:"skipFeeCalculating"` // do not pre-calculate fee at tracker, use last block's fee instead
 	UseDirectionalFee  bool        `json:"useDirectionalFee"`  // for Camelot and similar dexes
+
+	AlwaysUseTickLens bool
+	TickLensAddress   string
 }

--- a/pkg/source/algebrav1/embed.go
+++ b/pkg/source/algebrav1/embed.go
@@ -18,3 +18,6 @@ var algebraV1DirFeeDataStorageOperatorJson []byte
 
 //go:embed abis/ERC20.json
 var erc20Json []byte
+
+//go:embed abis/TickLens.json
+var ticklensJson []byte

--- a/pkg/source/algebrav1/errors.go
+++ b/pkg/source/algebrav1/errors.go
@@ -15,4 +15,6 @@ var (
 	ErrZeroAmountOut       = errors.New("amountOut is 0")
 	ErrSPL                 = errors.New("invalid sqrt price limit")
 	ErrPoolLocked          = errors.New("pool is locked")
+
+	ErrNotSupportFetchFullTick = errors.New("not support fetching full ticks")
 )

--- a/pkg/source/algebrav1/pool_tracker.go
+++ b/pkg/source/algebrav1/pool_tracker.go
@@ -47,7 +47,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ sourcePool.GetNewPoolStateParams,
+	param sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
@@ -84,6 +84,16 @@ func (d *PoolTracker) GetNewPoolState(
 	})
 	g.Go(func(context.Context) error {
 		var err error
+		if d.config.AlwaysUseTickLens {
+			poolTicks, err = d.getPoolTicksFromSC(ctx, p, param)
+			if err != nil {
+				l.WithFields(logger.Fields{
+					"error": err,
+				}).Error("failed to call SC for pool ticks")
+			}
+			return err
+		}
+
 		poolTicks, err = d.getPoolTicks(ctx, p.Address)
 		if err != nil {
 			l.WithFields(logger.Fields{

--- a/pkg/source/algebrav1/ticklens.go
+++ b/pkg/source/algebrav1/ticklens.go
@@ -79,7 +79,7 @@ func (d *PoolTracker) getPoolTicksFromSC(ctx context.Context, pool entity.Pool, 
 		}
 
 		// ticklens contract might return unchanged tick (in the same word), so need to filter them out
-		changedTickSet := mapset.NewSet(changedTicks...)
+		changedTickSet := mapset.NewThreadUnsafeSet(changedTicks...)
 		changedTickMap := make(map[int]TickResp, len(changedTicks))
 		for _, t := range ticks {
 			tIdx, err := strconv.ParseInt(t.TickIdx, 10, 64)

--- a/pkg/source/algebrav1/ticklens.go
+++ b/pkg/source/algebrav1/ticklens.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/samber/lo"
@@ -24,10 +23,6 @@ import (
 const (
 	batchSize   = 500
 	maxWordSize = 256
-)
-
-var (
-	minWordIndex = utils.MinTick / maxWordSize
 )
 
 func (d *PoolTracker) getPoolTicksFromSC(ctx context.Context, pool entity.Pool, param sourcePool.GetNewPoolStateParams) ([]TickResp, error) {

--- a/pkg/source/algebrav1/ticklens.go
+++ b/pkg/source/algebrav1/ticklens.go
@@ -1,0 +1,127 @@
+package algebrav1
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"github.com/daoleno/uniswapv3-sdk/utils"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/ticklens"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util"
+)
+
+const (
+	batchSize   = 500
+	maxWordSize = 256
+)
+
+var (
+	minWordIndex = utils.MinTick / maxWordSize
+)
+
+func (d *PoolTracker) getPoolTicksFromSC(ctx context.Context, pool entity.Pool, param sourcePool.GetNewPoolStateParams) ([]TickResp, error) {
+	var wordIndexes []int16
+
+	changedTicks := ticklens.GetChangedTicks(param.Logs)
+	if len(changedTicks) > 0 {
+		// only refetch changed tick if possible
+		wordIndexes = lo.Uniq(lo.Map(changedTicks, func(t int64, _ int) int16 { return int16(t >> 8) }))
+	} else {
+		// Algebra doesn't compact the tick table, so it's not feasible to fetch all for now
+		return nil, ErrNotSupportFetchFullTick
+	}
+
+	logger.Infof("Fetch tick from wordPosition %v to %v (%v)", wordIndexes[0], wordIndexes[len(wordIndexes)-1], changedTicks)
+
+	chunkedWordIndexes := lo.Chunk(wordIndexes, batchSize)
+
+	var ticks []TickResp
+
+	for _, chunk := range chunkedWordIndexes {
+		rpcRequest := d.ethrpcClient.NewRequest()
+		rpcRequest.SetContext(util.NewContextWithTimestamp(ctx))
+
+		var populatedTicks []ticklens.PopulatedTick
+		rpcRequest.AddCall(&ethrpc.Call{
+			ABI:    ticklensABI,
+			Target: d.config.TickLensAddress,
+			Method: "getPopulatedTicksInWord",
+			Params: []interface{}{common.HexToAddress(pool.Address), chunk},
+		}, []interface{}{&populatedTicks})
+
+		_, err := rpcRequest.Call()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(populatedTicks) > 0 {
+			for _, pt := range populatedTicks {
+				ticks = append(ticks, TickResp{
+					TickIdx:        pt.Tick.String(),
+					LiquidityGross: pt.LiquidityGross.String(),
+					LiquidityNet:   pt.LiquidityNet.String(),
+				})
+			}
+		}
+	}
+
+	// if we only fetched some ticks, then update them to the original ticks and return
+	if len(changedTicks) > 0 {
+		var extra Extra
+		if err := json.Unmarshal([]byte(pool.Extra), &extra); err != nil {
+			return nil, err
+		}
+
+		// ticklens contract might return unchanged tick (in the same word), so need to filter them out
+		changedTickSet := mapset.NewSet(changedTicks...)
+		changedTickMap := make(map[int]TickResp, len(changedTicks))
+		for _, t := range ticks {
+			tIdx, err := strconv.ParseInt(t.TickIdx, 10, 64)
+			if err == nil && changedTickSet.ContainsOne(tIdx) {
+				changedTickMap[int(tIdx)] = t
+			}
+		}
+
+		combined := make([]TickResp, 0, len(changedTicks)+len(extra.Ticks))
+		for _, t := range extra.Ticks {
+			if tick, ok := changedTickMap[t.Index]; ok {
+				// changed, use new value
+				combined = append(combined, tick)
+				delete(changedTickMap, t.Index)
+			} else {
+				// use old value
+				combined = append(combined, TickResp{
+					TickIdx:        strconv.Itoa(t.Index),
+					LiquidityGross: t.LiquidityGross.String(),
+					LiquidityNet:   t.LiquidityNet.String(),
+				})
+			}
+		}
+
+		// remaining (newly created ticks)
+		for _, tick := range changedTickMap {
+			combined = append(combined, tick)
+		}
+		ticks = combined
+	}
+
+	sort.SliceStable(ticks, func(i, j int) bool {
+		iTick, _ := strconv.Atoi(ticks[i].TickIdx)
+		jTick, _ := strconv.Atoi(ticks[j].TickIdx)
+
+		return iTick < jTick
+	})
+
+	return ticks, nil
+}

--- a/pkg/source/pancakev3/pool_tracker.go
+++ b/pkg/source/pancakev3/pool_tracker.go
@@ -45,7 +45,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ sourcePool.GetNewPoolStateParams,
+	param sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
@@ -83,7 +83,7 @@ func (d *PoolTracker) GetNewPoolState(
 	g.Go(func(context.Context) error {
 		var err error
 		if d.config.AlwaysUseTickLens {
-			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, d.ethrpcClient, d.config.TickLensAddress, p)
+			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, d.ethrpcClient, d.config.TickLensAddress, p, param)
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"error": err,

--- a/pkg/source/ramsesv2/pool_tracker.go
+++ b/pkg/source/ramsesv2/pool_tracker.go
@@ -45,7 +45,7 @@ func NewPoolTracker(
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ sourcePool.GetNewPoolStateParams,
+	param sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	logger.Infof("[%s] Start getting new state of pool: %v", d.config.DexID, p.Address)
 
@@ -71,7 +71,7 @@ func (d *PoolTracker) GetNewPoolState(
 	g.Go(func(context.Context) error {
 		var err error
 		if d.config.AlwaysUseTickLens {
-			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, d.ethrpcClient, d.config.TickLensAddress, p)
+			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, d.ethrpcClient, d.config.TickLensAddress, p, param)
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"error": err,

--- a/pkg/source/uniswapv3/pool_tracker.go
+++ b/pkg/source/uniswapv3/pool_tracker.go
@@ -79,7 +79,7 @@ func initializeConfig(cfg *Config) (*Config, error) {
 func (d *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
-	_ sourcePool.GetNewPoolStateParams,
+	param sourcePool.GetNewPoolStateParams,
 ) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
@@ -121,7 +121,7 @@ func (d *PoolTracker) GetNewPoolState(
 		// TLDR: Optimism has some pre-genesis Uniswap V3 pool. Subgraph does not have data for these pools
 		// So we have to fetch ticks data from the TickLens smart contract (which is slower).
 		if d.config.AlwaysUseTickLens || lo.Contains[string](d.config.preGenesisPoolIDs, p.Address) {
-			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, d.ethrpcClient, d.config.TickLensAddress, p)
+			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, d.ethrpcClient, d.config.TickLensAddress, p, param)
 			if err != nil {
 				l.WithFields(logger.Fields{
 					"error": err,

--- a/pkg/util/ticklens/Events.json
+++ b/pkg/util/ticklens/Events.json
@@ -1,0 +1,15 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "int24", "name": "bottomTick", "type": "int24" },
+      { "indexed": true, "internalType": "int24", "name": "topTick", "type": "int24" },
+      { "indexed": false, "internalType": "uint128", "name": "liquidityAmount", "type": "uint128" },
+      { "indexed": false, "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "name": "Burn",
+    "type": "event"
+  }
+]

--- a/pkg/util/ticklens/abis.go
+++ b/pkg/util/ticklens/abis.go
@@ -11,6 +11,12 @@ var (
 	//go:embed TickLensProxy.json
 	tickLensProxyJson []byte
 	tickLensABI       abi.ABI
+
+	//go:embed Events.json
+	eventsJson []byte
+	eventsABI  abi.ABI
+
+	burnEvent abi.Event
 )
 
 func init() {
@@ -19,6 +25,7 @@ func init() {
 		data []byte
 	}{
 		{&tickLensABI, tickLensProxyJson},
+		{&eventsABI, eventsJson},
 	}
 
 	for _, b := range builder {
@@ -28,4 +35,5 @@ func init() {
 			panic(err)
 		}
 	}
+	burnEvent = eventsABI.Events["Burn"]
 }

--- a/pkg/util/ticklens/ticklens.go
+++ b/pkg/util/ticklens/ticklens.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/daoleno/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswapv3-sdk/utils"
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/samber/lo"
 
 	"github.com/KyberNetwork/logger"
@@ -18,6 +20,7 @@ import (
 	"github.com/KyberNetwork/ethrpc"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util"
 )
 
@@ -27,10 +30,19 @@ type TickResp struct {
 	LiquidityNet   string `json:"liquidityNet"`
 }
 
-type populatedTick struct {
+type PopulatedTick struct {
 	Tick           *big.Int
 	LiquidityNet   *big.Int
 	LiquidityGross *big.Int
+}
+
+type commonExtra struct {
+	TickSpacing int
+	Ticks       []struct {
+		Index          int      `json:"index"`
+		LiquidityGross *big.Int `json:"liquidityGross"`
+		LiquidityNet   *big.Int `json:"liquidityNet"`
+	} `json:"ticks"`
 }
 
 const (
@@ -50,24 +62,39 @@ func GetPoolTicksFromSC(
 	ethrpcClient *ethrpc.Client,
 	tickLensAddress string,
 	pool entity.Pool,
+	param pool.GetNewPoolStateParams,
 ) ([]TickResp, error) {
 	tickSpace := getTickSpacing(pool.SwapFee)
-	if tickSpace == 0 {
-		// non-standard pool fee, try again from pool extra
-		var extra struct{ TickSpacing int }
+	var extra commonExtra
+
+	var wordIndexes []int16
+
+	changedTicks := GetChangedTicks(param.Logs)
+
+	if tickSpace == 0 || len(changedTicks) > 0 {
+		// if we need to get tickSpace or original ticks, then unmarshal pool.Extra
 		if err := json.Unmarshal([]byte(pool.Extra), &extra); err != nil {
-			return nil, errors.New("failed to get pool tick spacing")
+			return nil, errors.New("failed to unmarshal pool extra")
 		}
 		tickSpace = extra.TickSpacing
 	}
-	poolMinWordIdx := int16(minWordIndex/tickSpace - 1)
-	poolMaxWordIdx := -poolMinWordIdx
 
-	// Prepare the list of wordIndexes, the total number of indexes is poolMaxWordIdx-poolMinWordIdx+1
-	wordIndexes := make([]int16, 0, poolMaxWordIdx-poolMinWordIdx+1)
-	for idx := poolMinWordIdx; idx <= poolMaxWordIdx; idx++ {
-		wordIndexes = append(wordIndexes, idx)
+	if len(changedTicks) > 0 {
+		// only refetch changed tick if possible
+		wordIndexes = lo.Uniq(lo.Map(changedTicks, func(t int64, _ int) int16 { return int16((t / int64(tickSpace)) >> 8) }))
+	} else {
+		// fetch all
+		poolMinWordIdx := int16(minWordIndex/tickSpace - 1)
+		poolMaxWordIdx := -poolMinWordIdx
+
+		// Prepare the list of wordIndexes, the total number of indexes is poolMaxWordIdx-poolMinWordIdx+1
+		wordIndexes = make([]int16, 0, poolMaxWordIdx-poolMinWordIdx+1)
+		for idx := poolMinWordIdx; idx <= poolMaxWordIdx; idx++ {
+			wordIndexes = append(wordIndexes, idx)
+		}
 	}
+
+	logger.Infof("Fetch tick from wordPosition %v to %v (%v)", wordIndexes[0], wordIndexes[len(wordIndexes)-1], changedTicks)
 
 	// We will process 500 word indexes at a time
 	chunkedWordIndexes := lo.Chunk[int16](wordIndexes, multicallBatchSize)
@@ -79,7 +106,7 @@ func GetPoolTicksFromSC(
 		rpcRequest.SetContext(util.NewContextWithTimestamp(ctx))
 
 		// In each word index, there will be 256 populatedTick, that's why the type is [][]populatedTick
-		populatedTicks := make([][]populatedTick, multicallBatchSize)
+		populatedTicks := make([][]PopulatedTick, multicallBatchSize)
 		for i, wordIndex := range chunk {
 			rpcRequest.AddCall(&ethrpc.Call{
 				ABI:    tickLensABI,
@@ -115,6 +142,41 @@ func GetPoolTicksFromSC(
 		}
 	}
 
+	// if we only fetched some ticks, then update them to the original ticks and return
+	if len(changedTicks) > 0 {
+		// ticklens contract might return unchanged tick (in the same word), so need to filter them out
+		changedTickSet := mapset.NewSet(changedTicks...)
+		changedTickMap := make(map[int]TickResp, len(changedTicks))
+		for _, t := range ticks {
+			tIdx, err := strconv.ParseInt(t.TickIdx, 10, 64)
+			if err == nil && changedTickSet.ContainsOne(tIdx) {
+				changedTickMap[int(tIdx)] = t
+			}
+		}
+
+		combined := make([]TickResp, 0, len(changedTicks)+len(extra.Ticks))
+		for _, t := range extra.Ticks {
+			if tick, ok := changedTickMap[t.Index]; ok {
+				// changed, use new value
+				combined = append(combined, tick)
+				delete(changedTickMap, t.Index)
+			} else {
+				// use old value
+				combined = append(combined, TickResp{
+					TickIdx:        strconv.Itoa(t.Index),
+					LiquidityGross: t.LiquidityGross.String(),
+					LiquidityNet:   t.LiquidityNet.String(),
+				})
+			}
+		}
+
+		// remaining (newly created ticks)
+		for _, tick := range changedTickMap {
+			combined = append(combined, tick)
+		}
+		ticks = combined
+	}
+
 	// Sort the ticks because function NewTickListDataProvider needs
 	sort.SliceStable(ticks, func(i, j int) bool {
 		iTick, _ := strconv.Atoi(ticks[i].TickIdx)
@@ -128,4 +190,18 @@ func GetPoolTicksFromSC(
 
 func getTickSpacing(swapFee float64) int {
 	return constants.TickSpacings[constants.FeeAmount(swapFee)]
+}
+
+// only support Burn event for now
+func GetChangedTicks(logs []types.Log) []int64 {
+	var ticks []int64
+	for _, log := range logs {
+		if len(log.Topics) < 4 || log.Topics[0] != burnEvent.ID {
+			continue
+		}
+		bottomTick := log.Topics[2].Big().Int64()
+		topTick := log.Topics[3].Big().Int64()
+		ticks = append(ticks, bottomTick, topTick)
+	}
+	return lo.Uniq(ticks)
 }


### PR DESCRIPTION
Algebra doesn't have Ticklens contract deployed, so we need to use a custom one. Currently Algebra doesn't compact the ticktable, so we can only get a small number of ticks for now

This PR also update univ3-clones to support only re-fetching changed ticks (parsed from log)

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
