### PR TITLE
fluid: add center price for verify reserves

### DIFF
--- a/pkg/liquidity-source/fluid/dex-t1/abis/dexReservesResolver.json
+++ b/pkg/liquidity-source/fluid/dex-t1/abis/dexReservesResolver.json
@@ -118,6 +118,11 @@
           { "internalType": "address", "name": "token1", "type": "address" },
           { "internalType": "uint256", "name": "fee", "type": "uint256" },
           {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
+          {
             "components": [
               {
                 "internalType": "uint256",
@@ -295,6 +300,11 @@
           { "internalType": "address", "name": "token0", "type": "address" },
           { "internalType": "address", "name": "token1", "type": "address" },
           { "internalType": "uint256", "name": "fee", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
           {
             "components": [
               {
@@ -977,6 +987,11 @@
           { "internalType": "address", "name": "token1", "type": "address" },
           { "internalType": "uint256", "name": "fee", "type": "uint256" },
           {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
+          {
             "components": [
               {
                 "internalType": "uint256",
@@ -1156,6 +1171,11 @@
           { "internalType": "address", "name": "token0", "type": "address" },
           { "internalType": "address", "name": "token1", "type": "address" },
           { "internalType": "uint256", "name": "fee", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
           {
             "components": [
               {
@@ -1349,6 +1369,11 @@
           { "internalType": "address", "name": "token1", "type": "address" },
           { "internalType": "uint256", "name": "fee", "type": "uint256" },
           {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
+          {
             "components": [
               {
                 "internalType": "uint256",
@@ -1528,6 +1553,11 @@
           { "internalType": "address", "name": "token0", "type": "address" },
           { "internalType": "address", "name": "token1", "type": "address" },
           { "internalType": "uint256", "name": "fee", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
           {
             "components": [
               {

--- a/pkg/liquidity-source/fluid/dex-t1/constant.go
+++ b/pkg/liquidity-source/fluid/dex-t1/constant.go
@@ -29,7 +29,7 @@ const (
 
 	MaxPriceDiff int64 = 5 // 5%
 
-	MinSwapLiquidity int64 = 6667 // on-chain we use 1e4 but use extra buffer for potential price diff using pool price vs center price at the check
+	MinSwapLiquidity int64 = 2e4 // on-chain we use 1e4 but use extra buffer to avoid reverts
 )
 
 var bI1e18, _ = new(big.Int).SetString(String1e18, 10) // 1e18

--- a/pkg/liquidity-source/fluid/dex-t1/constant.go
+++ b/pkg/liquidity-source/fluid/dex-t1/constant.go
@@ -1,38 +1,38 @@
 package dexT1
 
-import "math/big"
+import (
+	"math/big"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
 
 const (
 	DexType = "fluid-dex-t1"
 )
 
-const (
-	// DexReservesResolver methods
+const ( // DexReservesResolver methods
 	DRRMethodGetAllPoolsReservesAdjusted = "getAllPoolsReservesAdjusted"
 	DRRMethodGetPoolReservesAdjusted     = "getPoolReservesAdjusted"
 
-	// ERC20 Token methods
+	// TokenMethodDecimals - ERC20 Token methods
 	TokenMethodDecimals = "decimals"
 
-	// StorageRead methods
+	// SRMethodReadFromStorage - StorageRead methods
 	SRMethodReadFromStorage = "readFromStorage"
 )
 
 const (
-	String1e18 = "1000000000000000000"
-	String1e27 = "1000000000000000000000000000"
-
 	DexAmountsDecimals = 12
 
-	FeePercentPrecision    int64 = 1e4
-	Fee100PercentPrecision int64 = 1e6
-
-	MaxPriceDiff int64 = 5 // 5%
-
-	MinSwapLiquidity int64 = 2e4 // on-chain we use 1e4 but use extra buffer to avoid reverts
+	FeePercentPrecision float64 = 1e4
 )
 
-var bI1e18, _ = new(big.Int).SetString(String1e18, 10) // 1e18
-var bI1e27, _ = new(big.Int).SetString(String1e27, 10) // 1e27
-var bI10 = new(big.Int).SetInt64(10)
-var bI100 = new(big.Int).SetInt64(100)
+var (
+	MaxPriceDiff           = big.NewInt(5)   // 5%
+	MinSwapLiquidity       = big.NewInt(2e4) // on-chain we use 1e4 but use extra buffer to avoid reverts
+	Fee100PercentPrecision = big.NewInt(1e6)
+
+	bI100  = big.NewInt(100)
+	bI1e18 = bignumber.TenPowInt(18)
+	bI1e27 = bignumber.TenPowInt(27)
+)

--- a/pkg/liquidity-source/fluid/dex-t1/pool_list_updater.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_list_updater.go
@@ -125,7 +125,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 					Decimals:  token1Decimals,
 				},
 			},
-			SwapFee:     float64(curPool.Fee.Int64()) / float64(FeePercentPrecision),
+			SwapFee:     float64(curPool.Fee.Int64()) / FeePercentPrecision,
 			Extra:       string(extraBytes),
 			StaticExtra: string(staticExtraBytes),
 		}

--- a/pkg/liquidity-source/fluid/dex-t1/pool_list_updater.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_list_updater.go
@@ -84,6 +84,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			CollateralReserves: curPool.CollateralReserves,
 			DebtReserves:       curPool.DebtReserves,
 			DexLimits:          curPool.Limits,
+			CenterPrice:        curPool.CenterPrice,
 		}
 
 		extraBytes, err := json.Marshal(extra)

--- a/pkg/liquidity-source/fluid/dex-t1/pool_list_updater_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_list_updater_test.go
@@ -29,7 +29,7 @@ func TestPoolListUpdater(t *testing.T) {
 		err              error
 
 		config = Config{
-			DexReservesResolver: "0x45f4ad57e300da55c33dea579a40fcee000d7b94",
+			DexReservesResolver: "0xF38082d58bF0f1e07C04684FF718d69a70f21e62",
 		}
 	)
 
@@ -93,6 +93,7 @@ func TestPoolListUpdater(t *testing.T) {
 	require.True(t, extra.DebtReserves.Token1RealReserves.Cmp(big.NewInt(0)) > 0)
 	require.True(t, extra.DebtReserves.Token0ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
 	require.True(t, extra.DebtReserves.Token1ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
+	require.True(t, extra.CenterPrice.Cmp(big.NewInt(0)) > 0)
 
 	// Log all pools
 	// for i, pool := range pools {

--- a/pkg/liquidity-source/fluid/dex-t1/pool_list_updater_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_list_updater_test.go
@@ -2,7 +2,6 @@ package dexT1
 
 import (
 	"context"
-	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -83,17 +82,17 @@ func TestPoolListUpdater(t *testing.T) {
 	require.NotEqual(t, "0", pools[0].Reserves[0], "Reserve should not be zero")
 	require.NotEqual(t, "0", pools[0].Reserves[1], "Reserve should not be zero")
 
-	require.True(t, extra.CollateralReserves.Token0RealReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.CollateralReserves.Token1RealReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.CollateralReserves.Token0ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.CollateralReserves.Token1ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.DebtReserves.Token0Debt.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.DebtReserves.Token1Debt.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.DebtReserves.Token0RealReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.DebtReserves.Token1RealReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.DebtReserves.Token0ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.DebtReserves.Token1ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-	require.True(t, extra.CenterPrice.Cmp(big.NewInt(0)) > 0)
+	require.True(t, extra.CollateralReserves.Token0RealReserves.Sign() > 0)
+	require.True(t, extra.CollateralReserves.Token1RealReserves.Sign() > 0)
+	require.True(t, extra.CollateralReserves.Token0ImaginaryReserves.Sign() > 0)
+	require.True(t, extra.CollateralReserves.Token1ImaginaryReserves.Sign() > 0)
+	require.True(t, extra.DebtReserves.Token0Debt.Sign() > 0)
+	require.True(t, extra.DebtReserves.Token1Debt.Sign() > 0)
+	require.True(t, extra.DebtReserves.Token0RealReserves.Sign() > 0)
+	require.True(t, extra.DebtReserves.Token1RealReserves.Sign() > 0)
+	require.True(t, extra.DebtReserves.Token0ImaginaryReserves.Sign() > 0)
+	require.True(t, extra.DebtReserves.Token1ImaginaryReserves.Sign() > 0)
+	require.True(t, extra.CenterPrice.Sign() > 0)
 
 	// Log all pools
 	// for i, pool := range pools {

--- a/pkg/liquidity-source/fluid/dex-t1/pool_list_updater_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_list_updater_test.go
@@ -28,7 +28,7 @@ func TestPoolListUpdater(t *testing.T) {
 		err              error
 
 		config = Config{
-			DexReservesResolver: "0xF38082d58bF0f1e07C04684FF718d69a70f21e62",
+			DexReservesResolver: "0xb387f9C2092cF7c4943F97842887eBff7AE96EB3",
 		}
 	)
 

--- a/pkg/liquidity-source/fluid/dex-t1/pool_simulator_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_simulator_test.go
@@ -39,15 +39,15 @@ func calculateReservesOutsideRange(geometricMeanPrice, priceAtRange, reserveX, r
 }
 
 func getApproxCenterPriceIn(amountToSwap *big.Int, swap0To1 bool, colReserves CollateralReserves, debtReserves DebtReserves) (*big.Int, error) {
-	colPoolEnabled := colReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		colReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		colReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		colReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+	colPoolEnabled := colReserves.Token0RealReserves.Sign() > 0 &&
+		colReserves.Token1RealReserves.Sign() > 0 &&
+		colReserves.Token0ImaginaryReserves.Sign() > 0 &&
+		colReserves.Token1ImaginaryReserves.Sign() > 0
 
-	debtPoolEnabled := debtReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		debtReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		debtReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		debtReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+	debtPoolEnabled := debtReserves.Token0RealReserves.Sign() > 0 &&
+		debtReserves.Token1RealReserves.Sign() > 0 &&
+		debtReserves.Token0ImaginaryReserves.Sign() > 0 &&
+		debtReserves.Token1ImaginaryReserves.Sign() > 0
 
 	var colIReserveIn, colIReserveOut, debtIReserveIn, debtIReserveOut *big.Int
 
@@ -74,10 +74,10 @@ func getApproxCenterPriceIn(amountToSwap *big.Int, swap0To1 bool, colReserves Co
 		return nil, errors.New("No pools are enabled")
 	}
 
-	amountInCollateral := big.NewInt(0)
-	amountInDebt := big.NewInt(0)
+	amountInCollateral := new(big.Int)
+	amountInDebt := new(big.Int)
 
-	if a.Cmp(big.NewInt(0)) <= 0 {
+	if a.Sign() <= 0 {
 		amountInDebt = amountToSwap
 	} else if a.Cmp(amountToSwap) >= 0 {
 		amountInCollateral = amountToSwap
@@ -105,15 +105,15 @@ func getApproxCenterPriceIn(amountToSwap *big.Int, swap0To1 bool, colReserves Co
 }
 
 func getApproxCenterPriceOut(amountOut *big.Int, swap0To1 bool, colReserves CollateralReserves, debtReserves DebtReserves) (*big.Int, error) {
-	colPoolEnabled := colReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		colReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		colReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		colReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+	colPoolEnabled := colReserves.Token0RealReserves.Sign() > 0 &&
+		colReserves.Token1RealReserves.Sign() > 0 &&
+		colReserves.Token0ImaginaryReserves.Sign() > 0 &&
+		colReserves.Token1ImaginaryReserves.Sign() > 0
 
-	debtPoolEnabled := debtReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		debtReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		debtReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
-		debtReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+	debtPoolEnabled := debtReserves.Token0RealReserves.Sign() > 0 &&
+		debtReserves.Token1RealReserves.Sign() > 0 &&
+		debtReserves.Token0ImaginaryReserves.Sign() > 0 &&
+		debtReserves.Token1ImaginaryReserves.Sign() > 0
 
 	var colIReserveIn, colIReserveOut, debtIReserveIn, debtIReserveOut *big.Int
 
@@ -140,10 +140,10 @@ func getApproxCenterPriceOut(amountOut *big.Int, swap0To1 bool, colReserves Coll
 		return nil, errors.New("No pools are enabled")
 	}
 
-	amountInCollateral := big.NewInt(0)
-	amountInDebt := big.NewInt(0)
+	amountInCollateral := new(big.Int)
+	amountInDebt := new(big.Int)
 
-	if a.Cmp(big.NewInt(0)) <= 0 {
+	if a.Sign() <= 0 {
 		amountInDebt = getAmountIn(amountOut, debtIReserveIn, debtIReserveOut)
 	} else if a.Cmp(amountOut) >= 0 {
 		amountInCollateral = getAmountIn(amountOut, colIReserveIn, colIReserveOut)
@@ -300,7 +300,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
-				CenterPrice:    big.NewInt(0).Mul(big.NewInt(1.2e18), big.NewInt(1e9)),
+				CenterPrice:    new(big.Int).Mul(big.NewInt(1.2e18), big.NewInt(1e9)),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -514,7 +514,7 @@ func TestPoolSimulator_CalcAmountIn(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
-				CenterPrice:    big.NewInt(0).Mul(big.NewInt(1.2e18), big.NewInt(1e9)),
+				CenterPrice:    new(big.Int).Mul(big.NewInt(1.2e18), big.NewInt(1e9)),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -597,22 +597,22 @@ var limitExpandTight, _ = new(big.Int).SetString("711907234052361388866", 10)
 var limitsTight = DexLimits{
 	WithdrawableToken0: TokenLimit{
 		Available:      big.NewInt(456740438880263),
-		ExpandsTo:      big.NewInt(0).Set(limitExpandTight),
+		ExpandsTo:      new(big.Int).Set(limitExpandTight),
 		ExpandDuration: big.NewInt(600),
 	},
 	WithdrawableToken1: TokenLimit{
 		Available:      big.NewInt(825179383432029),
-		ExpandsTo:      big.NewInt(0).Set(limitExpandTight),
+		ExpandsTo:      new(big.Int).Set(limitExpandTight),
 		ExpandDuration: big.NewInt(600),
 	},
 	BorrowableToken0: TokenLimit{
 		Available:      big.NewInt(941825058374170),
-		ExpandsTo:      big.NewInt(0).Set(limitExpandTight),
+		ExpandsTo:      new(big.Int).Set(limitExpandTight),
 		ExpandDuration: big.NewInt(600),
 	},
 	BorrowableToken1: TokenLimit{
 		Available:      big.NewInt(941825058374170),
-		ExpandsTo:      big.NewInt(0).Set(limitExpandTight),
+		ExpandsTo:      new(big.Int).Set(limitExpandTight),
 		ExpandDuration: big.NewInt(600),
 	},
 }
@@ -620,23 +620,23 @@ var limitsTight = DexLimits{
 var limitWide, _ = new(big.Int).SetString("34242332879776515083099999", 10)
 var limitsWide = DexLimits{
 	WithdrawableToken0: TokenLimit{
-		Available:      big.NewInt(0).Set(limitWide),
-		ExpandsTo:      big.NewInt(0).Set(limitWide),
+		Available:      new(big.Int).Set(limitWide),
+		ExpandsTo:      new(big.Int).Set(limitWide),
 		ExpandDuration: bignumber.ZeroBI,
 	},
 	WithdrawableToken1: TokenLimit{
-		Available:      big.NewInt(0).Set(limitWide),
-		ExpandsTo:      big.NewInt(0).Set(limitWide),
+		Available:      new(big.Int).Set(limitWide),
+		ExpandsTo:      new(big.Int).Set(limitWide),
 		ExpandDuration: big.NewInt(22),
 	},
 	BorrowableToken0: TokenLimit{
-		Available:      big.NewInt(0).Set(limitWide),
-		ExpandsTo:      big.NewInt(0).Set(limitWide),
+		Available:      new(big.Int).Set(limitWide),
+		ExpandsTo:      new(big.Int).Set(limitWide),
 		ExpandDuration: bignumber.ZeroBI,
 	},
 	BorrowableToken1: TokenLimit{
-		Available:      big.NewInt(0).Set(limitWide),
-		ExpandsTo:      big.NewInt(0).Set(limitWide),
+		Available:      new(big.Int).Set(limitWide),
+		ExpandsTo:      new(big.Int).Set(limitWide),
 		ExpandDuration: big.NewInt(308),
 	},
 }
@@ -652,19 +652,19 @@ func NewColReservesOne() CollateralReserves {
 
 func NewColReservesEmpty() CollateralReserves {
 	return CollateralReserves{
-		Token0RealReserves:      big.NewInt(0),
-		Token1RealReserves:      big.NewInt(0),
-		Token0ImaginaryReserves: big.NewInt(0),
-		Token1ImaginaryReserves: big.NewInt(0),
+		Token0RealReserves:      new(big.Int),
+		Token1RealReserves:      new(big.Int),
+		Token0ImaginaryReserves: new(big.Int),
+		Token1ImaginaryReserves: new(big.Int),
 	}
 }
 
 func NewDebtReservesEmpty() DebtReserves {
 	return DebtReserves{
-		Token0RealReserves:      big.NewInt(0),
-		Token1RealReserves:      big.NewInt(0),
-		Token0ImaginaryReserves: big.NewInt(0),
-		Token1ImaginaryReserves: big.NewInt(0),
+		Token0RealReserves:      new(big.Int),
+		Token1RealReserves:      new(big.Int),
+		Token0ImaginaryReserves: new(big.Int),
+		Token1ImaginaryReserves: new(big.Int),
 	}
 }
 
@@ -754,7 +754,7 @@ func TestPoolSimulator_swapInAdjusted(t *testing.T) {
 		price, _ := getApproxCenterPriceIn(amountIn, true, colReserves, debtReserves)
 		outAmt, _ := swapInAdjusted(true, amountIn, colReserves, debtReserves, 18, limitsWide, price, time.Now().Unix()-10)
 
-		require.Equal(t, expectedAmountOut, big.NewInt(0).Mul(outAmt, big.NewInt(1e6)).String())
+		require.Equal(t, expectedAmountOut, new(big.Int).Mul(outAmt, big.NewInt(1e6)).String())
 	})
 }
 
@@ -837,16 +837,16 @@ func NewVerifyRatioColReserves() CollateralReserves {
 	return CollateralReserves{
 		Token0RealReserves:      big.NewInt(2_000_000 * 1e6 * 1e6), // e.g. 2M USDC
 		Token1RealReserves:      big.NewInt(15_000 * 1e6 * 1e6),    // e.g. 15 USDT
-		Token0ImaginaryReserves: big.NewInt(0),
-		Token1ImaginaryReserves: big.NewInt(0),
+		Token0ImaginaryReserves: new(big.Int),
+		Token1ImaginaryReserves: new(big.Int),
 	}
 }
 func NewVerifyRatioDebtReserves() DebtReserves {
 	return DebtReserves{
 		Token0RealReserves:      big.NewInt(2_000_000 * 1e6 * 1e6), // e.g. 2M USDC
 		Token1RealReserves:      big.NewInt(15_000 * 1e6 * 1e6),    // e.g. 15 USDT
-		Token0ImaginaryReserves: big.NewInt(0),
-		Token1ImaginaryReserves: big.NewInt(0),
+		Token0ImaginaryReserves: new(big.Int),
+		Token1ImaginaryReserves: new(big.Int),
 	}
 }
 func TestSwapInVerifyReservesInRange(t *testing.T) {
@@ -926,16 +926,16 @@ func NewVerifyRatioColReservesSwapOut() CollateralReserves {
 	return CollateralReserves{
 		Token0RealReserves:      big.NewInt(15_000 * 1e6 * 1e6),    // e.g. 15 USDT
 		Token1RealReserves:      big.NewInt(2_000_000 * 1e6 * 1e6), // e.g. 2M USDC
-		Token0ImaginaryReserves: big.NewInt(0),
-		Token1ImaginaryReserves: big.NewInt(0),
+		Token0ImaginaryReserves: new(big.Int),
+		Token1ImaginaryReserves: new(big.Int),
 	}
 }
 func NewVerifyRatioDebtReservesSwapOut() DebtReserves {
 	return DebtReserves{
 		Token0RealReserves:      big.NewInt(15_000 * 1e6 * 1e6),    // e.g. 15 USDT
 		Token1RealReserves:      big.NewInt(2_000_000 * 1e6 * 1e6), // e.g. 2M USDC
-		Token0ImaginaryReserves: big.NewInt(0),
-		Token1ImaginaryReserves: big.NewInt(0),
+		Token0ImaginaryReserves: new(big.Int),
+		Token1ImaginaryReserves: new(big.Int),
 	}
 }
 

--- a/pkg/liquidity-source/fluid/dex-t1/pool_simulator_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_simulator_test.go
@@ -1,6 +1,7 @@
 package dexT1
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -35,6 +36,138 @@ func calculateReservesOutsideRange(geometricMeanPrice, priceAtRange, reserveX, r
 	reserveYOutside := new(big.Int).Div(new(big.Int).Mul(reserveXOutside, geometricMeanPrice), bI1e27)
 
 	return reserveXOutside, reserveYOutside
+}
+
+func getApproxCenterPriceIn(amountToSwap *big.Int, swap0To1 bool, colReserves CollateralReserves, debtReserves DebtReserves) (*big.Int, error) {
+	colPoolEnabled := colReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		colReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		colReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		colReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+
+	debtPoolEnabled := debtReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		debtReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		debtReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		debtReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+
+	var colIReserveIn, colIReserveOut, debtIReserveIn, debtIReserveOut *big.Int
+
+	if swap0To1 {
+		colIReserveIn = colReserves.Token0ImaginaryReserves
+		colIReserveOut = colReserves.Token1ImaginaryReserves
+		debtIReserveIn = debtReserves.Token0ImaginaryReserves
+		debtIReserveOut = debtReserves.Token1ImaginaryReserves
+	} else {
+		colIReserveIn = colReserves.Token1ImaginaryReserves
+		colIReserveOut = colReserves.Token0ImaginaryReserves
+		debtIReserveIn = debtReserves.Token1ImaginaryReserves
+		debtIReserveOut = debtReserves.Token0ImaginaryReserves
+	}
+
+	var a *big.Int
+	if colPoolEnabled && debtPoolEnabled {
+		a = swapRoutingIn(amountToSwap, colIReserveOut, colIReserveIn, debtIReserveOut, debtIReserveIn)
+	} else if debtPoolEnabled {
+		a = big.NewInt(-1) // Route from debt pool
+	} else if colPoolEnabled {
+		a = new(big.Int).Add(amountToSwap, big.NewInt(1)) // Route from collateral pool
+	} else {
+		return nil, errors.New("No pools are enabled")
+	}
+
+	amountInCollateral := big.NewInt(0)
+	amountInDebt := big.NewInt(0)
+
+	if a.Cmp(big.NewInt(0)) <= 0 {
+		amountInDebt = amountToSwap
+	} else if a.Cmp(amountToSwap) >= 0 {
+		amountInCollateral = amountToSwap
+	} else {
+		amountInCollateral = a
+		amountInDebt = new(big.Int).Sub(amountToSwap, a)
+	}
+
+	var price *big.Int
+	if amountInCollateral.Cmp(amountInDebt) > 0 {
+		if swap0To1 {
+			price = new(big.Int).Div(new(big.Int).Mul(colIReserveOut, bI1e27), colIReserveIn)
+		} else {
+			price = new(big.Int).Div(new(big.Int).Mul(colIReserveIn, bI1e27), colIReserveOut)
+		}
+	} else {
+		if swap0To1 {
+			price = new(big.Int).Div(new(big.Int).Mul(debtIReserveOut, bI1e27), debtIReserveIn)
+		} else {
+			price = new(big.Int).Div(new(big.Int).Mul(debtIReserveIn, bI1e27), debtIReserveOut)
+		}
+	}
+
+	return price, nil
+}
+
+func getApproxCenterPriceOut(amountOut *big.Int, swap0To1 bool, colReserves CollateralReserves, debtReserves DebtReserves) (*big.Int, error) {
+	colPoolEnabled := colReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		colReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		colReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		colReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+
+	debtPoolEnabled := debtReserves.Token0RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		debtReserves.Token1RealReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		debtReserves.Token0ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0 &&
+		debtReserves.Token1ImaginaryReserves.Cmp(bignumber.ZeroBI) > 0
+
+	var colIReserveIn, colIReserveOut, debtIReserveIn, debtIReserveOut *big.Int
+
+	if swap0To1 {
+		colIReserveIn = colReserves.Token0ImaginaryReserves
+		colIReserveOut = colReserves.Token1ImaginaryReserves
+		debtIReserveIn = debtReserves.Token0ImaginaryReserves
+		debtIReserveOut = debtReserves.Token1ImaginaryReserves
+	} else {
+		colIReserveIn = colReserves.Token1ImaginaryReserves
+		colIReserveOut = colReserves.Token0ImaginaryReserves
+		debtIReserveIn = debtReserves.Token1ImaginaryReserves
+		debtIReserveOut = debtReserves.Token0ImaginaryReserves
+	}
+
+	var a *big.Int
+	if colPoolEnabled && debtPoolEnabled {
+		a = swapRoutingOut(amountOut, colIReserveIn, colIReserveOut, debtIReserveIn, debtIReserveOut)
+	} else if debtPoolEnabled {
+		a = big.NewInt(-1) // Route from debt pool
+	} else if colPoolEnabled {
+		a = new(big.Int).Add(amountOut, big.NewInt(1)) // Route from collateral pool
+	} else {
+		return nil, errors.New("No pools are enabled")
+	}
+
+	amountInCollateral := big.NewInt(0)
+	amountInDebt := big.NewInt(0)
+
+	if a.Cmp(big.NewInt(0)) <= 0 {
+		amountInDebt = getAmountIn(amountOut, debtIReserveIn, debtIReserveOut)
+	} else if a.Cmp(amountOut) >= 0 {
+		amountInCollateral = getAmountIn(amountOut, colIReserveIn, colIReserveOut)
+	} else {
+		amountInCollateral = getAmountIn(a, colIReserveIn, colIReserveOut)
+		amountInDebt = getAmountIn(new(big.Int).Sub(amountOut, a), debtIReserveIn, debtIReserveOut)
+	}
+
+	var price *big.Int
+	if amountInCollateral.Cmp(amountInDebt) > 0 {
+		if swap0To1 {
+			price = new(big.Int).Div(new(big.Int).Mul(colIReserveOut, bI1e27), colIReserveIn)
+		} else {
+			price = new(big.Int).Div(new(big.Int).Mul(colIReserveIn, bI1e27), colIReserveOut)
+		}
+	} else {
+		if swap0To1 {
+			price = new(big.Int).Div(new(big.Int).Mul(debtIReserveOut, bI1e27), debtIReserveIn)
+		} else {
+			price = new(big.Int).Div(new(big.Int).Mul(debtIReserveIn, bI1e27), debtIReserveOut)
+		}
+	}
+
+	return price, nil
 }
 
 func TestPoolSimulator_CalcAmountOut(t *testing.T) {
@@ -74,6 +207,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(1),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -120,6 +254,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(1),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -165,6 +300,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(0).Mul(big.NewInt(1.2e18), big.NewInt(1e9)),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -211,6 +347,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(1),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -235,12 +372,18 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 				assert.ErrorIs(t, err, tc.expectedError)
 			} else {
 				t.Logf("Expected Amount Out: %s", tc.expectedAmountOut.String())
-				t.Logf("Result Amount: %s", result.TokenAmountOut.Amount.String())
-				t.Logf("Fee Amount: %s", result.Fee.Amount.String())
+				if result == nil {
+					t.Log("Result is nil")
+				} else {
+					t.Logf("Result Amount: %s", result.TokenAmountOut.Amount.String())
+					t.Logf("Fee Amount: %s", result.Fee.Amount.String())
+
+				}
 
 				if tc.expectedAmountOut != nil {
 					assert.Zero(t, tc.expectedAmountOut.Cmp(result.TokenAmountOut.Amount))
 				}
+
 			}
 		})
 	}
@@ -283,6 +426,7 @@ func TestPoolSimulator_CalcAmountIn(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(1),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -326,6 +470,7 @@ func TestPoolSimulator_CalcAmountIn(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(1),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -369,6 +514,7 @@ func TestPoolSimulator_CalcAmountIn(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(0).Mul(big.NewInt(1.2e18), big.NewInt(1e9)),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -412,6 +558,7 @@ func TestPoolSimulator_CalcAmountIn(t *testing.T) {
 					Token1ImaginaryReserves: bignumber.NewBig("73766803277429176"),
 				},
 				DexLimits:      limitsWide,
+				CenterPrice:    big.NewInt(1),
 				SyncTimestamp:  time.Now().Unix() - 10,
 				Token0Decimals: 18,
 				Token1Decimals: 18,
@@ -531,14 +678,16 @@ func NewDebtReservesOne() DebtReserves {
 }
 
 func assertSwapInResult(t *testing.T, swap0To1 bool, amountIn *big.Int, colReserves CollateralReserves, debtReserves DebtReserves, expectedAmountIn string, expectedAmountOut string, outDecimals int64, limits DexLimits, syncTime int64) {
-	outAmt, _ := swapInAdjusted(swap0To1, amountIn, colReserves, debtReserves, outDecimals, limits, syncTime)
+	price, _ := getApproxCenterPriceIn(amountIn, swap0To1, colReserves, debtReserves)
+	outAmt, _ := swapInAdjusted(swap0To1, amountIn, colReserves, debtReserves, outDecimals, limits, price, syncTime)
 
 	require.Equal(t, expectedAmountIn, amountIn.String())
 	require.Equal(t, expectedAmountOut, outAmt.String())
 }
 
 func assertSwapOutResult(t *testing.T, swap0To1 bool, amountOut *big.Int, colReserves CollateralReserves, debtReserves DebtReserves, expectedAmountIn string, expectedAmountOut string, outDecimals int64, limits DexLimits, syncTime int64) {
-	inAmt, _ := swapOutAdjusted(swap0To1, amountOut, colReserves, debtReserves, outDecimals, limits, syncTime)
+	price, _ := getApproxCenterPriceOut(amountOut, swap0To1, colReserves, debtReserves)
+	inAmt, _ := swapOutAdjusted(swap0To1, amountOut, colReserves, debtReserves, outDecimals, limits, price, syncTime)
 
 	require.Equal(t, expectedAmountIn, inAmt.String())
 	require.Equal(t, expectedAmountOut, amountOut.String())
@@ -558,21 +707,25 @@ func TestPoolSimulator_SwapIn(t *testing.T) {
 func TestPoolSimulator_SwapInLimits(t *testing.T) {
 	t.Run("TestPoolSimulator_SwapInLimits", func(t *testing.T) {
 		// when limits hit
-		outAmt, err := swapInAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, time.Now().Unix()-10)
+		price, _ := getApproxCenterPriceIn(big.NewInt(1e15), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, err := swapInAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, price, time.Now().Unix()-10)
 		require.Nil(t, outAmt)
 		require.EqualError(t, err, ErrInsufficientBorrowable.Error())
 
 		// when expanded
-		outAmt, _ = swapInAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, time.Now().Unix()-6000)
+		price, _ = getApproxCenterPriceIn(big.NewInt(1e15), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, _ = swapInAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, price, time.Now().Unix()-6000)
 		require.Equal(t, "998262697204710", outAmt.String())
 
 		// when price diff hit
-		outAmt, err = swapInAdjusted(true, big.NewInt(3e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, time.Now().Unix()-10)
+		price, _ = getApproxCenterPriceIn(big.NewInt(3e16), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, err = swapInAdjusted(true, big.NewInt(3e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, price, time.Now().Unix()-10)
 		require.Nil(t, outAmt)
 		require.EqualError(t, err, ErrInsufficientMaxPrice.Error())
 
 		// when reserves limt is hit
-		outAmt, err = swapInAdjusted(true, big.NewInt(5e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, time.Now().Unix()-10)
+		price, _ = getApproxCenterPriceIn(big.NewInt(5e16), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, err = swapInAdjusted(true, big.NewInt(5e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, price, time.Now().Unix()-10)
 		require.Nil(t, outAmt)
 		require.EqualError(t, err, ErrInsufficientReserve.Error())
 	})
@@ -598,7 +751,8 @@ func TestPoolSimulator_swapInAdjusted(t *testing.T) {
 		}
 
 		amountIn := big.NewInt(1e12)
-		outAmt, _ := swapInAdjusted(true, amountIn, colReserves, debtReserves, 18, limitsWide, time.Now().Unix()-10)
+		price, _ := getApproxCenterPriceIn(amountIn, true, colReserves, debtReserves)
+		outAmt, _ := swapInAdjusted(true, amountIn, colReserves, debtReserves, 18, limitsWide, price, time.Now().Unix()-10)
 
 		require.Equal(t, expectedAmountOut, big.NewInt(0).Mul(outAmt, big.NewInt(1e6)).String())
 	})
@@ -618,21 +772,25 @@ func TestPoolSimulator_SwapOut(t *testing.T) {
 func TestPoolSimulator_SwapOutLimits(t *testing.T) {
 	t.Run("TestPoolSimulator_SwapInLimits", func(t *testing.T) {
 		// when limits hit
-		outAmt, err := swapOutAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, time.Now().Unix()-10)
+		price, _ := getApproxCenterPriceOut(big.NewInt(1e15), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, err := swapOutAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, price, time.Now().Unix()-10)
 		require.Nil(t, outAmt)
 		require.EqualError(t, err, ErrInsufficientBorrowable.Error())
 
 		// when expanded
-		outAmt, _ = swapOutAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, time.Now().Unix()-6000)
+		price, _ = getApproxCenterPriceOut(big.NewInt(1e15), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, _ = swapOutAdjusted(true, big.NewInt(1e15), NewColReservesOne(), NewDebtReservesOne(), 18, limitsTight, price, time.Now().Unix()-6000)
 		require.Equal(t, "1001743360284199", outAmt.String())
 
 		// when price diff hit
-		outAmt, err = swapOutAdjusted(true, big.NewInt(2e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, time.Now().Unix()-10)
+		price, _ = getApproxCenterPriceOut(big.NewInt(2e16), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, err = swapOutAdjusted(true, big.NewInt(2e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, price, time.Now().Unix()-10)
 		require.Nil(t, outAmt)
 		require.EqualError(t, err, ErrInsufficientMaxPrice.Error())
 
 		// when reserves limt is hit
-		outAmt, err = swapOutAdjusted(true, big.NewInt(3e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, time.Now().Unix()-10)
+		price, _ = getApproxCenterPriceOut(big.NewInt(3e16), true, NewColReservesOne(), NewDebtReservesOne())
+		outAmt, err = swapOutAdjusted(true, big.NewInt(3e16), NewColReservesOne(), NewDebtReservesOne(), 18, limitsWide, price, time.Now().Unix()-10)
 		require.Nil(t, outAmt)
 		require.EqualError(t, err, ErrInsufficientReserve.Error())
 	})
@@ -720,14 +878,16 @@ func TestSwapInVerifyReservesInRange(t *testing.T) {
 
 		// expected required ratio:
 		// token1Reserves must be > (token0Reserves * price) / (1e27 * MIN_SWAP_LIQUIDITY)
-		// so 2M / 6667, which is ~300
+		// so 2M / 2e4, which is 100
 
-		// Test for swap amount 14_705, revert should hit
-		swapAmount := big.NewInt(14_705 * 1e6 * 1e6)
-		result, _ := swapInAdjusted(true, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, time.Now().Unix()-10)
-		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for col reserves when swap amount %d", 14_705)
-		result, _ = swapInAdjusted(true, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, time.Now().Unix()-10)
-		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for debt reserves when swap amount %d", 14_705)
+		// Test for swap amount 14_905, revert should hit
+		swapAmount := big.NewInt(14_905 * 1e6 * 1e6)
+		price, _ = getApproxCenterPriceIn(swapAmount, true, colReserves, NewDebtReservesEmpty())
+		result, _ := swapInAdjusted(true, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, price, time.Now().Unix()-10)
+		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for col reserves when swap amount %d", 14_905)
+		price, _ = getApproxCenterPriceIn(swapAmount, true, NewColReservesEmpty(), debtReserves)
+		result, _ = swapInAdjusted(true, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, price, time.Now().Unix()-10)
+		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for debt reserves when swap amount %d", 14_905)
 
 		// refresh reserves
 		colReserves = NewVerifyRatioColReserves()
@@ -749,14 +909,16 @@ func TestSwapInVerifyReservesInRange(t *testing.T) {
 		debtReserves.Token0ImaginaryReserves = new(big.Int).Add(reserveXOutside, debtReserves.Token0RealReserves)
 		debtReserves.Token1ImaginaryReserves = new(big.Int).Add(reserveYOutside, debtReserves.Token1RealReserves)
 
-		// Test for swap amount 14_695, revert should NOT hit
-		swapAmount = big.NewInt(14_695 * 1e6 * 1e6)
+		// Test for swap amount 14_895, revert should NOT hit
+		swapAmount = big.NewInt(14_895 * 1e6 * 1e6)
 		err := error(nil)
-		result, err = swapInAdjusted(true, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, time.Now().Unix()-10)
+		price, _ = getApproxCenterPriceIn(swapAmount, true, colReserves, NewDebtReservesEmpty())
+		result, err = swapInAdjusted(true, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, price, time.Now().Unix()-10)
 		require.NoError(t, err, "Error during swapInAdjusted for col reserves")
-		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for col reserves when swap amount %d", 14_695)
-		result, _ = swapInAdjusted(true, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, time.Now().Unix()-10)
-		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for debt reserves when swap amount %d", 14_695)
+		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for col reserves when swap amount %d", 14_895)
+		price, _ = getApproxCenterPriceIn(swapAmount, true, NewColReservesEmpty(), debtReserves)
+		result, _ = swapInAdjusted(true, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, price, time.Now().Unix()-10)
+		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for debt reserves when swap amount %d", 14_895)
 	})
 }
 
@@ -806,14 +968,16 @@ func TestSwapOutVerifyReservesInRange(t *testing.T) {
 
 		// expected required ratio:
 		// token0Reserves >= (token1Reserves * 1e27) / (price * MIN_SWAP_LIQUIDITY)
-		// so 2M / 6667, which is ~300
+		// so 2M / 2e4, which is 100
 
-		// Test for swap amount 14_705, revert should hit
-		swapAmount := big.NewInt(14_705 * 1e6 * 1e6)
-		result, _ := swapOutAdjusted(false, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, time.Now().Unix()-10)
-		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for col reserves when swap amount %d", 14_705)
-		result, _ = swapOutAdjusted(false, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, time.Now().Unix()-10)
-		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for debt reserves when swap amount %d", 14_705)
+		// Test for swap amount 14_905, revert should hit
+		swapAmount := big.NewInt(14_905 * 1e6 * 1e6)
+		price, _ = getApproxCenterPriceOut(swapAmount, false, colReserves, NewDebtReservesEmpty())
+		result, _ := swapOutAdjusted(false, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, price, time.Now().Unix()-10)
+		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for col reserves when swap amount %d", 14_905)
+		price, _ = getApproxCenterPriceOut(swapAmount, false, NewColReservesEmpty(), debtReserves)
+		result, _ = swapOutAdjusted(false, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, price, time.Now().Unix()-10)
+		require.Nil(t, result, "FAIL: reserves ratio verification revert NOT hit for debt reserves when swap amount %d", 14_905)
 
 		// refresh reserves
 		colReserves = NewVerifyRatioColReservesSwapOut()
@@ -835,13 +999,15 @@ func TestSwapOutVerifyReservesInRange(t *testing.T) {
 		debtReserves.Token0ImaginaryReserves = new(big.Int).Add(reserveXOutside, debtReserves.Token0RealReserves)
 		debtReserves.Token1ImaginaryReserves = new(big.Int).Add(reserveYOutside, debtReserves.Token1RealReserves)
 
-		// Test for swap amount 14_695, revert should NOT hit
-		swapAmount = big.NewInt(14_695 * 1e6 * 1e6)
+		// Test for swap amount 14_895, revert should NOT hit
+		swapAmount = big.NewInt(14_895 * 1e6 * 1e6)
 		err := error(nil)
-		result, err = swapOutAdjusted(false, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, time.Now().Unix()-10)
+		price, _ = getApproxCenterPriceOut(swapAmount, false, colReserves, NewDebtReservesEmpty())
+		result, err = swapOutAdjusted(false, swapAmount, colReserves, NewDebtReservesEmpty(), decimals, limitsWide, price, time.Now().Unix()-10)
 		require.NoError(t, err, "Error during swapOutAdjusted for col reserves")
-		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for col reserves when swap amount %d", 14_695)
-		result, _ = swapOutAdjusted(false, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, time.Now().Unix()-10)
-		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for debt reserves when swap amount %d", 14_695)
+		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for col reserves when swap amount %d", 14_895)
+		price, _ = getApproxCenterPriceOut(swapAmount, false, NewColReservesEmpty(), debtReserves)
+		result, _ = swapOutAdjusted(false, swapAmount, NewColReservesEmpty(), debtReserves, decimals, limitsWide, price, time.Now().Unix()-10)
+		require.NotNil(t, result, "FAIL: reserves ratio verification revert hit for debt reserves when swap amount %d", 14_895)
 	})
 }

--- a/pkg/liquidity-source/fluid/dex-t1/pool_tracker.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_tracker.go
@@ -70,7 +70,7 @@ func (t *PoolTracker) getNewPoolState(
 		return p, err
 	}
 
-	p.SwapFee = float64(poolReserves.Fee.Int64()) / float64(FeePercentPrecision)
+	p.SwapFee = float64(poolReserves.Fee.Int64()) / FeePercentPrecision
 	p.Extra = string(extraBytes)
 	p.BlockNumber = blockNumber
 	p.Timestamp = time.Now().Unix()
@@ -99,7 +99,7 @@ func (t *PoolTracker) getPoolReserves(
 ) (*PoolWithReserves, bool, uint64, error) {
 	pool := &PoolWithReserves{}
 
-	dexVariables2 := bignumber.ZeroBI
+	dexVariables2 := new(big.Int)
 
 	req := t.ethrpcClient.R().SetContext(ctx)
 	if overrides != nil {
@@ -130,7 +130,7 @@ func (t *PoolTracker) getPoolReserves(
 		return nil, false, 0, err
 	}
 
-	isSwapAndArbitragePaused := dexVariables2.Rsh(dexVariables2, 255).Cmp(bignumber.One) == 0
+	isSwapAndArbitragePaused := dexVariables2.Bit(255) == 1
 
 	return pool, isSwapAndArbitragePaused, resp.BlockNumber.Uint64(), nil
 }

--- a/pkg/liquidity-source/fluid/dex-t1/pool_tracker.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_tracker.go
@@ -61,6 +61,7 @@ func (t *PoolTracker) getNewPoolState(
 		DebtReserves:             debtReserves,
 		IsSwapAndArbitragePaused: isSwapAndArbitragePaused,
 		DexLimits:                poolReserves.Limits,
+		CenterPrice:              poolReserves.CenterPrice,
 	}
 
 	extraBytes, err := json.Marshal(extra)

--- a/pkg/liquidity-source/fluid/dex-t1/pool_tracker_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_tracker_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/KyberNetwork/ethrpc"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 func TestPoolTracker(t *testing.T) {
@@ -85,19 +86,19 @@ func TestPoolTracker(t *testing.T) {
 		reserve0, _ := new(big.Int).SetString(newPool.Reserves[0], 10)
 		reserve1, _ := new(big.Int).SetString(newPool.Reserves[1], 10)
 
-		require.True(t, reserve0.Cmp(big.NewInt(0)) > 0)
-		require.True(t, reserve1.Cmp(big.NewInt(0)) > 0)
+		require.True(t, reserve0.Sign() > 0)
+		require.True(t, reserve1.Sign() > 0)
 
-		require.True(t, extra.CollateralReserves.Token0RealReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.CollateralReserves.Token1RealReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.CollateralReserves.Token0ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.CollateralReserves.Token1ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.DebtReserves.Token0Debt.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.DebtReserves.Token1Debt.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.DebtReserves.Token0RealReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.DebtReserves.Token1RealReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.DebtReserves.Token0ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
-		require.True(t, extra.CenterPrice.Cmp(big.NewInt(0)) > 0)
+		require.True(t, extra.CollateralReserves.Token0RealReserves.Sign() > 0)
+		require.True(t, extra.CollateralReserves.Token1RealReserves.Sign() > 0)
+		require.True(t, extra.CollateralReserves.Token0ImaginaryReserves.Sign() > 0)
+		require.True(t, extra.CollateralReserves.Token1ImaginaryReserves.Sign() > 0)
+		require.True(t, extra.DebtReserves.Token0Debt.Sign() > 0)
+		require.True(t, extra.DebtReserves.Token1Debt.Sign() > 0)
+		require.True(t, extra.DebtReserves.Token0RealReserves.Sign() > 0)
+		require.True(t, extra.DebtReserves.Token1RealReserves.Sign() > 0)
+		require.True(t, extra.DebtReserves.Token0ImaginaryReserves.Sign() > 0)
+		require.True(t, extra.CenterPrice.Sign() > 0)
 
 		logger.Debugf("Reserve0: %s", newPool.Reserves[0])
 		logger.Debugf("Reserve1: %s", newPool.Reserves[1])

--- a/pkg/liquidity-source/fluid/dex-t1/pool_tracker_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_tracker_test.go
@@ -26,7 +26,7 @@ func TestPoolTracker(t *testing.T) {
 
 	var (
 		config = Config{
-			DexReservesResolver: "0xF38082d58bF0f1e07C04684FF718d69a70f21e62",
+			DexReservesResolver: "0xb387f9C2092cF7c4943F97842887eBff7AE96EB3",
 		}
 	)
 

--- a/pkg/liquidity-source/fluid/dex-t1/pool_tracker_test.go
+++ b/pkg/liquidity-source/fluid/dex-t1/pool_tracker_test.go
@@ -25,7 +25,7 @@ func TestPoolTracker(t *testing.T) {
 
 	var (
 		config = Config{
-			DexReservesResolver: "0x45f4ad57e300da55c33dea579a40fcee000d7b94",
+			DexReservesResolver: "0xF38082d58bF0f1e07C04684FF718d69a70f21e62",
 		}
 	)
 
@@ -97,9 +97,12 @@ func TestPoolTracker(t *testing.T) {
 		require.True(t, extra.DebtReserves.Token0RealReserves.Cmp(big.NewInt(0)) > 0)
 		require.True(t, extra.DebtReserves.Token1RealReserves.Cmp(big.NewInt(0)) > 0)
 		require.True(t, extra.DebtReserves.Token0ImaginaryReserves.Cmp(big.NewInt(0)) > 0)
+		require.True(t, extra.CenterPrice.Cmp(big.NewInt(0)) > 0)
 
 		logger.Debugf("Reserve0: %s", newPool.Reserves[0])
 		logger.Debugf("Reserve1: %s", newPool.Reserves[1])
+
+		logger.Debugf("CenterPrice: %s", extra.CenterPrice.String())
 
 		logger.Debugf("Debt Reserves: Token0Debt: %s", extra.DebtReserves.Token0Debt.String())
 		logger.Debugf("Debt Reserves: Token1Debt: %s", extra.DebtReserves.Token1Debt.String())

--- a/pkg/liquidity-source/fluid/dex-t1/types.go
+++ b/pkg/liquidity-source/fluid/dex-t1/types.go
@@ -25,6 +25,15 @@ type CollateralReserves struct {
 	Token1ImaginaryReserves *big.Int `json:"token1ImaginaryReserves"`
 }
 
+func (r CollateralReserves) Clone() CollateralReserves {
+	return CollateralReserves{
+		Token0RealReserves:      new(big.Int).Set(r.Token0RealReserves),
+		Token1RealReserves:      new(big.Int).Set(r.Token1RealReserves),
+		Token0ImaginaryReserves: new(big.Int).Set(r.Token0ImaginaryReserves),
+		Token1ImaginaryReserves: new(big.Int).Set(r.Token1ImaginaryReserves),
+	}
+}
+
 type DebtReserves struct {
 	Token0Debt              *big.Int `json:"token0Debt"`
 	Token1Debt              *big.Int `json:"token1Debt"`
@@ -34,10 +43,29 @@ type DebtReserves struct {
 	Token1ImaginaryReserves *big.Int `json:"token1ImaginaryReserves"`
 }
 
+func (r DebtReserves) Clone() DebtReserves {
+	return DebtReserves{
+		Token0Debt:              new(big.Int).Set(r.Token0Debt),
+		Token1Debt:              new(big.Int).Set(r.Token1Debt),
+		Token0RealReserves:      new(big.Int).Set(r.Token0RealReserves),
+		Token1RealReserves:      new(big.Int).Set(r.Token1RealReserves),
+		Token0ImaginaryReserves: new(big.Int).Set(r.Token0ImaginaryReserves),
+		Token1ImaginaryReserves: new(big.Int).Set(r.Token1ImaginaryReserves),
+	}
+}
+
 type TokenLimit struct {
 	Available      *big.Int `json:"available"`      // maximum available swap amount
 	ExpandsTo      *big.Int `json:"expandsTo"`      // maximum amount the available swap amount expands to
 	ExpandDuration *big.Int `json:"expandDuration"` // duration for `available` to grow to `expandsTo`
+}
+
+func (t TokenLimit) Clone() TokenLimit {
+	return TokenLimit{
+		Available:      new(big.Int).Set(t.Available),
+		ExpandsTo:      new(big.Int).Set(t.ExpandsTo),
+		ExpandDuration: new(big.Int).Set(t.ExpandDuration),
+	}
 }
 
 type DexLimits struct {
@@ -45,6 +73,15 @@ type DexLimits struct {
 	WithdrawableToken1 TokenLimit `json:"withdrawableToken1"`
 	BorrowableToken0   TokenLimit `json:"borrowableToken0"`
 	BorrowableToken1   TokenLimit `json:"borrowableToken1"`
+}
+
+func (d DexLimits) Clone() DexLimits {
+	return DexLimits{
+		WithdrawableToken0: d.WithdrawableToken0.Clone(),
+		WithdrawableToken1: d.WithdrawableToken1.Clone(),
+		BorrowableToken0:   d.BorrowableToken0.Clone(),
+		BorrowableToken1:   d.BorrowableToken1.Clone(),
+	}
 }
 
 type PoolWithReserves struct {

--- a/pkg/liquidity-source/fluid/dex-t1/types.go
+++ b/pkg/liquidity-source/fluid/dex-t1/types.go
@@ -15,6 +15,7 @@ type PoolExtra struct {
 	DebtReserves             DebtReserves
 	IsSwapAndArbitragePaused bool
 	DexLimits                DexLimits
+	CenterPrice              *big.Int
 }
 
 type CollateralReserves struct {
@@ -51,6 +52,7 @@ type PoolWithReserves struct {
 	Token0Address      common.Address     `json:"token0Address"`
 	Token1Address      common.Address     `json:"token1Address"`
 	Fee                *big.Int           `json:"fee"`
+	CenterPrice        *big.Int           `json:"centerPrice"`
 	CollateralReserves CollateralReserves `json:"collateralReserves"`
 	DebtReserves       DebtReserves       `json:"debtReserves"`
 	Limits             DexLimits          `json:"limits"`


### PR DESCRIPTION
improves pool reserves ratio verification check by using the pool center price, properly simulating the on-chain flow. buffer margin is reduced to 2e4 which is still double the on-chain 1e4