### PR TITLE
fix(mx-trading): reduce inventory limit

### DIFF
--- a/pkg/liquidity-source/mx-trading/pool_simulator.go
+++ b/pkg/liquidity-source/mx-trading/pool_simulator.go
@@ -130,7 +130,11 @@ func (p *PoolSimulator) CalculateLimit() map[string]*big.Int {
 	tokens, reserves := p.GetTokens(), p.GetReserves()
 	inventory := make(map[string]*big.Int, len(tokens))
 	for i, token := range tokens {
-		inventory[token] = new(big.Int).Set(reserves[i])
+		var reducedReserve big.Float
+		reducedReserve.SetInt(reserves[i]).Mul(&reducedReserve, big.NewFloat(0.95))
+		// Reduce each token's reserve by 5% to prevent the total quote amount of a token
+		// from potentially exceeding the maker's balance when building the route
+		inventory[token], _ = reducedReserve.Int(nil)
 	}
 
 	return inventory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
Reduce each token's reserve by 5% to prevent the total quote amount of a token from potentially exceeding the maker's balance when building the route

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
