### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/source/camelot/pool_lists_updater.go
+++ b/pkg/source/camelot/pool_lists_updater.go
@@ -171,10 +171,7 @@ func (d *PoolListsUpdater) getNewPools(ctx context.Context, pairAddresses []comm
 
 func (d *PoolListsUpdater) getPairAddresses(ctx context.Context, offset uint64, pairCount uint64) ([]common.Address, error) {
 	start := offset
-	end := offset + uint64(d.cfg.NewPoolLimit)
-	if end > pairCount {
-		end = pairCount
-	}
+	end := min(offset+uint64(d.cfg.NewPoolLimit), pairCount)
 
 	if start >= end {
 		return []common.Address{}, nil

--- a/pkg/source/iziswap/swap/swap_x2y.go
+++ b/pkg/source/iziswap/swap/swap_x2y.go
@@ -138,10 +138,7 @@ func SwapX2Y(amount *uint256.Int, lowPt int, pool PoolInfoU256) (SwapResult, err
 			break
 		}
 
-		nextPt := orderData.MoveX2Y(searchStart, pointDelta)
-		if nextPt < lowPt {
-			nextPt = lowPt
-		}
+		nextPt := max(orderData.MoveX2Y(searchStart, pointDelta), lowPt)
 
 		if liquidity.Sign() == 0 {
 			// no liquidity in the range [nextPt, st.currentPoint]
@@ -297,10 +294,7 @@ func SwapX2YDesireY(desireY *uint256.Int, lowPt int, pool PoolInfoU256) (SwapRes
 			break
 		}
 
-		nextPt := orderData.MoveX2Y(searchStart, pointDelta)
-		if nextPt < lowPt {
-			nextPt = lowPt
-		}
+		nextPt := max(orderData.MoveX2Y(searchStart, pointDelta), lowPt)
 
 		// in [nextPt, st.currentPoint)
 		if liquidity.Sign() == 0 {

--- a/pkg/source/iziswap/swap/swap_y2x.go
+++ b/pkg/source/iziswap/swap/swap_y2x.go
@@ -77,10 +77,7 @@ func SwapY2X(amount *uint256.Int, highPt int, pool PoolInfoU256) (SwapResult, er
 			break
 		}
 
-		nextPoint := orderData.MoveY2X(currentPoint, pointDelta)
-		if nextPoint > highPt {
-			nextPoint = highPt
-		}
+		nextPoint := min(orderData.MoveY2X(currentPoint, pointDelta), highPt)
 
 		// in [st.currentPoint, nextPoint)
 		if liquidity.Sign() == 0 {
@@ -204,10 +201,7 @@ func SwapY2XDesireX(desireX *uint256.Int, highPt int, pool PoolInfoU256) (SwapRe
 			break
 		}
 
-		nextPoint := orderData.MoveY2X(currentPoint, pointDelta)
-		if nextPoint > highPt {
-			nextPoint = highPt
-		}
+		nextPoint := min(orderData.MoveY2X(currentPoint, pointDelta), highPt)
 
 		// in [st.currentPoint, nextPoint)
 		if liquidity.Sign() == 0 {

--- a/pkg/source/liquiditybookv20/fee_parameters.go
+++ b/pkg/source/liquiditybookv20/fee_parameters.go
@@ -41,11 +41,7 @@ func (fp *feeParameters) updateVariableFeeParameters(blockTimestamp uint64, acti
 
 func (fp *feeParameters) updateVolatilityAccumulated(activeID uint32) {
 	absSub := math.Abs(float64(activeID) - float64(fp.IndexRef))
-	volatilityAccumulated := uint64(absSub)*basisPointMax + uint64(fp.VolatilityReference)
-
-	if volatilityAccumulated > uint64(fp.MaxVolatilityAccumulated) {
-		volatilityAccumulated = uint64(fp.MaxVolatilityAccumulated)
-	}
+	volatilityAccumulated := min(uint64(absSub)*basisPointMax+uint64(fp.VolatilityReference), uint64(fp.MaxVolatilityAccumulated))
 
 	fp.VolatilityAccumulated = uint32(volatilityAccumulated)
 }

--- a/pkg/source/maverickv1/pool_tracker.go
+++ b/pkg/source/maverickv1/pool_tracker.go
@@ -139,10 +139,7 @@ func (d *PoolTracker) getNewPoolState(
 	g := pool.New().WithContext(ctx)
 	for i := 0; i <= binLength; i += chunk {
 		startBin := i
-		endBin := startBin + chunk - 1
-		if endBin > binLength {
-			endBin = binLength
-		}
+		endBin := min(startBin+chunk-1, binLength)
 		g.Go(func(context.Context) error {
 			return func(startBin, endBin int) error {
 				binCalls := d.ethrpcClient.NewRequest().SetContext(ctx)

--- a/pkg/source/smardex/pool_list_updater_test.go
+++ b/pkg/source/smardex/pool_list_updater_test.go
@@ -64,10 +64,7 @@ func (ts *PoolListUpdaterTestSuite) TestGetNewPools() {
 	for _, p := range pools {
 		assert.NotNil(ts.Suite.T(), p.Address)
 	}
-	compare := length.Int64()
-	if compare > length.Int64()-int64(metadata.Offset) {
-		compare = length.Int64() - int64(metadata.Offset)
-	}
+	compare := min(length.Int64(), length.Int64()-int64(metadata.Offset))
 	assert.Equal(ts.T(), compare, int64(len(pools)))
 	var savedMetadataRes PoolListUpdaterMetadata
 	err = json.Unmarshal(metadataRes, &savedMetadataRes)

--- a/pkg/source/syncswap/pools_list_updater.go
+++ b/pkg/source/syncswap/pools_list_updater.go
@@ -103,10 +103,7 @@ func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		}).Info("scan SyncSwapPoolMaster")
 	}
 
-	nextOffset := currentOffset + batchSize
-	if nextOffset > totalNumberOfPools {
-		nextOffset = totalNumberOfPools
-	}
+	nextOffset := min(currentOffset+batchSize, totalNumberOfPools)
 	newMetadataBytes, err := json.Marshal(Metadata{
 		Offset: nextOffset,
 	})

--- a/pkg/source/synthetix/dex_price_aggregator_uniswapv3.go
+++ b/pkg/source/synthetix/dex_price_aggregator_uniswapv3.go
@@ -111,17 +111,9 @@ func (dp *DexPriceAggregatorUniswapV3) _fetchAmountFromSinglePool(
 	// we need to treat the tick as an inverse
 	var minTick int
 	if _tokenIn.String() < _tokenOut.String() {
-		if spotTick < twapTick {
-			minTick = spotTick
-		} else {
-			minTick = twapTick
-		}
+		minTick = min(spotTick, twapTick)
 	} else {
-		if spotTick > twapTick {
-			minTick = spotTick
-		} else {
-			minTick = twapTick
-		}
+		minTick = max(spotTick, twapTick)
 	}
 
 	return getQuoteAtTick(

--- a/pkg/source/uniswapv3/util.go
+++ b/pkg/source/uniswapv3/util.go
@@ -21,10 +21,7 @@ func FetchTickSpacings(
 	tickSpacings := make(map[string]uint64, len(poolAddresses))
 
 	for i := 0; i < len(poolAddresses); i += rpcChunkSize {
-		endIndex := i + rpcChunkSize
-		if endIndex > len(poolAddresses) {
-			endIndex = len(poolAddresses)
-		}
+		endIndex := min(i+rpcChunkSize, len(poolAddresses))
 
 		chunk := poolAddresses[i:endIndex]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
