### PR TITLE
fix: GetTokenIndex to work in Case-Insensitive Comparison

### DIFF
--- a/pkg/source/pool/pool.go
+++ b/pkg/source/pool/pool.go
@@ -121,7 +121,7 @@ type PoolInfo struct {
 
 func (t *PoolInfo) GetTokenIndex(address string) int {
 	for i, poolToken := range t.Tokens {
-		if poolToken == address {
+		if strings.EqualFold(poolToken, address) {
 			return i
 		}
 	}


### PR DESCRIPTION
Fixed case-sensitive token address comparison in `GetTokenIndex` function

## Why did we need it?
The original implementation of the `GetTokenIndex` function used a case-sensitive comparison (==) for token addresses. However, blockchain addresses are often presented in mixed cases, and this led to potential mismatches when comparing addresses with different casing (e.g., "0xAaaa...B" vs. "0xaaaa...b"). 
To address this issue, I replaced the comparison with a case-insensitive method using `strings.EqualFold`.

## Related Issue
N/A (No specific issue was opened for this PR)

## Release Note

-  Updated the `GetTokenIndex` function to use `strings.EqualFold` for case-insensitive token address comparison.
-  This change improves robustness and ensures that addresses are compared correctly regardless of casing.

