### PR TITLE
fix: Handle bebop call rfq fail

### DIFF
--- a/pkg/liquidity-source/bebop/client/http.go
+++ b/pkg/liquidity-source/bebop/client/http.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/KyberNetwork/kutils/klog"
 	"github.com/ethereum/go-ethereum/common"
@@ -71,26 +72,31 @@ func (c *HTTPClient) QuoteSingleOrderResult(ctx context.Context,
 		SetQueryParam(bebop.ParamsReceiverAddress, common.HexToAddress(params.ReceiverAddress).Hex()).
 		SetQueryParam(bebop.ParamsApproveType, "Standard").
 		SetQueryParam(bebop.ParamsSkipValidation, "true"). // not checking balance
-		SetQueryParam(bebop.ParamsGasLess, "false").       // self-execution
+		SetQueryParam(bebop.ParamsGasLess, "false"). // self-execution
 		SetQueryParam(querySourceKey, c.config.Name)
 
-	var result bebop.QuoteSingleOrderResult
-	var fail bebop.QuoteFail
-	resp, err := req.SetResult(&result).SetError(&fail).Get(pathQuote)
+	var result struct {
+		bebop.QuoteSingleOrderResult
+		bebop.QuoteFail
+	}
+	resp, err := req.SetResult(&result).SetError(&result).Get(pathQuote)
 	if err != nil {
 		return bebop.QuoteSingleOrderResult{}, err
 	}
 
-	if !resp.IsSuccess() || fail.Failed() {
+	if !resp.IsSuccess() || result.Failed() {
 		klog.WithFields(ctx, klog.Fields{
-			"rfq.client": bebop.DexType,
-			"rfq.resp":   util.MaxBytesToString(resp.Body(), 256),
-			"rfq.status": resp.StatusCode(),
+			"rfq.client":        bebop.DexType,
+			"rfq.resp":          util.MaxBytesToString(resp.Body(), 256),
+			"rfq.status":        resp.StatusCode(),
+			"rfq.error.code":    result.Error.ErrorCode,
+			"rfq.error.message": result.Error.Message,
 		}).Error("quote failed")
-		return bebop.QuoteSingleOrderResult{}, parseRFQError(fail.Error.ErrorCode)
+		err = parseRFQError(result.Error.ErrorCode)
+		return bebop.QuoteSingleOrderResult{}, fmt.Errorf("%w: %s", err, result.Error.Message)
 	}
 
-	return result, nil
+	return result.QuoteSingleOrderResult, nil
 }
 
 func parseRFQError(errorCode int) error {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
When an error occurs when calling rfq, bebop still return error response with http status is 200. So I update to handle it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
