### PR TITLE
feat(*): expose NextStateSqrtRatioX96 field in swapInfo

### DIFF
--- a/pkg/source/uniswapv3/pool_simulator.go
+++ b/pkg/source/uniswapv3/pool_simulator.go
@@ -189,7 +189,7 @@ func (p *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcA
 				},
 				Gas: totalGas,
 				SwapInfo: SwapInfo{
-					nextStateSqrtRatioX96: new(uint256.Int).Set(newPoolState.SqrtRatioX96),
+					NextStateSqrtRatioX96: new(uint256.Int).Set(newPoolState.SqrtRatioX96),
 					nextStateLiquidity:    new(uint256.Int).Set(newPoolState.Liquidity),
 					nextStateTickCurrent:  newPoolState.TickCurrent,
 				},
@@ -257,7 +257,7 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 				},
 				Gas: totalGas,
 				SwapInfo: SwapInfo{
-					nextStateSqrtRatioX96: new(uint256.Int).Set(amountOutResult.SqrtRatioX96),
+					NextStateSqrtRatioX96: new(uint256.Int).Set(amountOutResult.SqrtRatioX96),
 					nextStateLiquidity:    new(uint256.Int).Set(amountOutResult.Liquidity),
 					nextStateTickCurrent:  amountOutResult.CurrentTick,
 				},
@@ -286,7 +286,7 @@ func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 		logger.Warn("failed to UpdateBalance for UniV3 pool, wrong swapInfo type")
 		return
 	}
-	p.V3Pool.SqrtRatioX96 = si.nextStateSqrtRatioX96
+	p.V3Pool.SqrtRatioX96 = si.NextStateSqrtRatioX96
 	p.V3Pool.Liquidity = si.nextStateLiquidity
 	p.V3Pool.TickCurrent = si.nextStateTickCurrent
 }

--- a/pkg/source/uniswapv3/type.go
+++ b/pkg/source/uniswapv3/type.go
@@ -18,7 +18,7 @@ type Gas struct {
 }
 
 type SwapInfo struct {
-	nextStateSqrtRatioX96 *v3Utils.Uint160
+	NextStateSqrtRatioX96 *v3Utils.Uint160 `json:"nSqrtRx96"`
 	nextStateLiquidity    *v3Utils.Uint128
 	nextStateTickCurrent  int
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, we need `NextStateSqrtRatioX96` at some internal services. But it didn't return in router API due to this field is private.
## Why did we need it?
<!--- Describe your changes in detail -->
- Set `NextStateSqrtRatioX96` as public field
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
