### PR TITLE
refactor: use uint256 instead of *big.Int for 1inch limit order

### DIFF
--- a/pkg/liquidity-source/lo1inch/pool_simulator.go
+++ b/pkg/liquidity-source/lo1inch/pool_simulator.go
@@ -6,12 +6,15 @@ import (
 	"strings"
 
 	"github.com/KyberNetwork/blockchain-toolkit/integer"
+	"github.com/KyberNetwork/blockchain-toolkit/number"
 	"github.com/KyberNetwork/logger"
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
-	utils "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	utils "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
 type (
@@ -31,7 +34,7 @@ type (
 
 		// store min(balance, allowance) for all unique pairs of maker:makerAsset in this pool
 		// will be aggregated up by router-service to be a global value for all maker:makerAsset in LO
-		minBalanceAllowanceByMakerAndAsset map[makerAndAsset]*big.Int
+		minBalanceAllowanceByMakerAndAsset map[makerAndAsset]*uint256.Int
 
 		routerAddress string
 	}
@@ -46,7 +49,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	}
 	for i := 0; i < numTokens; i += 1 {
 		tokens[i] = entityPool.Tokens[i].Address
-		reserves[i] = utils.NewBig10(entityPool.Reserves[i])
+		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 	}
 
 	var staticExtra StaticExtra
@@ -63,7 +66,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	takeToken1OrdersMapping := make(map[string]int, len(extra.TakeToken1Orders))
 
 	numOrders := len(extra.TakeToken0Orders) + len(extra.TakeToken1Orders)
-	minBalanceAllowanceByMakerAndAsset := make(map[makerAndAsset]*big.Int, numOrders)
+	minBalanceAllowanceByMakerAndAsset := make(map[makerAndAsset]*uint256.Int, numOrders)
 
 	for i, takeToken0Order := range extra.TakeToken0Orders {
 		takeToken0OrdersMapping[takeToken0Order.OrderHash] = i
@@ -117,8 +120,8 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		return nil, ErrNoOrderAvailable
 	}
 
-	totalAmountOut := integer.Zero()
-	remainingAmountIn := tokenAmountIn.Amount
+	totalAmountOut := number.Set(number.Zero)
+	remainingAmountIn := number.SetFromBig(tokenAmountIn.Amount)
 
 	swapInfo := SwapInfo{
 		AmountIn:     tokenAmountIn.Amount.String(),
@@ -133,9 +136,9 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 	// because in LO we have multiple makers, and also because we still need to allow orders that have part of the balance available
 	// the problem is that in this func we cannot update the limit,
 	// so we'll use this map to track filled amount for each maker, then subtract from the original balance, to have the remaining balance available
-	filledMakingAmountByMaker := make(map[string]*big.Int, len(p.minBalanceAllowanceByMakerAndAsset))
+	filledMakingAmountByMaker := make(map[string]*uint256.Int, len(p.minBalanceAllowanceByMakerAndAsset))
 
-	totalMakingAmount := new(big.Int)
+	totalMakingAmount := number.Set(number.Zero)
 
 	for i, order := range orders {
 		orderRemainingMakingAmount := order.RemainingMakerAmount
@@ -158,7 +161,7 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 
 		// calculate order's remaining taking amount
 		// orderRemainingTakingAmount = order.TakingAmount * orderRemainingMakingAmount / order.MakingAmount
-		orderRemainingTakingAmount := new(big.Int).Set(order.TakingAmount)
+		orderRemainingTakingAmount := number.Set(order.TakingAmount)
 		orderRemainingTakingAmount.Mul(orderRemainingTakingAmount, orderRemainingMakingAmount)
 		orderRemainingTakingAmount.Div(orderRemainingTakingAmount, order.MakingAmount)
 
@@ -166,12 +169,15 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 
 		// Case 1: This order can fulfill the remaining amount in
 		if orderRemainingTakingAmount.Cmp(remainingAmountIn) >= 0 {
-			takerRateBF := new(big.Float).Quo(new(big.Float).SetInt(order.MakingAmount), new(big.Float).SetInt(order.TakingAmount))
-			orderAmountOutBF := new(big.Float).Mul(
-				new(big.Float).SetInt(remainingAmountIn),
-				takerRateBF,
+			orderAmountOut, overflow := new(uint256.Int).MulDivOverflow(
+				remainingAmountIn,
+				order.MakingAmount,
+				order.TakingAmount,
 			)
-			orderAmountOut, _ := orderAmountOutBF.Int(nil)
+
+			if overflow {
+				continue
+			}
 
 			// order too small
 			if orderAmountOut.Sign() <= 0 {
@@ -180,8 +186,8 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 
 			totalAmountOut.Add(totalAmountOut, orderAmountOut)
 
-			orderFilledMakingAmount := orderAmountOut
-			orderFilledTakingAmount := remainingAmountIn
+			orderFilledMakingAmount := number.Set(orderAmountOut)
+			orderFilledTakingAmount := number.Set(remainingAmountIn)
 			filledOrderInfo := newFilledOrderInfo(
 				order,
 				orderFilledMakingAmount,
@@ -192,21 +198,25 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 			isAmountInFulfilled = true
 
 			// orderAmountOut is the filled making amount for this order because this order is partially filled
-			addFilledMakingAmount(filledMakingAmountByMaker, order.Maker, orderAmountOut)
+			addFilledMakingAmount(
+				filledMakingAmountByMaker,
+				order.Maker,
+				orderAmountOut,
+			)
 
 			// Currently, the aggregator finds route, returns some orders and sends them to the smart contract to execute.
 			// We often meet edge cases that these orders can be fulfilled by a trading bot or another taker on the aggregator beforehand.
 			// From that, the estimated amount out and filled orders are not correct. So we need to add more "backup" orders when sending to SC to the executor.
 			// In this case, we will send some orders util total MakingAmount(remainMakingAmount)/estimated amountOut >= 1.3 (130%)
-			totalAmountOutBF := new(big.Float).SetInt(totalAmountOut)
+			totalAmountOutBF := new(big.Float).SetInt(totalAmountOut.ToBig())
 			for j := i + 1; j < len(orders); j++ {
-				if new(big.Float).SetInt(totalMakingAmount).Cmp(new(big.Float).Mul(totalAmountOutBF, FallbackPercentageOfTotalMakingAmount)) >= 0 {
+				if new(big.Float).SetInt(totalMakingAmount.ToBig()).Cmp(new(big.Float).Mul(totalAmountOutBF, FallbackPercentageOfTotalMakingAmount)) >= 0 {
 					break
 				}
 
 				order := orders[j]
 
-				orderRemainingMakingAmount := new(big.Int).Set(order.RemainingMakerAmount)
+				orderRemainingMakingAmount := number.Set(order.RemainingMakerAmount)
 				if makerRemainingBalance := getMakerRemainingBalance(
 					param.Limit,
 					filledMakingAmountByMaker,
@@ -234,10 +244,10 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		}
 
 		// Case 2: This order can't fulfill the remaining amount in
-		remainingAmountIn = new(big.Int).Sub(remainingAmountIn, orderRemainingTakingAmount)
+		remainingAmountIn = number.Sub(remainingAmountIn, orderRemainingTakingAmount)
 		orderFilledMakingAmount := orderRemainingMakingAmount // because this order is fully filled
 		orderFilledTakingAmount := orderRemainingTakingAmount // because this order is fully filled
-		totalAmountOut = new(big.Int).Add(totalAmountOut, orderFilledMakingAmount)
+		totalAmountOut = number.Add(totalAmountOut, orderFilledMakingAmount)
 		filledOrderInfo := newFilledOrderInfo(
 			order,
 			orderFilledMakingAmount,
@@ -255,7 +265,7 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 	return &pool.CalcAmountOutResult{
 		TokenAmountOut: &pool.TokenAmount{
 			Token:  tokenOut,
-			Amount: totalAmountOut,
+			Amount: totalAmountOut.ToBig(),
 		},
 		Fee: &pool.TokenAmount{
 			Token:  tokenAmountIn.Token,
@@ -268,15 +278,15 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 
 func newFilledOrderInfo(
 	order *Order,
-	orderFilledMakingAmount *big.Int,
-	orderFilledTakingAmount *big.Int,
+	orderFilledMakingAmount *uint256.Int,
+	orderFilledTakingAmount *uint256.Int,
 ) *FilledOrderInfo {
 	return &FilledOrderInfo{
 		Signature:            order.Signature,
 		OrderHash:            order.OrderHash,
-		RemainingMakerAmount: new(big.Int).Sub(order.RemainingMakerAmount, orderFilledMakingAmount),
-		MakerBalance:         new(big.Int).Sub(order.MakerBalance, orderFilledMakingAmount),
-		MakerAllowance:       new(big.Int).Sub(order.MakerAllowance, orderFilledMakingAmount),
+		RemainingMakerAmount: number.Sub(order.RemainingMakerAmount, orderFilledMakingAmount),
+		MakerBalance:         number.Sub(order.MakerBalance, orderFilledMakingAmount),
+		MakerAllowance:       number.Sub(order.MakerAllowance, orderFilledMakingAmount),
 		MakerAsset:           order.MakerAsset,
 		TakerAsset:           order.TakerAsset,
 		Salt:                 order.Salt,
@@ -296,39 +306,41 @@ func newFilledOrderInfo(
 }
 
 func addFilledMakingAmount(
-	filledMakingAmountByMaker map[string]*big.Int,
+	filledMakingAmountByMaker map[string]*uint256.Int,
 	maker string,
-	filledMakingAmount *big.Int,
+	filledMakingAmount *uint256.Int,
 ) {
 	if totalFilled, ok := filledMakingAmountByMaker[maker]; ok {
-		filledMakingAmountByMaker[maker] = new(big.Int).Add(totalFilled, filledMakingAmount)
+		filledMakingAmountByMaker[maker] = number.Add(totalFilled, filledMakingAmount)
 	} else {
-		filledMakingAmountByMaker[maker] = new(big.Int).Set(filledMakingAmount)
+		filledMakingAmountByMaker[maker] = number.Set(filledMakingAmount)
 	}
 }
 
 func getMakerRemainingBalance(
 	limit pool.SwapLimit,
-	filledMakingAmountByMaker map[string]*big.Int,
+	filledMakingAmountByMaker map[string]*uint256.Int,
 	maker, makerAsset string,
-) *big.Int {
+) *uint256.Int {
 	if limit == nil {
 		// can happen if this change get deployed to router-service before pool-service, just ignore
 		return nil
 	}
 
 	makerBalanceAllowance := limit.GetLimit(newMakerAndAsset(maker, makerAsset))
+	makerBalanceAllowanceUint256 := number.SetFromBig(makerBalanceAllowance)
+
 	if makerBalanceAllowance == nil {
 		// should not happen, but anw just return 0 as if this maker has no balance left
-		// Do not return bignumber.ZeroBI because if the `makerRemainingBalance` is updated somewhere else,
-		// it will also alter the original value of bignumber.ZeroBI
-		return integer.Zero()
+		// Do not return number.Zero directly because if the `makerRemainingBalance` is updated somewhere else,
+		// it will also alter the original value of number.Zero
+		return number.Set(number.Zero)
 	}
 
 	if totalFilled := filledMakingAmountByMaker[maker]; totalFilled != nil {
-		return new(big.Int).Sub(makerBalanceAllowance, totalFilled)
+		return number.Sub(makerBalanceAllowanceUint256, totalFilled)
 	} else {
-		return makerBalanceAllowance
+		return makerBalanceAllowanceUint256
 	}
 }
 
@@ -370,8 +382,8 @@ func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 			_, _, _ = params.SwapLimit.UpdateLimit(
 				newMakerAndAsset(order.Maker, order.MakerAsset),
 				newMakerAndAsset(order.Maker, order.TakerAsset),
-				filledOrderInfo.FilledMakingAmount,
-				filledOrderInfo.FilledTakingAmount,
+				filledOrderInfo.FilledMakingAmount.ToBig(),
+				filledOrderInfo.FilledTakingAmount.ToBig(),
 			)
 		}
 	}
@@ -430,7 +442,7 @@ func (p *PoolSimulator) CalculateLimit() map[string]*big.Int {
 
 	res := make(map[string]*big.Int, count)
 	for k, v := range p.minBalanceAllowanceByMakerAndAsset {
-		res[k] = new(big.Int).Set(v)
+		res[k] = v.ToBig()
 	}
 
 	return res

--- a/pkg/liquidity-source/lo1inch/pool_simulator_test.go
+++ b/pkg/liquidity-source/lo1inch/pool_simulator_test.go
@@ -6,31 +6,35 @@ import (
 	"testing"
 
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/KyberNetwork/blockchain-toolkit/integer"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/swaplimit"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
 func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 	// prepare data for test case 2
-	takingAmount := new(big.Int).SetInt64(100000000 - 101)
-	orderMakingAmount, _ := new(big.Int).SetString("100000000000", 10)
-	orderTakingAmount, _ := new(big.Int).SetString("100247731166", 10)
+	takingAmount := uint256.NewInt(100000000 - 101)
+	orderMakingAmount := uint256.NewInt(100000000000)
+	orderTakingAmount := uint256.NewInt(100247731166)
 
-	makingAmount := new(big.Int).Div(new(big.Int).Mul(takingAmount, orderMakingAmount), orderTakingAmount)
-	makerBalance, _ := new(big.Int).SetString("722627607117", 10)
-	makerAllowance, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	makingAmount := new(uint256.Int).Div(
+		new(uint256.Int).Mul(takingAmount, orderMakingAmount),
+		orderTakingAmount,
+	)
+	makerBalance := uint256.MustFromDecimal("722627607117")
+	makerAllowance := uint256.MustFromDecimal("115792089237316195423570985008687907853269984665640564039457584007913129639935")
 
-	remainingMakerAmount := new(big.Int).Sub(orderMakingAmount, makingAmount)
-	remainingMakerBalance := new(big.Int).Sub(makerBalance, makingAmount)
-	remainingMakerAllowance := new(big.Int).Sub(makerAllowance, makingAmount)
+	remainingMakerAmount := new(uint256.Int).Sub(orderMakingAmount, makingAmount)
+	remainingMakerBalance := new(uint256.Int).Sub(makerBalance, makingAmount)
+	remainingMakerAllowance := new(uint256.Int).Sub(makerAllowance, makingAmount)
 
-	amountOut := new(big.Int).Add(big.NewInt(10000), makingAmount)
+	amountOut := new(uint256.Int).Add(uint256.NewInt(10000), makingAmount)
 	// end of prepare data for test case 2
 
 	type fields struct {
@@ -70,15 +74,15 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 							{
 								Signature:            "0x3f31467bce6bb134944a8c3c57a8c2786ffadf31a7c39cb22a9c51cceb7e3c0f7ed91bba74a8227aae8933fa72cc8c6e3796bd4c4e734fcbe22bf5061ef9e8971c",
 								OrderHash:            "0x177af74e4d3880743ac6603323a9a50f6999968e499f44966dd00d642e933285",
-								RemainingMakerAmount: big.NewInt(10000),
-								MakerBalance:         big.NewInt(10437135),
-								MakerAllowance:       big.NewInt(900000),
+								RemainingMakerAmount: uint256.NewInt(10000),
+								MakerBalance:         uint256.NewInt(10437135),
+								MakerAllowance:       uint256.NewInt(900000),
 								MakerAsset:           "0xdac17f958d2ee523a2206206994597c13d831ec7",
 								TakerAsset:           "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 								Salt:                 "54304030",
 								Receiver:             "0x0000000000000000000000000000000000000000",
-								MakingAmount:         big.NewInt(10000),
-								TakingAmount:         big.NewInt(101),
+								MakingAmount:         uint256.NewInt(10000),
+								TakingAmount:         uint256.NewInt(101),
 								Maker:                "0xdf4039a454d58868dfd43f076ee46c92a35fdfd9",
 							},
 						},
@@ -90,7 +94,7 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 				param: pool.CalcAmountOutParams{
 					TokenAmountIn: pool.TokenAmount{
 						Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-						Amount: big.NewInt(101),
+						Amount: uint256.NewInt(101).ToBig(),
 					},
 					TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
 					Limit:    nil,
@@ -99,12 +103,12 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 			want: &pool.CalcAmountOutResult{
 				TokenAmountOut: &pool.TokenAmount{
 					Token:     "0xdac17f958d2ee523a2206206994597c13d831ec7",
-					Amount:    big.NewInt(10000),
+					Amount:    uint256.NewInt(10000).ToBig(),
 					AmountUsd: 0,
 				},
 				Fee: &pool.TokenAmount{
 					Token:     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-					Amount:    big.NewInt(0),
+					Amount:    integer.Zero(),
 					AmountUsd: 0,
 				},
 				Gas: 113308,
@@ -115,19 +119,19 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 						{
 							Signature:            "0x3f31467bce6bb134944a8c3c57a8c2786ffadf31a7c39cb22a9c51cceb7e3c0f7ed91bba74a8227aae8933fa72cc8c6e3796bd4c4e734fcbe22bf5061ef9e8971c",
 							OrderHash:            "0x177af74e4d3880743ac6603323a9a50f6999968e499f44966dd00d642e933285",
-							RemainingMakerAmount: new(big.Int).Sub(big.NewInt(10000), big.NewInt(10000)),
-							MakerBalance:         big.NewInt(10437135 - 10000),
-							MakerAllowance:       big.NewInt(900000 - 10000),
+							RemainingMakerAmount: uint256.NewInt(0),
+							MakerBalance:         uint256.NewInt(10437135 - 10000),
+							MakerAllowance:       uint256.NewInt(900000 - 10000),
 							MakerAsset:           "0xdac17f958d2ee523a2206206994597c13d831ec7",
 							TakerAsset:           "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 							Salt:                 "54304030",
 							Receiver:             "0x0000000000000000000000000000000000000000",
-							MakingAmount:         big.NewInt(10000),
-							TakingAmount:         big.NewInt(101),
+							MakingAmount:         uint256.NewInt(10000),
+							TakingAmount:         uint256.NewInt(101),
 							Maker:                "0xdf4039a454d58868dfd43f076ee46c92a35fdfd9",
 
-							FilledMakingAmount: big.NewInt(10000),
-							FilledTakingAmount: big.NewInt(101),
+							FilledMakingAmount: uint256.NewInt(10000),
+							FilledTakingAmount: uint256.NewInt(101),
 						},
 					},
 				},
@@ -161,7 +165,7 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 				param: pool.CalcAmountOutParams{
 					TokenAmountIn: pool.TokenAmount{
 						Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-						Amount: big.NewInt(100000000),
+						Amount: uint256.NewInt(100000000).ToBig(),
 					},
 					TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
 					Limit:    nil,
@@ -170,12 +174,12 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 			want: &pool.CalcAmountOutResult{
 				TokenAmountOut: &pool.TokenAmount{
 					Token:     "0xdac17f958d2ee523a2206206994597c13d831ec7",
-					Amount:    amountOut,
+					Amount:    amountOut.ToBig(),
 					AmountUsd: 0,
 				},
 				Fee: &pool.TokenAmount{
 					Token:     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-					Amount:    big.NewInt(0),
+					Amount:    integer.Zero(),
 					AmountUsd: 0,
 				},
 				Gas: 136616,
@@ -186,19 +190,19 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 						{
 							Signature:            "0x3f31467bce6bb134944a8c3c57a8c2786ffadf31a7c39cb22a9c51cceb7e3c0f7ed91bba74a8227aae8933fa72cc8c6e3796bd4c4e734fcbe22bf5061ef9e8971c",
 							OrderHash:            "0x177af74e4d3880743ac6603323a9a50f6999968e499f44966dd00d642e933285",
-							RemainingMakerAmount: new(big.Int).Sub(big.NewInt(10000), big.NewInt(10000)),
-							MakerBalance:         big.NewInt(10437135 - 10000),
-							MakerAllowance:       big.NewInt(900000 - 10000),
+							RemainingMakerAmount: uint256.NewInt(0),
+							MakerBalance:         uint256.NewInt(10437135 - 10000),
+							MakerAllowance:       uint256.NewInt(900000 - 10000),
 							MakerAsset:           "0xdac17f958d2ee523a2206206994597c13d831ec7",
 							TakerAsset:           "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 							Salt:                 "54304030",
 							Receiver:             "0x0000000000000000000000000000000000000000",
-							MakingAmount:         big.NewInt(10000),
-							TakingAmount:         big.NewInt(101),
+							MakingAmount:         uint256.NewInt(10000),
+							TakingAmount:         uint256.NewInt(101),
 							Maker:                "0xdf4039a454d58868dfd43f076ee46c92a35fdfd9",
 
-							FilledMakingAmount: big.NewInt(10000),
-							FilledTakingAmount: big.NewInt(101),
+							FilledMakingAmount: uint256.NewInt(10000),
+							FilledTakingAmount: uint256.NewInt(101),
 						},
 						{
 							Signature:            "0xd6a593b5bcdbe12600f09c421a769fdc2c5dd10399e71a873b7fbad1cb764b0b484452ab925d3420a9a58188b38a8b44eb91892c938ffe622c7cb6b4dd2634511b",
@@ -210,8 +214,8 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 							TakerAsset:           "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 							Salt:                 "67123001626078665156821660044248014421358635920891485277615109939076199471724",
 							Receiver:             "0x0000000000000000000000000000000000000000",
-							MakingAmount:         big.NewInt(100000000000),
-							TakingAmount:         big.NewInt(100247731166),
+							MakingAmount:         uint256.NewInt(100000000000),
+							TakingAmount:         uint256.NewInt(100247731166),
 							Maker:                "0x29eba388141f070e6824dd7628f11cb946bc548b",
 
 							FilledMakingAmount: makingAmount,
@@ -282,15 +286,15 @@ func TestPoolSimulator_CalcAmountOut_RealPool(t *testing.T) {
 							{
 								Signature:            "0x3f31467bce6bb134944a8c3c57a8c2786ffadf31a7c39cb22a9c51cceb7e3c0f7ed91bba74a8227aae8933fa72cc8c6e3796bd4c4e734fcbe22bf5061ef9e8971c",
 								OrderHash:            "0x177af74e4d3880743ac6603323a9a50f6999968e499f44966dd00d642e933285",
-								RemainingMakerAmount: big.NewInt(10000),
-								MakerBalance:         big.NewInt(10437135),
-								MakerAllowance:       big.NewInt(900000),
+								RemainingMakerAmount: uint256.NewInt(10000),
+								MakerBalance:         uint256.NewInt(10437135),
+								MakerAllowance:       uint256.NewInt(900000),
 								MakerAsset:           "0xdac17f958d2ee523a2206206994597c13d831ec7",
 								TakerAsset:           "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
 								Salt:                 "54304030",
 								Receiver:             "0x0000000000000000000000000000000000000000",
-								MakingAmount:         big.NewInt(10000),
-								TakingAmount:         big.NewInt(101),
+								MakingAmount:         uint256.NewInt(10000),
+								TakingAmount:         uint256.NewInt(101),
 								Maker:                "0xdf4039a454d58868dfd43f076ee46c92a35fdfd9",
 							},
 						},
@@ -389,11 +393,11 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 			TakeToken0Orders: lo.Map(orders, func(o testorder, _ int) *Order {
 				return &Order{
 					OrderHash:            o.hash,
-					MakingAmount:         bignumber.NewBig10(o.makingAmount),
-					TakingAmount:         bignumber.NewBig10(o.takingAmount),
-					RemainingMakerAmount: bignumber.NewBig10(o.remainingMakerAmount),
-					MakerBalance:         bignumber.NewBig10("100000000000000000000"),
-					MakerAllowance:       bignumber.NewBig10("100000000000000000000"),
+					MakingAmount:         uint256.MustFromDecimal(o.makingAmount),
+					TakingAmount:         uint256.MustFromDecimal(o.takingAmount),
+					RemainingMakerAmount: uint256.MustFromDecimal(o.remainingMakerAmount),
+					MakerBalance:         uint256.MustFromDecimal("100000000000000000000"),
+					MakerAllowance:       uint256.MustFromDecimal("100000000000000000000"),
 				}
 			}),
 		}
@@ -415,7 +419,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 			res, err := sims[tc.pool].CalcAmountOut(pool.CalcAmountOutParams{
 				TokenAmountIn: pool.TokenAmount{
 					Token:  "A",
-					Amount: bignumber.NewBig10(tc.amountIn),
+					Amount: uint256.MustFromDecimal(tc.amountIn).ToBig(),
 				},
 				TokenOut: "B",
 				Limit:    limit,
@@ -490,11 +494,11 @@ func TestPoolSimulator_UpdateBalance(t *testing.T) {
 				TakeToken0Orders: lo.Map(orders, func(o testorder, _ int) *Order {
 					return &Order{
 						OrderHash:            o.hash,
-						MakingAmount:         bignumber.NewBig10(o.makingAmount),
-						TakingAmount:         bignumber.NewBig10(o.takingAmount),
-						RemainingMakerAmount: bignumber.NewBig10(o.remainingMakerAmount),
-						MakerBalance:         bignumber.NewBig10("100000000000000000000"),
-						MakerAllowance:       bignumber.NewBig10("100000000000000000000"),
+						MakingAmount:         uint256.MustFromDecimal(o.makingAmount),
+						TakingAmount:         uint256.MustFromDecimal(o.takingAmount),
+						RemainingMakerAmount: uint256.MustFromDecimal(o.remainingMakerAmount),
+						MakerBalance:         uint256.MustFromDecimal("100000000000000000000"),
+						MakerAllowance:       uint256.MustFromDecimal("100000000000000000000"),
 					}
 				}),
 			}
@@ -519,7 +523,7 @@ func TestPoolSimulator_UpdateBalance(t *testing.T) {
 				res, err := sims[tc.pool].CalcAmountOut(pool.CalcAmountOutParams{
 					TokenAmountIn: pool.TokenAmount{
 						Token:  "A",
-						Amount: bignumber.NewBig10(swap.amountIn),
+						Amount: uint256.MustFromDecimal(swap.amountIn).ToBig(),
 					},
 					TokenOut: "B",
 					Limit:    limit,
@@ -547,7 +551,7 @@ func TestPoolSimulator_UpdateBalance(t *testing.T) {
 				sims[tc.pool].UpdateBalance(pool.UpdateBalanceParams{
 					TokenAmountIn: pool.TokenAmount{
 						Token:  "A",
-						Amount: bignumber.NewBig10(swap.amountIn),
+						Amount: uint256.MustFromDecimal(swap.amountIn).ToBig(),
 					},
 					TokenAmountOut: *res.TokenAmountOut,
 					Fee:            *res.Fee,
@@ -583,13 +587,13 @@ func TestPoolSimulator_Inventory(t *testing.T) {
 		},
 	}
 
-	makerBalances := map[string]*big.Int{
-		"maker1": bignumber.NewBig10("250"),
-		"maker2": bignumber.NewBig10("100"),
+	makerBalances := map[string]*uint256.Int{
+		"maker1": uint256.MustFromDecimal("250"),
+		"maker2": uint256.MustFromDecimal("100"),
 	}
-	minBalanceAllowanceByMakerAndAsset := map[makerAndAsset]*big.Int{
-		newMakerAndAsset("maker1", "B"): bignumber.NewBig10("150"), // maker1 original balance is 250, but 100 has been spent in previous paths (order with same makerAsset but different takerAsset)
-		newMakerAndAsset("maker2", "B"): bignumber.NewBig10("50"),  // same, maker2 has spent 50 already
+	minBalanceAllowanceByMakerAndAsset := map[makerAndAsset]*uint256.Int{
+		newMakerAndAsset("maker1", "B"): uint256.MustFromDecimal("150"), // maker1 original balance is 250, but 100 has been spent in previous paths (order with same makerAsset but different takerAsset)
+		newMakerAndAsset("maker2", "B"): uint256.MustFromDecimal("50"),  // same, maker2 has spent 50 already
 	}
 
 	testcases := []struct {
@@ -634,9 +638,9 @@ func TestPoolSimulator_Inventory(t *testing.T) {
 						Maker:                o.maker,
 						MakerAsset:           "B",
 						TakerAsset:           "A",
-						MakingAmount:         bignumber.NewBig10(o.makingAmount),
-						TakingAmount:         bignumber.NewBig10(o.takingAmount),
-						RemainingMakerAmount: bignumber.NewBig10(o.remainingMakerAmount),
+						MakingAmount:         uint256.MustFromDecimal(o.makingAmount),
+						TakingAmount:         uint256.MustFromDecimal(o.takingAmount),
+						RemainingMakerAmount: uint256.MustFromDecimal(o.remainingMakerAmount),
 						MakerBalance:         makerBalances[o.maker],
 						MakerAllowance:       makerBalances[o.maker],
 					}
@@ -665,7 +669,7 @@ func TestPoolSimulator_Inventory(t *testing.T) {
 				res, err := sims[tc.pool].CalcAmountOut(pool.CalcAmountOutParams{
 					TokenAmountIn: pool.TokenAmount{
 						Token:  "A",
-						Amount: bignumber.NewBig10(swap.amountIn),
+						Amount: uint256.MustFromDecimal(swap.amountIn).ToBig(),
 					},
 					TokenOut: "B",
 					Limit:    limit,
@@ -693,7 +697,7 @@ func TestPoolSimulator_Inventory(t *testing.T) {
 				sims[tc.pool].UpdateBalance(pool.UpdateBalanceParams{
 					TokenAmountIn: pool.TokenAmount{
 						Token:  "A",
-						Amount: bignumber.NewBig10(swap.amountIn),
+						Amount: uint256.MustFromDecimal(swap.amountIn).ToBig(),
 					},
 					TokenAmountOut: *res.TokenAmountOut,
 					Fee:            *res.Fee,

--- a/pkg/liquidity-source/lo1inch/type.go
+++ b/pkg/liquidity-source/lo1inch/type.go
@@ -1,6 +1,8 @@
 package lo1inch
 
-import "math/big"
+import (
+	"github.com/holiman/uint256"
+)
 
 type ChainID uint
 
@@ -13,21 +15,21 @@ const (
 )
 
 type Order struct {
-	Signature            string   `json:"signature"`
-	OrderHash            string   `json:"orderHash"`
-	RemainingMakerAmount *big.Int `json:"remainingMakerAmount"`
-	MakerBalance         *big.Int `json:"makerBalance"`
-	MakerAllowance       *big.Int `json:"makerAllowance"`
-	MakerAsset           string   `json:"makerAsset"`
-	TakerAsset           string   `json:"takerAsset"`
-	Salt                 string   `json:"salt"`
-	Receiver             string   `json:"receiver"`
-	MakingAmount         *big.Int `json:"makingAmount"`
-	TakingAmount         *big.Int `json:"takingAmount"`
-	Maker                string   `json:"maker"`
-	Extension            string   `json:"extension"`
-	MakerTraits          string   `json:"makerTraits"`
-	IsMakerContract      bool     `json:"isMakerContract"`
+	Signature            string       `json:"signature"`
+	OrderHash            string       `json:"orderHash"`
+	RemainingMakerAmount *uint256.Int `json:"remainingMakerAmount"`
+	MakerBalance         *uint256.Int `json:"makerBalance"`
+	MakerAllowance       *uint256.Int `json:"makerAllowance"`
+	MakerAsset           string       `json:"makerAsset"`
+	TakerAsset           string       `json:"takerAsset"`
+	Salt                 string       `json:"salt"`
+	Receiver             string       `json:"receiver"`
+	MakingAmount         *uint256.Int `json:"makingAmount"`
+	TakingAmount         *uint256.Int `json:"takingAmount"`
+	Maker                string       `json:"maker"`
+	Extension            string       `json:"extension"`
+	MakerTraits          string       `json:"makerTraits"`
+	IsMakerContract      bool         `json:"isMakerContract"`
 }
 
 type StaticExtra struct {
@@ -48,31 +50,31 @@ type SwapInfo struct {
 }
 
 type FilledOrderInfo struct {
-	Signature            string   `json:"signature"`
-	OrderHash            string   `json:"orderHash"`
-	RemainingMakerAmount *big.Int `json:"remainingMakerAmount"`
-	MakerBalance         *big.Int `json:"makerBalance"`
-	MakerAllowance       *big.Int `json:"makerAllowance"`
-	MakerAsset           string   `json:"makerAsset"`
-	TakerAsset           string   `json:"takerAsset"`
-	Salt                 string   `json:"salt"`
-	Receiver             string   `json:"receiver"`
-	MakingAmount         *big.Int `json:"makingAmount"`
-	TakingAmount         *big.Int `json:"takingAmount"`
-	Maker                string   `json:"maker"`
-	Extension            string   `json:"extension"`
-	MakerTraits          string   `json:"makerTraits"`
-	IsMakerContract      bool     `json:"isMakerContract"`
+	Signature            string       `json:"signature"`
+	OrderHash            string       `json:"orderHash"`
+	RemainingMakerAmount *uint256.Int `json:"remainingMakerAmount"`
+	MakerBalance         *uint256.Int `json:"makerBalance"`
+	MakerAllowance       *uint256.Int `json:"makerAllowance"`
+	MakerAsset           string       `json:"makerAsset"`
+	TakerAsset           string       `json:"takerAsset"`
+	Salt                 string       `json:"salt"`
+	Receiver             string       `json:"receiver"`
+	MakingAmount         *uint256.Int `json:"makingAmount"`
+	TakingAmount         *uint256.Int `json:"takingAmount"`
+	Maker                string       `json:"maker"`
+	Extension            string       `json:"extension"`
+	MakerTraits          string       `json:"makerTraits"`
+	IsMakerContract      bool         `json:"isMakerContract"`
 
 	// Some extra fields compared to Order
 
 	// FilledMakingAmount is the amount of maker asset that has been filled
 	// But keep in mind that this is just the amount that has been filled after ONE CalcAmountOut call, not the total amount that has been filled in this order
-	FilledMakingAmount *big.Int `json:"filledMakingAmount"`
+	FilledMakingAmount *uint256.Int `json:"filledMakingAmount"`
 
 	// FilledTakingAmount is the amount of taker asset that has been filled
 	// But keep in mind that this is just the amount that has been filled after ONE CalcAmountOut call, not the total amount that has been filled in this order
-	FilledTakingAmount *big.Int `json:"filledTakingAmount"`
+	FilledTakingAmount *uint256.Int `json:"filledTakingAmount"`
 
 	IsBackup bool `json:"isBackup"`
 }

--- a/pkg/util/big256/big256.go
+++ b/pkg/util/big256/big256.go
@@ -31,3 +31,22 @@ func TenPowDecimals(decimal uint8) *big.Float {
 func TenPowInt(decimal uint8) *uint256.Int {
 	return new(uint256.Int).Exp(uint256.NewInt(10), uint256.NewInt(uint64(decimal)))
 }
+
+func NewUint256(s string) (res *uint256.Int, err error) {
+	res = new(uint256.Int)
+	err = res.SetFromDecimal(s)
+	return
+}
+
+// Min returns the smaller of a or b.
+func Min(a, b *uint256.Int) *uint256.Int {
+	if a == nil || b == nil {
+		return nil
+	}
+
+	if a.Cmp(b) < 0 {
+		return a
+	}
+
+	return b
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
