### PR TITLE
feat: Xpress Protocol

### DIFF
--- a/pkg/liquidity-source/xpress/abi.go
+++ b/pkg/liquidity-source/xpress/abi.go
@@ -1,0 +1,30 @@
+package xpress
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	onchainClobHelperABI abi.ABI
+	onchainClobABI       abi.ABI
+)
+
+func init() {
+	builder := []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{&onchainClobHelperABI, onchainClobHelperABIJson},
+		{&onchainClobABI, OnchainClobABIJson},
+	}
+
+	for _, b := range builder {
+		var err error
+		*b.ABI, err = abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkg/liquidity-source/xpress/abis/OnchainClob.json
+++ b/pkg/liquidity-source/xpress/abis/OnchainClob.json
@@ -1,0 +1,1530 @@
+[
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "_watch_dog",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "receive",
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "UPGRADE_INTERFACE_VERSION",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string",
+                "internalType": "string"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "acceptOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "batchChangeOrder",
+        "inputs": [
+            {
+                "name": "order_ids",
+                "type": "uint64[]",
+                "internalType": "uint64[]"
+            },
+            {
+                "name": "quantities",
+                "type": "uint128[]",
+                "internalType": "uint128[]"
+            },
+            {
+                "name": "prices",
+                "type": "uint72[]",
+                "internalType": "uint72[]"
+            },
+            {
+                "name": "max_commission_per_order",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "post_only",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "transfer_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "new_order_ids",
+                "type": "uint64[]",
+                "internalType": "uint64[]"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "batchClaim",
+        "inputs": [
+            {
+                "name": "addresses",
+                "type": "address[]",
+                "internalType": "address[]"
+            },
+            {
+                "name": "order_ids",
+                "type": "uint64[]",
+                "internalType": "uint64[]"
+            },
+            {
+                "name": "only_claim",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "changeMarketMaker",
+        "inputs": [
+            {
+                "name": "_marketmaker",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_should_invoke_on_trade",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "_admin_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "changeOrder",
+        "inputs": [
+            {
+                "name": "old_order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "new_quantity",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "new_price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "max_commission",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "post_only",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "transfer_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "changePauser",
+        "inputs": [
+            {
+                "name": "pauser_",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "claimOrder",
+        "inputs": [
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "only_claim",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "transfer_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "depositTokens",
+        "inputs": [
+            {
+                "name": "token_x_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_y_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "depositTokens",
+        "inputs": [
+            {
+                "name": "token_x_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_y_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "v_x",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "r_x",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "s_x",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "v_y",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "r_y",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "s_y",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "getAccumulatedFees",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getConfig",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "_scaling_factor_token_x",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_scaling_factor_token_y",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_token_x",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_token_y",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_supports_native_eth",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "_is_token_x_weth",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "_ask_trie",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_bid_trie",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_admin_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_total_aggressive_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_total_passive_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_passive_order_payout_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_should_invoke_on_trade",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getTraderBalance",
+        "inputs": [
+            {
+                "name": "address_",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "initialize",
+        "inputs": [
+            {
+                "name": "_trie_factory",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_tokenXAddress",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_tokenYAddress",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_supports_native_eth",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "_is_token_x_weth",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "scaling_token_x",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "scaling_token_y",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_administrator",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_marketmaker",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_pauser",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_should_invoke_on_trade",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "_admin_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_total_aggressive_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_total_passive_commission_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "_passive_order_payout_rate",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "marketmaker_config",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "marketmaker",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "should_invoke_on_trade",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "nonce",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "owner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "pause",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "paused",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "pauser",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "pendingOwner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "placeMarketOrderWithTargetValue",
+        "inputs": [
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "target_token_y_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "max_commission",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "amount_to_approve",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "transfer_executed_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "executed_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "executed_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "placeMarketOrderWithTargetValue",
+        "inputs": [
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "target_token_y_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "max_commission",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "transfer_executed_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "executed_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "executed_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "placeOrder",
+        "inputs": [
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "quantity",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "max_commission",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "amount_to_approve",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "market_only",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "post_only",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "transfer_executed_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "executed_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "executed_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "placeOrder",
+        "inputs": [
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "quantity",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "max_commission",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "market_only",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "post_only",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "transfer_executed_tokens",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "expires",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            },
+            {
+                "name": "executed_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "executed_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "proxiableUUID",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "renounceOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "setClaimableStatus",
+        "inputs": [
+            {
+                "name": "status",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "transferFees",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "transferOwnership",
+        "inputs": [
+            {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "unpause",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "upgradeToAndCall",
+        "inputs": [
+            {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "withdrawTokens",
+        "inputs": [
+            {
+                "name": "withdraw_all",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "token_x_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_y_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "event",
+        "name": "ClaimableStatusChanged",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "status",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Deposited",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "token_x",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_y",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Initialized",
+        "inputs": [
+            {
+                "name": "version",
+                "type": "uint64",
+                "indexed": false,
+                "internalType": "uint64"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "MarketMakerChanged",
+        "inputs": [
+            {
+                "name": "new_marketmaker",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "old_marketmaker",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OrderClaimed",
+        "inputs": [
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "indexed": false,
+                "internalType": "uint64"
+            },
+            {
+                "name": "order_shares_remaining",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_x_sent",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_y_sent",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "passive_payout",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "only_claim",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OrderPlaced",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "indexed": false,
+                "internalType": "uint64"
+            },
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "indexed": true,
+                "internalType": "bool"
+            },
+            {
+                "name": "quantity",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "indexed": false,
+                "internalType": "uint72"
+            },
+            {
+                "name": "passive_shares",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "passive_fee",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_shares",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_value",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "aggressive_fee",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "market_only",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            },
+            {
+                "name": "post_only",
+                "type": "bool",
+                "indexed": false,
+                "internalType": "bool"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferStarted",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferred",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Paused",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "PauserChanged",
+        "inputs": [
+            {
+                "name": "new_pauser",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "old_pauser",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Unpaused",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Upgraded",
+        "inputs": [
+            {
+                "name": "implementation",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Withdrawn",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "token_x",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            },
+            {
+                "name": "token_y",
+                "type": "uint128",
+                "indexed": false,
+                "internalType": "uint128"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "AddressEmptyCode",
+        "inputs": [
+            {
+                "name": "target",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "AddressInsufficientBalance",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "AddressIsZero",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ArrayLengthMismatch",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ChainIsUnstableForTrades",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ClaimNotAllowed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ERC1967InvalidImplementation",
+        "inputs": [
+            {
+                "name": "implementation",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ERC1967NonPayable",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "EnforcedPause",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ExcessiveSignificantFigures",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ExpectedPause",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "Expired",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "FailedInnerCall",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "Forbidden",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InsufficientTokenXBalance",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InsufficientTokenYBalance",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidCommissionRate",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidFloatingPointRepresentation",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidInitialization",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidMarketMaker",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidPriceRange",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidTransfer",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "MarketOnlyAndPostOnlyFlagsConflict",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "MaxCommissionFailure",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NativeETHDisabled",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NonceExhaustedFailure",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotInitializing",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "OnlyOwnerCanCancelOrders",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "OwnableInvalidOwner",
+        "inputs": [
+            {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "OwnableUnauthorizedAccount",
+        "inputs": [
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ReentrancyGuardReentrantCall",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SafeCastOverflowedUintDowncast",
+        "inputs": [
+            {
+                "name": "bits",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "SafeERC20FailedOperation",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "TransferFailed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UUPSUnauthorizedCallContext",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UUPSUnsupportedProxiableUUID",
+        "inputs": [
+            {
+                "name": "slot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "ZeroTokenTransferNotAllowed",
+        "inputs": []
+    }
+]

--- a/pkg/liquidity-source/xpress/abis/OnchainClobHelper.json
+++ b/pkg/liquidity-source/xpress/abis/OnchainClobHelper.json
@@ -1,0 +1,242 @@
+[
+    {
+        "type": "function",
+        "name": "assembleOrderbookFromOrders",
+        "inputs": [
+            {
+                "name": "lob_address",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "max_price_levels",
+                "type": "uint24",
+                "internalType": "uint24"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "array_prices",
+                "type": "uint72[]",
+                "internalType": "uint72[]"
+            },
+            {
+                "name": "array_shares",
+                "type": "uint128[]",
+                "internalType": "uint128[]"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "convertToActualPrice",
+        "inputs": [
+            {
+                "name": "lob_address",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "extractDirectionAndPrice",
+        "inputs": [
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "firstLevel",
+        "inputs": [
+            {
+                "name": "lob_address",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "bid",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "ask",
+                "type": "uint72",
+                "internalType": "uint72"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getOrderInfo",
+        "inputs": [
+            {
+                "name": "lob_address",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "order_id",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "total_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "remain_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "payout_amount",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "total_fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "current_execution_fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "previewPlaceAggressiveOrder",
+        "inputs": [
+            {
+                "name": "lob_address",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "isAsk",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "price",
+                "type": "uint72",
+                "internalType": "uint72"
+            },
+            {
+                "name": "max_executable_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "max_executable_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "executed_shares",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "executed_value",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "fee",
+                "type": "uint128",
+                "internalType": "uint128"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "error",
+        "name": "ExcessiveSignificantFigures",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidFloatingPointRepresentation",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidPriceRange",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "SafeCastOverflowedUintDowncast",
+        "inputs": [
+            {
+                "name": "bits",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    }
+]

--- a/pkg/liquidity-source/xpress/config.go
+++ b/pkg/liquidity-source/xpress/config.go
@@ -1,0 +1,19 @@
+package xpress
+
+import (
+	"github.com/KyberNetwork/blockchain-toolkit/time/durationjson"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+type HTTPConfig struct {
+	BaseURL    string                `json:"baseUrl,omitempty"`
+	Timeout    durationjson.Duration `json:"timeout,omitempty"`
+	RetryCount int                   `json:"retryCount,omitempty"`
+}
+
+type Config struct {
+	DexId         string              `json:"dexId"`
+	HTTPConfig    HTTPConfig          `json:"httpConfig"`
+	ChainId       valueobject.ChainID `json:"chainId"`
+	HelperAddress string              `json:"helperAddress"`
+}

--- a/pkg/liquidity-source/xpress/constant.go
+++ b/pkg/liquidity-source/xpress/constant.go
@@ -1,0 +1,7 @@
+package xpress
+
+const (
+	DexType = "xpress"
+
+	DefaultGas = 200000
+)

--- a/pkg/liquidity-source/xpress/embed.go
+++ b/pkg/liquidity-source/xpress/embed.go
@@ -1,0 +1,9 @@
+package xpress
+
+import _ "embed"
+
+//go:embed abis/OnchainClobHelper.json
+var onchainClobHelperABIJson []byte
+
+//go:embed abis/OnchainClob.json
+var OnchainClobABIJson []byte

--- a/pkg/liquidity-source/xpress/pool_simulator.go
+++ b/pkg/liquidity-source/xpress/pool_simulator.go
@@ -1,0 +1,209 @@
+package xpress
+
+import (
+	"encoding/json"
+	"math/big"
+	"slices"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+	OrderBook *OrderBook
+	LobConfig *LobConfig
+}
+
+var _ = pool.RegisterFactory1(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(entityPool entity.Pool, chainID valueobject.ChainID) (*PoolSimulator, error) {
+	var orderBook OrderBook
+	if err := json.Unmarshal([]byte(entityPool.Extra), &orderBook); err != nil {
+		return nil, err
+	}
+
+	var lobConfig LobConfig
+	if err := json.Unmarshal([]byte(entityPool.StaticExtra), &lobConfig); err != nil {
+		return nil, err
+	}
+
+	var swapFeeFl = new(big.Float).Mul(big.NewFloat(entityPool.SwapFee), bignumber.BoneFloat)
+	var swapFee, _ = swapFeeFl.Int(nil)
+
+	info := pool.PoolInfo{
+		Address:     entityPool.Address,
+		Exchange:    entityPool.Exchange,
+		Type:        entityPool.Type,
+		Tokens:      []string{entityPool.Tokens[0].Address, entityPool.Tokens[1].Address},
+		Reserves:    []*big.Int{bignumber.NewBig10(entityPool.Reserves[0]), bignumber.NewBig10(entityPool.Reserves[1])},
+		SwapFee:     swapFee,
+		BlockNumber: entityPool.BlockNumber,
+	}
+
+	return &PoolSimulator{
+		Pool:      pool.Pool{Info: info},
+		OrderBook: &orderBook,
+		LobConfig: &lobConfig,
+	}, nil
+}
+
+func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (swapResult *pool.CalcAmountOutResult, err error) {
+	tokenAmountIn := param.TokenAmountIn
+	tokenOut := param.TokenOut
+
+	// TODO: check tokenIn and tokenOut is correct
+
+	// tokenOut is tokenX means buy, tokenOut is tokenY means sell
+	var isBuy = common.HexToAddress(param.TokenOut).Cmp(p.LobConfig.TokenX) == 0
+	var levels *OrderBookLevels
+	var scalingFactorIn *big.Int
+	var scalingFactorOut *big.Int
+
+	if isBuy {
+		levels = &OrderBookLevels{
+			ArrayPrices: slices.Clone(p.OrderBook.Asks.ArrayPrices),
+			ArrayShares: slices.Clone(p.OrderBook.Asks.ArrayShares),
+		}
+		scalingFactorIn = p.LobConfig.ScalingFactorTokenY
+		scalingFactorOut = p.LobConfig.ScalingFactorTokenX
+	} else {
+		levels = &OrderBookLevels{
+			ArrayPrices: slices.Clone(p.OrderBook.Bids.ArrayPrices),
+			ArrayShares: slices.Clone(p.OrderBook.Bids.ArrayShares),
+		}
+		scalingFactorIn = p.LobConfig.ScalingFactorTokenX
+		scalingFactorOut = p.LobConfig.ScalingFactorTokenY
+	}
+
+	// for buys fees deducted from tokenIn (tokenY), for sells fees deducted from result tokenOut (tokenY)
+	var availableAmountIn = new(big.Int).Set(tokenAmountIn.Amount)
+
+	if isBuy {
+		availableAmountIn.Mul(availableAmountIn, bignumber.BONE)
+		availableAmountIn.Div(availableAmountIn, new(big.Int).Add(bignumber.BONE, p.Info.SwapFee))
+	}
+
+	var scaledAmountIn = new(big.Int).Div(availableAmountIn, scalingFactorIn)
+	var executedScaledAmountOut = new(big.Int)
+	var executedScaledAmountIn = new(big.Int)
+
+	for i := 0; i < len(levels.ArrayPrices); i++ {
+		price := levels.ArrayPrices[i]
+		shares := levels.ArrayShares[i] // in tokenX
+
+		var maxSharesIn *big.Int
+		if isBuy {
+			maxSharesIn = new(big.Int).Div(scaledAmountIn, price) // in tokenX
+		} else {
+			maxSharesIn = scaledAmountIn // in tokenX
+		}
+
+		executedShares := new(big.Int).Set(bignumber.Min(shares, maxSharesIn)) // in tokenX
+		executedValue := new(big.Int).Mul(executedShares, price)               // in tokenY
+
+		if isBuy {
+			scaledAmountIn.Sub(scaledAmountIn, executedValue)                    // in tokenY
+			executedScaledAmountOut.Add(executedScaledAmountOut, executedShares) // in tokenX
+			executedScaledAmountIn.Add(executedScaledAmountIn, executedValue)    // in tokenY
+		} else {
+			scaledAmountIn.Sub(scaledAmountIn, executedShares)                  // in tokenX
+			executedScaledAmountOut.Add(executedScaledAmountOut, executedValue) // in tokenY
+			executedScaledAmountIn.Add(executedScaledAmountIn, executedShares)  // in tokenX
+		}
+
+		levels.ArrayShares[i] = new(big.Int).Sub(shares, executedShares)
+
+		// check if amountIn is fully executed
+		if scaledAmountIn.Cmp(bignumber.ZeroBI) == 0 {
+			break
+		}
+	}
+
+	executedAmountIn := new(big.Int).Mul(executedScaledAmountIn, scalingFactorIn)
+	executedAmountOut := new(big.Int).Mul(executedScaledAmountOut, scalingFactorOut)
+
+	var feesTokenY *big.Int
+	var remainingAmountIn *big.Int
+	if isBuy {
+		feesTokenY = bignumber.MulWadUp(executedAmountIn, p.Info.SwapFee)
+		remainingAmountIn = new(big.Int).Sub(tokenAmountIn.Amount, new(big.Int).Add(executedAmountIn, feesTokenY))
+	} else {
+		feesTokenY = bignumber.MulWadUp(executedAmountOut, p.Info.SwapFee)
+		remainingAmountIn = new(big.Int).Sub(tokenAmountIn.Amount, executedAmountIn)
+
+		executedAmountOut.Sub(executedAmountOut, feesTokenY)
+	}
+
+	var updatedOrderBook *OrderBook
+	if isBuy {
+		updatedOrderBook = &OrderBook{
+			Bids: p.OrderBook.Bids,
+			Asks: *p.removeExecutedLevels(levels),
+		}
+	} else {
+		updatedOrderBook = &OrderBook{
+			Bids: *p.removeExecutedLevels(levels),
+			Asks: p.OrderBook.Asks,
+		}
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut:         &pool.TokenAmount{Token: tokenOut, Amount: executedAmountOut},
+		Fee:                    &pool.TokenAmount{Token: p.LobConfig.TokenY.Hex(), Amount: feesTokenY},
+		RemainingTokenAmountIn: &pool.TokenAmount{Token: tokenAmountIn.Token, Amount: remainingAmountIn},
+		Gas:                    DefaultGas,
+		SwapInfo: SwapInfo{
+			UpdatedOrderBook: updatedOrderBook,
+		},
+	}, nil
+}
+
+func (p *PoolSimulator) removeExecutedLevels(levels *OrderBookLevels) *OrderBookLevels {
+	for len(levels.ArrayShares) > 0 {
+		if levels.ArrayShares[0].Cmp(bignumber.ZeroBI) == 0 {
+			levels.ArrayShares = levels.ArrayShares[1:]
+			levels.ArrayPrices = levels.ArrayPrices[1:]
+		} else {
+			break
+		}
+	}
+	return levels
+}
+
+func (p *PoolSimulator) CloneState() pool.IPoolSimulator {
+	clonedOrderBook := OrderBook{
+		Bids: OrderBookLevels{
+			ArrayPrices: slices.Clone(p.OrderBook.Bids.ArrayPrices),
+			ArrayShares: slices.Clone(p.OrderBook.Bids.ArrayShares),
+		},
+		Asks: OrderBookLevels{
+			ArrayPrices: slices.Clone(p.OrderBook.Asks.ArrayPrices),
+			ArrayShares: slices.Clone(p.OrderBook.Asks.ArrayShares),
+		},
+	}
+	clonedLobConfig := *p.LobConfig
+
+	return &PoolSimulator{
+		Pool:      p.Pool,
+		OrderBook: &clonedOrderBook,
+		LobConfig: &clonedLobConfig,
+	}
+}
+
+func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	si, ok := params.SwapInfo.(SwapInfo)
+	if !ok {
+		logger.Warn("failed to UpdateBalance for OnchainClob pool, wrong swapInfo type")
+		return
+	}
+	p.OrderBook = si.UpdatedOrderBook
+}
+
+func (p *PoolSimulator) GetMetaInfo(tokenIn string, _ string) any {
+	return nil
+}

--- a/pkg/liquidity-source/xpress/pool_simulator_test.go
+++ b/pkg/liquidity-source/xpress/pool_simulator_test.go
@@ -1,0 +1,457 @@
+package xpress
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var susdcPool = `{
+    "address": "0xc7723fe3df538f76a063eb5e62867960d236accf",
+    "swapFee": 0.0003,
+    "exchange": "xpress",
+    "type": "onchainclob",
+    "reserves": [
+      "0",
+      "0"
+    ],
+    "tokens": [
+      {
+        "address": "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+        "symbol": "S",
+        "decimals": 18,
+        "swappable": true
+      },
+      {
+        "address": "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+        "symbol": "USDC",
+        "decimals": 6,
+        "swappable": true
+      }
+    ],
+    "extra": "{\"bids\":{\"array_prices\":[3117,3116,3113,3000,2925,2120,1950,1822,1745,890],\"array_shares\":[933470,2800410,14935837,121630,81729,4000720,2468061,269134,1037263,1048295]},\"asks\":{\"array_prices\":[3119,3120,3123,3200,3375,3450,4000,4400,4464,4895,5689,6818,7000,13300,19900,30000,100000000],\"array_shares\":[933470,8401546,9334701,45000,10000,15000,172000,2500,212,1202718,1845777,94259,100,11779,200,100,300]}}",
+    "staticExtra": "{\"_scaling_factor_token_x\":10000000000000000,\"_scaling_factor_token_y\":1,\"_token_x\":\"0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38\",\"_token_y\":\"0x29219dd400f2bf60e5a23d13be72b486d4038894\",\"_supports_native_eth\":true,\"_is_token_x_weth\":true,\"_ask_trie\":\"0xe297b863db3837cf96a5232286f095c45924bad6\",\"_bid_trie\":\"0xefc3ab06db0bbc03e1e381be4a86715d29d100f1\",\"_admin_commission_rate\":670000000000000000,\"_total_aggressive_commission_rate\":300000000000000,\"_total_passive_commission_rate\":0,\"_passive_order_payout_rate\":0,\"_should_invoke_on_trade\":false}",
+    "blockNumber": 45624444
+  }`
+
+var susdcPoolEmpty = `{
+    "address": "0xc7723fe3df538f76a063eb5e62867960d236accf",
+    "swapFee": 0.0003,
+    "exchange": "xpress",
+    "type": "onchainclob",
+    "reserves": [
+      "0",
+      "0"
+    ],
+    "tokens": [
+      {
+        "address": "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+        "symbol": "S",
+        "decimals": 18,
+        "swappable": true
+      },
+      {
+        "address": "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+        "symbol": "USDC",
+        "decimals": 6,
+        "swappable": true
+      }
+    ],
+    "extra": "{}",
+    "staticExtra": "{\"_scaling_factor_token_x\":10000000000000000,\"_scaling_factor_token_y\":1,\"_token_x\":\"0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38\",\"_token_y\":\"0x29219dd400f2bf60e5a23d13be72b486d4038894\",\"_supports_native_eth\":true,\"_is_token_x_weth\":true,\"_ask_trie\":\"0xe297b863db3837cf96a5232286f095c45924bad6\",\"_bid_trie\":\"0xefc3ab06db0bbc03e1e381be4a86715d29d100f1\",\"_admin_commission_rate\":670000000000000000,\"_total_aggressive_commission_rate\":300000000000000,\"_total_passive_commission_rate\":0,\"_passive_order_payout_rate\":0,\"_should_invoke_on_trade\":false}",
+    "blockNumber": 45624444
+  }`
+
+func TestPoolSimulator_CalcAmountOut_X_To_Y(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("1000000000000000000"), // 1 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "311606", result.TokenAmountOut.Amount.String())
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.TokenAmountOut.Token)
+	require.Equal(t, "94", result.Fee.Amount.String()) // 0.0003%
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.Fee.Token)
+	require.Equal(t, common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(), result.RemainingTokenAmountIn.Token)
+	require.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "3117", swapInfo.UpdatedOrderBook.Bids.ArrayPrices[0].String())
+	require.Equal(t, "933370", swapInfo.UpdatedOrderBook.Bids.ArrayShares[0].String()) // 933470 - 100 = 933370
+	require.Equal(t, "3119", swapInfo.UpdatedOrderBook.Asks.ArrayPrices[0].String())
+	require.Equal(t, "933470", swapInfo.UpdatedOrderBook.Asks.ArrayShares[0].String())
+}
+
+func TestPoolSimulator_CalcAmountOut_X_To_Y_FillBid(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("9334700000000000000000"), // 9334.70 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "2800410", swapInfo.UpdatedOrderBook.Bids.ArrayShares[0].String())
+	require.Equal(t, "3116", swapInfo.UpdatedOrderBook.Bids.ArrayPrices[0].String())
+}
+
+func TestPoolSimulator_CalcAmountOut_X_To_Y_FillAll(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("276965490000000000000000"), // 27696.549 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayPrices))
+}
+
+func TestPoolSimulator_CalcAmountOut_X_To_Y_FillAllWithRemainder(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("276965500000000000000000"), // 27696.550 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "10000000000000000", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayPrices))
+}
+
+func TestPoolSimulator_CalcAmountOut_X_To_Y_WithDust(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("1000000000000000123"), // 1 S + dust
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "311606", result.TokenAmountOut.Amount.String())
+	require.Equal(t, "94", result.Fee.Amount.String()) // 0.0003%
+	require.Equal(t, "123", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "3117", swapInfo.UpdatedOrderBook.Bids.ArrayPrices[0].String())
+	require.Equal(t, "933370", swapInfo.UpdatedOrderBook.Bids.ArrayShares[0].String()) // 933470 - 100 = 933370
+}
+
+func TestPoolSimulator_CalcAmountOut_X_To_Y_EmptyPool(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPoolEmpty), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("1000000000000000000"), // 1 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "0", result.TokenAmountOut.Amount.String())
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.TokenAmountOut.Token)
+	require.Equal(t, "0", result.Fee.Amount.String())
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.Fee.Token)
+	require.Equal(t, common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(), result.RemainingTokenAmountIn.Token)
+	require.Equal(t, "1000000000000000000", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayPrices))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayPrices))
+}
+
+func TestPoolSimulator_CalcAmountOut_Y_To_X(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+			Amount: bignumber.NewBig10("998380"), // 0.998080 USDC + 0.0003 USDC (fee)
+		},
+		TokenOut: common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "3200000000000000000", result.TokenAmountOut.Amount.String()) // 3.2 S
+	require.Equal(t, common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(), result.TokenAmountOut.Token)
+	require.Equal(t, "300", result.Fee.Amount.String()) // 0.0003%
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.Fee.Token)
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.RemainingTokenAmountIn.Token)
+	require.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "933150", swapInfo.UpdatedOrderBook.Asks.ArrayShares[0].String()) // 933470 - 320 = 933150
+	require.Equal(t, "3119", swapInfo.UpdatedOrderBook.Asks.ArrayPrices[0].String())
+	require.Equal(t, "3117", swapInfo.UpdatedOrderBook.Bids.ArrayPrices[0].String())
+	require.Equal(t, "933470", swapInfo.UpdatedOrderBook.Bids.ArrayShares[0].String())
+}
+
+func TestPoolSimulator_CalcAmountOut_Y_To_X_FillAsk(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+			Amount: bignumber.NewBig10("2912366378"), // 2911.492930 USDC + 0.873448 USDC (fee)
+		},
+		TokenOut: common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "9334700000000000000000", result.TokenAmountOut.Amount.String()) // 9334.70 S
+	require.Equal(t, "873448", result.Fee.Amount.String())                            // 0.0003%
+	require.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "8401546", swapInfo.UpdatedOrderBook.Asks.ArrayShares[0].String())
+	require.Equal(t, "3120", swapInfo.UpdatedOrderBook.Asks.ArrayPrices[0].String())
+}
+
+func TestPoolSimulator_CalcAmountOut_Y_To_X_FillAll(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+			Amount: bignumber.NewBig10("106432882855"), // 106400.962566 USDC + 31.920289 USDC (fee)
+		},
+		TokenOut: common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "220696620000000000000000", result.TokenAmountOut.Amount.String()) // 220696.62 S
+	require.Equal(t, "31920289", result.Fee.Amount.String())                            // 0.0003%
+	require.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayPrices))
+}
+
+func TestPoolSimulator_CalcAmountOut_Y_To_X_FillAllWithRemainder(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+			Amount: bignumber.NewBig10("106432882856"), // 106400.962566 USDC + 31.920289 USDC (fee) + 0.000001 USDC
+		},
+		TokenOut: common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "220696620000000000000000", result.TokenAmountOut.Amount.String()) // 220696.62 S
+	require.Equal(t, "31920289", result.Fee.Amount.String())                            // 0.0003%
+	require.Equal(t, "1", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayPrices))
+}
+
+func TestPoolSimulator_CalcAmountOut_Y_To_X_WithDust(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+			Amount: bignumber.NewBig10("998381"), // 0.998080 USDC + 0.0003 USDC (fee) + 0.000001 USDC
+		},
+		TokenOut: common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "3200000000000000000", result.TokenAmountOut.Amount.String()) // 3.2 S
+	require.Equal(t, "300", result.Fee.Amount.String())                            // 0.0003%
+	require.Equal(t, "1", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "933150", swapInfo.UpdatedOrderBook.Asks.ArrayShares[0].String()) // 933470 - 320 = 933150
+	require.Equal(t, "3119", swapInfo.UpdatedOrderBook.Asks.ArrayPrices[0].String())
+}
+
+func TestPoolSimulator_CalcAmountOut_Y_To_X_EmptyPool(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPoolEmpty), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+	require.NoError(t, err)
+
+	result, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+			Amount: bignumber.NewBig10("998380"),
+		},
+		TokenOut: common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "0", result.TokenAmountOut.Amount.String())
+	require.Equal(t, common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(), result.TokenAmountOut.Token)
+	require.Equal(t, "0", result.Fee.Amount.String())
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.Fee.Token)
+	require.Equal(t, common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(), result.RemainingTokenAmountIn.Token)
+	require.Equal(t, "998380", result.RemainingTokenAmountIn.Amount.String())
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Bids.ArrayPrices))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayShares))
+	require.Equal(t, 0, len(swapInfo.UpdatedOrderBook.Asks.ArrayPrices))
+}
+
+func TestPoolSimulator_UpdateBalance(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	json.Unmarshal([]byte(susdcPool), poolEntity)
+	poolSim, _ := NewPoolSimulator(*poolEntity, valueobject.ChainID(146))
+
+	result, _ := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("1000000000000000000"), // 1 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+
+	poolSim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("1000000000000000000"), // 1 S
+		},
+		TokenAmountOut: *result.TokenAmountOut,
+		Fee:            *result.Fee,
+		SwapInfo:       result.SwapInfo,
+	})
+
+	result, _ = poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  common.HexToAddress("0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38").Hex(),
+			Amount: bignumber.NewBig10("9333700000000000000000"), // 9333.70 S
+		},
+		TokenOut: common.HexToAddress("0x29219dd400f2bf60e5a23d13be72b486d4038894").Hex(),
+	})
+
+	swapInfo := result.SwapInfo.(SwapInfo)
+	require.Equal(t, "2800410", swapInfo.UpdatedOrderBook.Bids.ArrayShares[0].String())
+	require.Equal(t, "3116", swapInfo.UpdatedOrderBook.Bids.ArrayPrices[0].String())
+}

--- a/pkg/liquidity-source/xpress/pool_tracker.go
+++ b/pkg/liquidity-source/xpress/pool_tracker.go
@@ -1,0 +1,137 @@
+package xpress
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sourcegraph/conc/pool"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poolpkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+	"github.com/KyberNetwork/logger"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+const (
+	maxPriceLevels = 50
+)
+
+var _ = pooltrack.RegisterFactoryCE(DexType, NewPoolTracker)
+
+func NewPoolTracker(config *Config, ethrpcClient *ethrpc.Client) (*PoolTracker, error) {
+	return &PoolTracker{
+		config:       config,
+		ethrpcClient: ethrpcClient,
+	}, nil
+}
+
+func (t *PoolTracker) FetchRPCData(ctx context.Context, p *entity.Pool, blockNumber uint64) (*OrderBook, error) {
+	l := logger.WithFields(logger.Fields{
+		"poolAddress": p.Address,
+		"dexID":       t.config.DexId,
+	})
+	l.Info("Start fetching RPC data of onchainclob pool")
+
+	result := &OrderBook{
+		Bids: OrderBookLevels{
+			ArrayPrices: make([]*big.Int, 0, maxPriceLevels),
+			ArrayShares: make([]*big.Int, 0, maxPriceLevels),
+		},
+		Asks: OrderBookLevels{
+			ArrayPrices: make([]*big.Int, 0, maxPriceLevels),
+			ArrayShares: make([]*big.Int, 0, maxPriceLevels),
+		},
+	}
+
+	rpcRequests := t.ethrpcClient.NewRequest().SetContext(ctx)
+	if blockNumber > 0 {
+		rpcRequests.SetBlockNumber(big.NewInt(int64(blockNumber)))
+	}
+
+	rpcRequests.AddCall(&ethrpc.Call{
+		ABI:    onchainClobHelperABI,
+		Target: t.config.HelperAddress,
+		Method: "assembleOrderbookFromOrders",
+		Params: []any{common.HexToAddress(p.Address), false, big.NewInt(int64(maxPriceLevels))},
+	}, []any{&result.Bids})
+
+	rpcRequests.AddCall(&ethrpc.Call{
+		ABI:    onchainClobHelperABI,
+		Target: t.config.HelperAddress,
+		Method: "assembleOrderbookFromOrders",
+		Params: []any{common.HexToAddress(p.Address), true, big.NewInt(int64(maxPriceLevels))},
+	}, []any{&result.Asks})
+
+	_, err := rpcRequests.Aggregate()
+	if err != nil {
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to aggregate RPC requests")
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	params poolpkg.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	l := logger.WithFields(logger.Fields{
+		"poolAddress": p.Address,
+		"dexID":       t.config.DexId,
+	})
+	l.Info("Start getting new state of onchainclob pool")
+
+	blockNumber, err := t.ethrpcClient.GetBlockNumber(ctx)
+	if err != nil {
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to get block number")
+		return entity.Pool{}, err
+	}
+
+	var (
+		orderBook *OrderBook
+	)
+
+	g := pool.New().WithContext(ctx)
+	g.Go(func(context.Context) error {
+		var err error
+		orderBook, err = t.FetchRPCData(ctx, &p, 0)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch pool state")
+		return entity.Pool{}, err
+	}
+
+	extraBytes, err := json.Marshal(orderBook)
+	if err != nil {
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to marshal extra data")
+		return entity.Pool{}, err
+	}
+
+	p.Extra = string(extraBytes)
+	p.BlockNumber = blockNumber
+
+	l.Infof("Finish updating state of pool")
+	return p, nil
+}

--- a/pkg/liquidity-source/xpress/pool_tracker_test.go
+++ b/pkg/liquidity-source/xpress/pool_tracker_test.go
@@ -1,0 +1,40 @@
+package xpress
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolTracker_GetNewPoolState(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip()
+	}
+
+	rpcURL := "https://rpc.soniclabs.com"
+	multicallAddress := common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11")
+	poolAddress := "0xc7723fe3df538f76a063eb5e62867960d236accf"
+	helperAddress := "0x38e577290CAf18d07b5719cc9da1E91Bd753f8c0"
+	chainId := valueobject.ChainID(146)
+
+	pt := &PoolTracker{
+		config: &Config{
+			DexId:         DexType,
+			HelperAddress: helperAddress,
+			ChainId:       chainId,
+		},
+		ethrpcClient: ethrpc.New(rpcURL).SetMulticallContract(multicallAddress),
+	}
+	_, err := pt.GetNewPoolState(context.Background(),
+		entity.Pool{Address: poolAddress},
+		pool.GetNewPoolStateParams{})
+	require.NoError(t, err)
+}

--- a/pkg/liquidity-source/xpress/pools_list_updater.go
+++ b/pkg/liquidity-source/xpress/pools_list_updater.go
@@ -1,0 +1,155 @@
+package xpress
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-resty/resty/v2"
+	"github.com/samber/lo"
+)
+
+type PoolListUpdater struct {
+	config       *Config
+	httpClient   *resty.Client
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolListUpdater)
+
+func NewPoolListUpdater(
+	cfg *Config,
+	ethrpcClient *ethrpc.Client,
+) *PoolListUpdater {
+	httpClient := resty.New().
+		SetBaseURL(cfg.HTTPConfig.BaseURL).
+		SetTimeout(cfg.HTTPConfig.Timeout.Duration).
+		SetRetryCount(cfg.HTTPConfig.RetryCount)
+
+	return &PoolListUpdater{
+		config:       cfg,
+		httpClient:   httpClient,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (u *PoolListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	metadata := Metadata{
+		Pools: []common.Address{},
+	}
+
+	if len(metadataBytes) != 0 {
+		err := json.Unmarshal(metadataBytes, &metadata)
+		if err != nil {
+			return nil, metadataBytes, err
+		}
+	}
+
+	markets, err := u.getPoolsList(ctx)
+	if err != nil {
+		logger.WithFields(logger.Fields{
+			"error": err,
+		}).Errorf("failed to get pools list")
+		return nil, nil, err
+	}
+
+	numMarkets := len(markets)
+	logger.Infof("got %v markets", numMarkets)
+
+	pools := make([]entity.Pool, 0, len(markets))
+
+	for _, market := range markets {
+		// skip pool if already processed
+		if lo.Contains(metadata.Pools, common.HexToAddress(market.OrderbookAddress)) {
+			continue
+		}
+
+		staticExtra, err := u.getLobConfig(ctx, &market)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// TODO: compare scaling factors from staticExtra with market info
+
+		staticExtraBytes, _ := json.Marshal(staticExtra)
+
+		var newPool = entity.Pool{
+			Address:  market.OrderbookAddress,
+			SwapFee:  market.AggressiveFee,
+			Exchange: u.config.DexId,
+			Type:     DexType,
+			//Timestamp: time.Now().Unix(),
+			Tokens: []*entity.PoolToken{
+				{
+					Address:   market.BaseToken.ContractAddress,
+					Symbol:    market.BaseToken.Symbol,
+					Decimals:  market.BaseToken.Decimals,
+					Swappable: true,
+				},
+				{
+					Address:   market.QuoteToken.ContractAddress,
+					Symbol:    market.QuoteToken.Symbol,
+					Decimals:  market.QuoteToken.Decimals,
+					Swappable: true,
+				},
+			},
+			Reserves:    entity.PoolReserves{"0", "0"},
+			Extra:       "{}",
+			StaticExtra: string(staticExtraBytes),
+		}
+
+		pools = append(pools, newPool)
+
+		metadata.Pools = append(metadata.Pools, common.HexToAddress(market.OrderbookAddress))
+	}
+
+	metadataBytes, err = json.Marshal(metadata)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	return pools, metadataBytes, nil
+}
+
+func (u *PoolListUpdater) getPoolsList(ctx context.Context) ([]MarketInfo, error) {
+	var result []MarketInfo
+
+	resp, err := u.httpClient.NewRequest().
+		SetContext(ctx).
+		SetResult(&result).
+		Get("/markets")
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.IsSuccess() {
+		return nil, errors.New("failed to get pools list")
+	}
+
+	return result, nil
+}
+
+func (u *PoolListUpdater) getLobConfig(ctx context.Context, market *MarketInfo) (*LobConfig, error) {
+	lobConfig := LobConfig{}
+	rpcRequests := u.ethrpcClient.NewRequest().SetContext(ctx)
+
+	rpcRequests.AddCall(&ethrpc.Call{
+		ABI:    onchainClobABI,
+		Target: market.OrderbookAddress,
+		Method: "getConfig",
+		Params: nil,
+	}, []any{&lobConfig})
+
+	_, err := rpcRequests.Call()
+	if err != nil {
+		return nil, err
+	}
+
+	return &lobConfig, nil
+}

--- a/pkg/liquidity-source/xpress/pools_list_updater_test.go
+++ b/pkg/liquidity-source/xpress/pools_list_updater_test.go
@@ -1,0 +1,53 @@
+package xpress
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolsListUpdater_GetNewPools(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	rpcURL := "https://rpc.soniclabs.com"
+	multicallAddress := common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11")
+	chainId := valueobject.ChainID(146)
+	xpressApiURL := "https://api.xpressprotocol.com"
+	helperAddress := "0x38e577290CAF18D07B5719CC9DA1E91BD753F8C0"
+
+	plUpdater := NewPoolListUpdater(&Config{
+		DexId: DexType,
+		HTTPConfig: HTTPConfig{
+			BaseURL: xpressApiURL,
+		},
+		HelperAddress: helperAddress,
+		ChainId:       chainId,
+	}, ethrpc.New(rpcURL).
+		SetMulticallContract(multicallAddress))
+
+	pools, poolsMetadataBytes, err := plUpdater.GetNewPools(context.Background(), nil)
+	require.NoError(t, err)
+	require.Greater(t, len(pools), 0)
+
+	for _, p := range pools {
+		tracker, err := NewPoolTracker(plUpdater.config, plUpdater.ethrpcClient)
+		require.NoError(t, err)
+
+		pool, err := tracker.GetNewPoolState(context.Background(), p, pool.GetNewPoolStateParams{})
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+	}
+
+	newPools, _, err := plUpdater.GetNewPools(context.Background(), poolsMetadataBytes)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(newPools))
+}

--- a/pkg/liquidity-source/xpress/type.go
+++ b/pkg/liquidity-source/xpress/type.go
@@ -1,0 +1,57 @@
+package xpress
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type OrderBookLevels struct {
+	ArrayPrices []*big.Int `json:"array_prices"`
+	ArrayShares []*big.Int `json:"array_shares"`
+}
+
+type OrderBook struct {
+	Bids OrderBookLevels `json:"bids"`
+	Asks OrderBookLevels `json:"asks"`
+}
+
+type LobConfig struct {
+	ScalingFactorTokenX           *big.Int       `json:"_scaling_factor_token_x"`
+	ScalingFactorTokenY           *big.Int       `json:"_scaling_factor_token_y"`
+	TokenX                        common.Address `json:"_token_x"`
+	TokenY                        common.Address `json:"_token_y"`
+	SupportsNativeEth             bool           `json:"_supports_native_eth"`
+	IsTokenXWeth                  bool           `json:"_is_token_x_weth"`
+	AskTrie                       common.Address `json:"_ask_trie"`
+	BidTrie                       common.Address `json:"_bid_trie"`
+	AdminCommissionRate           uint64         `json:"_admin_commission_rate"`
+	TotalAggressiveCommissionRate uint64         `json:"_total_aggressive_commission_rate"`
+	TotalPassiveCommissionRate    uint64         `json:"_total_passive_commission_rate"`
+	PassiveOrderPayoutRate        uint64         `json:"_passive_order_payout_rate"`
+	ShouldInvokeOnTrade           bool           `json:"_should_invoke_on_trade"`
+}
+
+type Metadata struct {
+	Pools []common.Address `json:"pools"`
+}
+
+type TokenInfo struct {
+	ContractAddress string `json:"contractAddress"`
+	Decimals        uint8  `json:"decimals"`
+	Symbol          string `json:"symbol"`
+	IsNative        bool   `json:"isNative"`
+}
+
+type MarketInfo struct {
+	OrderbookAddress     string    `json:"orderbookAddress"`
+	BaseToken            TokenInfo `json:"baseToken"`
+	QuoteToken           TokenInfo `json:"quoteToken"`
+	TokenXScallingFactor uint8     `json:"tokenXScallingFactor"`
+	TokenYScallingFactor uint8     `json:"tokenYScallingFactor"`
+	AggressiveFee        float64   `json:"aggressiveFee"`
+}
+
+type SwapInfo struct {
+	UpdatedOrderBook *OrderBook `json:"orderBook"`
+}

--- a/pkg/util/bignumber/bignumber.go
+++ b/pkg/util/bignumber/bignumber.go
@@ -108,3 +108,27 @@ func Min(a, b *big.Int) *big.Int {
 
 	return b
 }
+
+func MulDivUp(x, y, denominator *big.Int) *big.Int {
+	xy := new(big.Int).Mul(x, y)
+	quotient := new(big.Int).Div(xy, denominator)
+	remainder := new(big.Int).Mod(xy, denominator)
+	if remainder.Cmp(ZeroBI) != 0 {
+		quotient.Add(quotient, One)
+	}
+	return quotient
+}
+
+func MulDivDown(x, y, denominator *big.Int) *big.Int {
+	xy := new(big.Int).Mul(x, y)
+	quotient := new(big.Int).Div(xy, denominator)
+	return quotient
+}
+
+func MulWadUp(x, y *big.Int) *big.Int {
+	return MulDivUp(x, y, BONE)
+}
+
+func MulWadDown(x, y *big.Int) *big.Int {
+	return MulDivDown(x, y, BONE)
+}


### PR DESCRIPTION
Added support for Xpress Protocol (on-chain orderbook dex on Sonic):

- [x] pool_list_updater.go
- [x] pool_simulator.go
- [x] pool_tracker.go
- [x] pool_list_updater_test.go
- [x] pool_simulator_test.go
- [x] pool_tracker_test.go

## Notes

In the current implementation, pools are requested from the Xpress Protocol API, but in the near future it is possible to change/add contracts to obtain a list of pools from the blockchain.

The state of the pools is requested from the helper contract, but it is also technically possible to switch to events.