### PR TITLE
fix: erc4626 and balancer-v3 wrong calc amount in

### DIFF
--- a/pkg/liquidity-source/balancer/v3/eclp/pool_simulator_test.go
+++ b/pkg/liquidity-source/balancer/v3/eclp/pool_simulator_test.go
@@ -155,7 +155,7 @@ func TestPoolSimulator_CalcAmountIn(t *testing.T) {
 				Amount: big.NewInt(997094),
 			},
 			tokenIn:          "0x6440f144b7e50d6a8439336510312d2f54beb01d",
-			expectedAmountIn: "999996963127157068",
+			expectedAmountIn: "999998110061304284",
 			expectedError:    nil,
 		},
 	}

--- a/pkg/liquidity-source/balancer/v3/weighted/pool_simulator_test.go
+++ b/pkg/liquidity-source/balancer/v3/weighted/pool_simulator_test.go
@@ -209,7 +209,7 @@ func TestCalcAmountIn(t *testing.T) {
 		}
 		tokenIn := "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 
-		expectedAmountIn := "76924349808837"
+		expectedAmountIn := "76924349808954"
 		expectedSwapFee := "600782751970"
 
 		result, err := testutil.MustConcurrentSafe(t, func() (*pool.CalcAmountInResult, error) {

--- a/pkg/liquidity-source/erc4626/pool_simulator.go
+++ b/pkg/liquidity-source/erc4626/pool_simulator.go
@@ -64,7 +64,7 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		if s.MaxDeposit != nil && amountIn.Gt(s.MaxDeposit) {
 			return nil, ErrERC4626DepositMoreThanMax
 		}
-		amountOut, err = GetClosestRate(s.DepositRates, amountIn)
+		amountOut, err = GetClosestRate(s.DepositRates, amountIn, false)
 		if err != nil {
 			return nil, ErrInvalidDepositRate
 		}
@@ -72,7 +72,7 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		if s.MaxRedeem != nil && amountIn.Gt(s.MaxRedeem) {
 			return nil, ErrERC4626RedeemMoreThanMax
 		}
-		amountOut, err = GetClosestRate(s.RedeemRates, amountIn)
+		amountOut, err = GetClosestRate(s.RedeemRates, amountIn, false)
 		if err != nil {
 			return nil, ErrInvalidRedeemRate
 		}
@@ -104,14 +104,14 @@ func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.Calc
 
 	var amountIn *uint256.Int
 	if isDeposit {
-		amountIn, err = GetClosestRate(s.DepositRates, amountOut)
+		amountIn, err = GetClosestRate(s.DepositRates, amountOut, true)
 		if err != nil {
 			return nil, ErrInvalidDepositRate
 		} else if s.MaxDeposit != nil && amountIn.Gt(s.MaxDeposit) {
 			return nil, ErrERC4626DepositMoreThanMax
 		}
 	} else {
-		amountIn, err = GetClosestRate(s.RedeemRates, amountOut)
+		amountIn, err = GetClosestRate(s.RedeemRates, amountOut, true)
 		if err != nil {
 			return nil, ErrInvalidRedeemRate
 		} else if s.MaxRedeem != nil && amountIn.Gt(s.MaxRedeem) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->
the `GetClosestRate` only support for exactIn, but it's used for `CalcAmountIn` too. So I updated it for support both `CalcAmountOut` and `CalcAmountIn`.

Because balancer-v3 use this function too, so I updated it too.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
