### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/source/iziswap/snapshot.go
+++ b/pkg/source/iziswap/snapshot.go
@@ -16,13 +16,6 @@ func getPointDelta(fee int) int {
 	return pointDeltas[fee]
 }
 
-func minInt(a int, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (d *PoolTracker) getLiquiditySnapshot(ctx context.Context, pool entity.Pool, poolInfo swap.PoolInfo) ([]swap.LiquidityPoint, error) {
 	ptRange := d.config.PointRange
 	if ptRange <= 0 {
@@ -50,7 +43,7 @@ func (d *PoolTracker) getLiquiditySnapshot(ctx context.Context, pool entity.Pool
 	liqudityPointLen := (rightPoint - leftPoint) / pointDelta
 	liquidityPointData := make([]swap.LiquidityPoint, 0, liqudityPointLen)
 	for start := leftPoint; start < rightPoint; start += batchLen {
-		end := minInt(start+batchLen, rightPoint)
+		end := min(start+batchLen, rightPoint)
 		rpcRequest := d.ethrpcClient.NewRequest()
 		rpcRequest.SetContext(util.NewContextWithTimestamp(ctx))
 		rpcRequest.AddCall(&ethrpc.Call{
@@ -118,7 +111,7 @@ func (d *PoolTracker) getLimitOrderSnapshot(ctx context.Context, pool entity.Poo
 	limitOrderPointLen := (rightPoint - leftPoint) / pointDelta
 	limitOrderPointData := make([]swap.LimitOrderPoint, 0, limitOrderPointLen)
 	for start := leftPoint; start < rightPoint; start += batchLen {
-		end := minInt(start+batchLen, rightPoint)
+		end := min(start+batchLen, rightPoint)
 		rpcRequest := d.ethrpcClient.NewRequest()
 		rpcRequest.SetContext(util.NewContextWithTimestamp(ctx))
 		rpcRequest.AddCall(&ethrpc.Call{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
