### PR TITLE
fix: fix possible panic with batchSize

### DIFF
--- a/pkg/liquidity-source/deltaswap-v1/pool_list_updater.go
+++ b/pkg/liquidity-source/deltaswap-v1/pool_list_updater.go
@@ -261,7 +261,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/deltaswap-v1/pool_list_updater.go
+++ b/pkg/liquidity-source/deltaswap-v1/pool_list_updater.go
@@ -59,7 +59,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
 
 	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -255,12 +255,19 @@ func (u *PoolsListUpdater) newMetadata(newOffset int) ([]byte, error) {
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/ether-vista/pool_list_updater.go
+++ b/pkg/liquidity-source/ether-vista/pool_list_updater.go
@@ -62,7 +62,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
 
 	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -258,12 +258,19 @@ func (u *PoolsListUpdater) newMetadata(newOffset int) ([]byte, error) {
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/ether-vista/pool_list_updater.go
+++ b/pkg/liquidity-source/ether-vista/pool_list_updater.go
@@ -264,7 +264,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/ringswap/pool_list_updater.go
+++ b/pkg/liquidity-source/ringswap/pool_list_updater.go
@@ -316,7 +316,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/ringswap/pool_list_updater.go
+++ b/pkg/liquidity-source/ringswap/pool_list_updater.go
@@ -59,7 +59,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
 
 	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -310,12 +310,19 @@ func (u *PoolsListUpdater) newMetadata(newOffset int) ([]byte, error) {
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/solidly-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/solidly-v2/pool_list_updater.go
@@ -335,7 +335,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/solidly-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/solidly-v2/pool_list_updater.go
@@ -66,7 +66,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(int(poolFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(int(poolFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
 
 	poolAddresses, err := u.listPoolAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -329,12 +329,19 @@ func (u *PoolsListUpdater) newStaticExtra(poolMetadata PoolMetadata) ([]byte, er
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/swap-x-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/swap-x-v2/pool_list_updater.go
@@ -348,7 +348,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/swap-x-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/swap-x-v2/pool_list_updater.go
@@ -72,7 +72,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(int(poolFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(int(poolFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
 
 	poolAddresses, err := u.listPoolAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -342,12 +342,19 @@ func (u *PoolsListUpdater) newStaticExtra(poolMetadata velodromev2.PoolMetadata)
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/uniswap-v1/pool_list_updater.go
+++ b/pkg/liquidity-source/uniswap-v1/pool_list_updater.go
@@ -242,7 +242,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/uniswap-v1/pool_list_updater.go
+++ b/pkg/liquidity-source/uniswap-v1/pool_list_updater.go
@@ -65,7 +65,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(totalExchanges, u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(totalExchanges, u.config.NewPoolLimit, offset)
 
 	exchanges, err := u.listExchanges(ctx, offset, batchSize)
 	if err != nil {
@@ -236,12 +236,19 @@ func (u *PoolsListUpdater) newMetadata(newOffset int) ([]byte, error) {
 	return metadataBytes, nil
 }
 
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    DexType,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/uniswap-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/uniswap-v2/pool_list_updater.go
@@ -62,7 +62,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
 
 	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -273,12 +273,19 @@ func (u *PoolsListUpdater) newExtra(fee uint64, feePrecision uint64) ([]byte, er
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/uniswap-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/uniswap-v2/pool_list_updater.go
@@ -279,7 +279,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/velodrome-v1/pool_list_updater.go
+++ b/pkg/liquidity-source/velodrome-v1/pool_list_updater.go
@@ -345,7 +345,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/velodrome-v1/pool_list_updater.go
+++ b/pkg/liquidity-source/velodrome-v1/pool_list_updater.go
@@ -71,7 +71,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(int(pairFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(int(pairFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
 
 	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -339,12 +339,19 @@ func (u *PoolsListUpdater) newExtra(pairMetadata PairMetadata, factoryData PairF
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/velodrome-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/velodrome-v2/pool_list_updater.go
@@ -343,7 +343,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit

--- a/pkg/liquidity-source/velodrome-v2/pool_list_updater.go
+++ b/pkg/liquidity-source/velodrome-v2/pool_list_updater.go
@@ -71,7 +71,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(int(poolFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(int(poolFactoryData.AllPairsLength.Int64()), u.config.NewPoolLimit, offset)
 
 	poolAddresses, err := u.listPoolAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -337,12 +337,19 @@ func (u *PoolsListUpdater) newStaticExtra(poolMetadata PoolMetadata) ([]byte, er
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    u.config.DexID,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/virtual-fun/pool_list_updater.go
+++ b/pkg/liquidity-source/virtual-fun/pool_list_updater.go
@@ -63,7 +63,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Warn("getOffset failed")
 	}
 
-	batchSize := getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
+	batchSize := u.getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
 
 	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
 	if err != nil {
@@ -286,12 +286,19 @@ func (u *PoolsListUpdater) newMetadata(newOffset int) ([]byte, error) {
 // @params limit number of pairs to be fetched in one run
 // @params offset index of the last pair has been fetched
 // @returns batchSize
-func getBatchSize(length int, limit int, offset int) int {
+func (u *PoolsListUpdater) getBatchSize(length int, limit int, offset int) int {
 	if offset == length {
 		return 0
 	}
 
 	if offset+limit >= length {
+		if offset > length {
+			logger.WithFields(logger.Fields{
+				"dex":    DexType,
+				"offset": offset,
+				"length": length,
+			}).Warn("[getBatchSize] offset is greater than length")
+		}
 		return max(length-offset, 0)
 	}
 

--- a/pkg/liquidity-source/virtual-fun/pool_list_updater.go
+++ b/pkg/liquidity-source/virtual-fun/pool_list_updater.go
@@ -292,7 +292,7 @@ func getBatchSize(length int, limit int, offset int) int {
 	}
 
 	if offset+limit >= length {
-		return length - offset
+		return max(length-offset, 0)
 	}
 
 	return limit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
Our system retrieves the latest "allPairsLength." Reverted blocks may cause the "allPairsLength" in our system to be greater than the actual value on the blockchain, causing the "batchSize" to return a negative value and causing panic.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
