### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/pkg/util/israce/norace.go
+++ b/pkg/util/israce/norace.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // Package israce reports if the Go race detector is enabled.
 package israce

--- a/pkg/util/israce/race.go
+++ b/pkg/util/israce/race.go
@@ -1,5 +1,4 @@
 //go:build race
-// +build race
 
 // Package israce reports if the Go race detector is enabled.
 package israce


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->


From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
