### PR TITLE
ft: add buffer for lgl-clob's price limit

### DIFF
--- a/pkg/liquidity-source/lgl-clob/constant.go
+++ b/pkg/liquidity-source/lgl-clob/constant.go
@@ -3,6 +3,10 @@ package lglclob
 import (
 	"errors"
 	"math/big"
+
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 const (
@@ -14,7 +18,8 @@ const (
 )
 
 var (
-	bMaxPriceLevels = big.NewInt(maxPriceLevels)
+	bMaxPriceLevels       = big.NewInt(maxPriceLevels)
+	uPriceLimitMultiplier = new(uint256.Int).AddUint64(big256.UBasisPoint, 12)
 
 	ErrInvalidToken         = errors.New("invalid token")
 	ErrInvalidAmount        = errors.New("invalid amount")

--- a/pkg/liquidity-source/lgl-clob/pool_simulator_test.go
+++ b/pkg/liquidity-source/lgl-clob/pool_simulator_test.go
@@ -43,6 +43,7 @@ func TestPoolSimulator_CalcAmountOut_X_To_Y(t *testing.T) {
 	assert.Equal(t, "0x29219dd400f2bf60e5a23d13be72b486d4038894", result.Fee.Token)
 	assert.Equal(t, "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38", result.RemainingTokenAmountIn.Token)
 	assert.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.LtUint64(890))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -77,6 +78,7 @@ func TestPoolSimulator_CalcAmountOut_X_To_Y_FillBid(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.LtUint64(890))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -153,6 +155,7 @@ func TestPoolSimulator_CalcAmountOut_X_To_Y_WithDust(t *testing.T) {
 	assert.Equal(t, "311606", result.TokenAmountOut.Amount.String())
 	assert.Equal(t, "94", result.Fee.Amount.String()) // 0.0003%
 	assert.Equal(t, "123", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.LtUint64(890))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -211,6 +214,7 @@ func TestPoolSimulator_CalcAmountOut_Y_To_X(t *testing.T) {
 	assert.Equal(t, "0x29219dd400f2bf60e5a23d13be72b486d4038894", result.Fee.Token)
 	assert.Equal(t, "0x29219dd400f2bf60e5a23d13be72b486d4038894", result.RemainingTokenAmountIn.Token)
 	assert.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.GtUint64(100000000))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -247,6 +251,7 @@ func TestPoolSimulator_CalcAmountOut_Y_To_X_FillAsk(t *testing.T) {
 	assert.Equal(t, "9334700000000000000000", result.TokenAmountOut.Amount.String()) // 9334.70 S
 	assert.Equal(t, "873448", result.Fee.Amount.String())                            // 0.0003%
 	assert.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.GtUint64(100000000))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -281,6 +286,7 @@ func TestPoolSimulator_CalcAmountOut_Y_To_X_FillAll(t *testing.T) {
 	assert.Equal(t, "220696620000000000000000", result.TokenAmountOut.Amount.String()) // 220696.62 S
 	assert.Equal(t, "31920289", result.Fee.Amount.String())                            // 0.0003%
 	assert.Equal(t, "0", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.GtUint64(100000000))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -315,6 +321,7 @@ func TestPoolSimulator_CalcAmountOut_Y_To_X_FillAllWithRemainder(t *testing.T) {
 	assert.Equal(t, "220696620000000000000000", result.TokenAmountOut.Amount.String()) // 220696.62 S
 	assert.Equal(t, "31920289", result.Fee.Amount.String())                            // 0.0003%
 	assert.Equal(t, "1", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.GtUint64(100000000))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,
@@ -349,6 +356,7 @@ func TestPoolSimulator_CalcAmountOut_Y_To_X_WithDust(t *testing.T) {
 	assert.Equal(t, "3200000000000000000", result.TokenAmountOut.Amount.String()) // 3.2 S
 	assert.Equal(t, "300", result.Fee.Amount.String())                            // 0.0003%
 	assert.Equal(t, "1", result.RemainingTokenAmountIn.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.GtUint64(100000000))
 
 	poolSim.UpdateBalance(pool.UpdateBalanceParams{
 		TokenAmountIn:  tokenAmtIn,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add price limit buffer calculation for buy/sell orders

- Import uint256 and big256 utility packages for calculations

- Define uPriceLimitMultiplier constant using basis points

- Add assertions in tests to verify price limit bounds

- Adjust price limit based on swap direction and execution value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CalcAmountOut"] --> B["Get base price limit"]
  B --> C{Is Buy Order?}
  C -->|Yes| D["Apply MulDivUp buffer"]
  C -->|No| E["Apply MulDivDown buffer"]
  D --> F["Return adjusted price limit"]
  E --> F
  F --> G["Test assertions verify bounds"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constant.go</strong><dd><code>Add price limit multiplier constant and imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/lgl-clob/constant.go

<ul><li>Import uint256 and big256 utility packages<br> <li> Add uPriceLimitMultiplier variable initialized with basis point offset<br> <li> Align bMaxPriceLevels variable formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1232/files#diff-fa12e349f89854efe0a064607cebf01baf2b7ac82f0419a7049ae8b72457bf94">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pool_simulator.go</strong><dd><code>Implement dynamic price limit buffer calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/lgl-clob/pool_simulator.go

<ul><li>Extract base price limit from last array price level<br> <li> Apply MulDivUp buffer for buy orders to increase price limit<br> <li> Apply MulDivDown buffer for sell orders to decrease price limit<br> <li> Update SwapInfo to use calculated priceLimit instead of raw array <br>value<br> <li> Reorder code statements for logical clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1232/files#diff-29d3df579e020467db0b7bcd1edbce5b3373c0c0a7accd9a64540f270fc43f65">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pool_simulator_test.go</strong><dd><code>Add price limit validation assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/lgl-clob/pool_simulator_test.go

<ul><li>Add price limit assertions for buy order tests (LtUint64 890)<br> <li> Add price limit assertions for sell order tests (GtUint64 100000000)<br> <li> Verify price limit bounds across all test scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1232/files#diff-fc89e357d5952303d9847f021c13c570ad935330f0126d6d21fd60178708f442">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

