### PR TITLE
Revert "fix LO swapInfo.AmountIn in case take fee in takerAsset (#644)"

### DIFF
--- a/pkg/source/limitorder/pool_simulator.go
+++ b/pkg/source/limitorder/pool_simulator.go
@@ -215,7 +215,6 @@ func (p *PoolSimulator) calcAmountWithSwapInfo(swapSide SwapSide, tokenAmountIn 
 		SwapSide:     swapSide,
 		AmountIn:     tokenAmountIn.Amount.String(),
 	}
-	totalFilledTakingAmountWei := big.NewInt(0)
 	isFulfillAmountIn := false
 	totalFeeAmountWei := new(big.Int)
 
@@ -277,7 +276,6 @@ func (p *PoolSimulator) calcAmountWithSwapInfo(swapSide SwapSide, tokenAmountIn 
 			swapInfo.FilledOrders = append(swapInfo.FilledOrders, filledOrderInfo)
 			isFulfillAmountIn = true
 			addFilledMakingAmount(filledMakingAmountByMaker, order.Maker, filledMakingAmountWei)
-			totalFilledTakingAmountWei.Add(totalFilledTakingAmountWei, filledTakingAmountWei)
 
 			// Currently, when Aggregator finds route and returns some orders and sends them to the smart contract to execute.
 			// We will often meet edge cases that these orders can be fulfilled by a trading bot or taker on Aggregator.
@@ -320,12 +318,10 @@ func (p *PoolSimulator) calcAmountWithSwapInfo(swapSide SwapSide, tokenAmountIn 
 		filledOrderInfo := newFilledOrderInfo(order, remainingTakingAmountWei.String(), remainingMakingAmountWei.String(), feeAmountWeiByOrder.String())
 		swapInfo.FilledOrders = append(swapInfo.FilledOrders, filledOrderInfo)
 		addFilledMakingAmount(filledMakingAmountByMaker, order.Maker, remainingMakingAmountWei)
-		totalFilledTakingAmountWei.Add(totalFilledTakingAmountWei, remainingTakingAmountWei)
 	}
 	if !isFulfillAmountIn {
 		return nil, SwapInfo{}, nil, ErrCannotFulfillAmountIn
 	}
-	swapInfo.AmountIn = totalFilledTakingAmountWei.String()
 	return totalAmountOutWei, swapInfo, totalFeeAmountWei, nil
 }
 

--- a/pkg/source/limitorder/pool_simulator_test.go
+++ b/pkg/source/limitorder/pool_simulator_test.go
@@ -971,7 +971,6 @@ func TestPool_CalcAmountOut_v2(t *testing.T) {
 			assert.Equal(t, tc.expAmountOut, res.TokenAmountOut.Amount.String())
 
 			si := res.SwapInfo.(SwapInfo)
-			assert.Equal(t, bignumber.NewBig10(tc.amountIn), bignumber.NewBig10(si.AmountIn))
 			oid := make([]int64, 0, len(si.FilledOrders))
 			oinfo := ""
 			for _, o := range si.FilledOrders {
@@ -1080,7 +1079,6 @@ func TestPool_UpdateBalance(t *testing.T) {
 				assert.Equal(t, swap.expAmountOut, res.TokenAmountOut.Amount.String())
 
 				si := res.SwapInfo.(SwapInfo)
-				assert.Equal(t, bignumber.NewBig10(swap.amountIn), bignumber.NewBig10(si.AmountIn))
 				oid := make([]int64, 0, len(si.FilledOrders))
 				oinfo := ""
 				for _, o := range si.FilledOrders {
@@ -1231,7 +1229,6 @@ func TestPool_Inventory(t *testing.T) {
 				assert.Equal(t, swap.expAmountOut, res.TokenAmountOut.Amount.String())
 
 				si := res.SwapInfo.(SwapInfo)
-				assert.Equal(t, bignumber.NewBig10(swap.amountIn), bignumber.NewBig10(si.AmountIn))
 				oid := make([]int64, 0, len(si.FilledOrders))
 				oinfo := ""
 				for _, o := range si.FilledOrders {
@@ -1366,7 +1363,6 @@ func TestPool_CalcAmountOut_TakerAssetFee(t *testing.T) {
 			}
 			assert.Equal(t, tc.expOrderIds, oid, oinfo)
 			fmt.Println(oinfo)
-			fmt.Println("--", si.AmountIn)
 		})
 	}
 }


### PR DESCRIPTION
This reverts commit 90de6a5d310bce447c32b63e52fb0a204249a526.

The correct amount will be calculated by SC instead of BE. The reason is that if the LO pool is not the 1st swap, SC will have to calculate the takerAsset fee by themself anyway (from amountOut of previous swap)

<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
