### PR TITLE
fix(clear): bidirectional rate tracking and proper CloneState

### DIFF
--- a/pkg/liquidity-source/clear/pool_simulator_test.go
+++ b/pkg/liquidity-source/clear/pool_simulator_test.go
@@ -1,46 +1,236 @@
 package clear
 
 import (
-	"fmt"
-	"strings"
+	"math/big"
 	"testing"
 
 	"github.com/goccy/go-json"
-	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
-func getPoolSim(reserveIn, reserveOut string) *PoolSimulator {
-	extraStr := `{"address":"0xcac0fa2818aed2eea8b9f52ca411e6ec3e13d822","exchange":"clear","type":"clear","timestamp":1766474455,"reserves":["100000000000000000000000000","100000000000000000000000000"],"tokens":[{"address":"0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d","symbol":"USDC","decimals":6,"swappable":true},{"address":"0x69cac783c212bfae06e3c1a9a2e6ae6b17ba0614","symbol":"GHO","decimals":18,"swappable":true}],"extra":"{\"reserves\":{\"0\":{\"1\":{\"AmountIn\":null,\"AmountOut\":null}}}}","staticExtra":"{\"swapAddress\":\"0x5144e17c86d6e1b25f61a036024a65bc4775e37e\"}"}`
-	extraStr = strings.Replace(extraStr, `\"AmountIn\":null`, fmt.Sprintf(`\"AmountIn\":%v`, reserveIn), 1)
-	extraStr = strings.Replace(extraStr, `\"AmountOut\":null`, fmt.Sprintf(`\"AmountOut\":%v`, reserveOut), 1)
-	var entityPool entity.Pool
-	_ = json.Unmarshal([]byte(extraStr),
-		&entityPool)
-	return lo.Must(NewPoolSimulator(entityPool))
+// createTestPool creates a pool with bidirectional rates
+func createTestPool(rate0to1In, rate0to1Out, rate1to0In, rate1to0Out *big.Int) *PoolSimulator {
+	extra := Extra{
+		Reserves: map[int]map[int]*PreviewSwapResult{
+			0: {
+				1: {AmountIn: rate0to1In, AmountOut: rate0to1Out},
+			},
+			1: {
+				0: {AmountIn: rate1to0In, AmountOut: rate1to0Out},
+			},
+		},
+	}
+	extraBytes, _ := json.Marshal(extra)
+
+	staticExtra := StaticExtra{
+		SwapAddress: "0xswap",
+	}
+	staticExtraBytes, _ := json.Marshal(staticExtra)
+
+	entityPool := entity.Pool{
+		Address:  "0xvault",
+		Exchange: "clear",
+		Type:     DexType,
+		Reserves: entity.PoolReserves{"1000000000000000000", "1000000000000000000"},
+		Tokens: []*entity.PoolToken{
+			{Address: "0xUSDC", Decimals: 6, Swappable: true},
+			{Address: "0xGHO", Decimals: 18, Swappable: true},
+		},
+		Extra:       string(extraBytes),
+		StaticExtra: string(staticExtraBytes),
+	}
+
+	sim, _ := NewPoolSimulator(entityPool)
+	return sim
 }
 
-func TestPoolSimulator_CalcAmountOut(t *testing.T) {
-	testCases := []struct {
-		name      string
-		indexIn   int
-		indexOut  int
-		amountIn  string
-		amountOut string
-		poolSim   *PoolSimulator
+func TestPoolSimulator_CalcAmountOut_Bidirectional(t *testing.T) {
+	t.Parallel()
+
+	// Create pool with bidirectional rates:
+	// 0→1: 1 USDC (1e6) gives 1 GHO (1e18) - rate 1:1
+	// 1→0: 1 GHO (1e18) gives 0.95 USDC (0.95e6) - rate 1:0.95 (simulating depeg)
+	sim := createTestPool(
+		big.NewInt(1000000),           // 0→1: 1e6 USDC in
+		big.NewInt(1000000000000000000), // 0→1: 1e18 GHO out
+		big.NewInt(1000000000000000000), // 1→0: 1e18 GHO in
+		big.NewInt(950000),            // 1→0: 0.95e6 USDC out
+	)
+
+	tests := []struct {
+		name        string
+		tokenIn     string
+		tokenOut    string
+		amountIn    *big.Int
+		expectedOut *big.Int
 	}{
-		{name: "USDC -> GHO", indexIn: 0, indexOut: 1, amountIn: "1000", amountOut: "2000", poolSim: getPoolSim("1000000", "2000000")},
-		{name: "GHO -> USDC", indexIn: 1, indexOut: 0, amountIn: "2000", amountOut: "1000", poolSim: getPoolSim("1000000", "2000000")},
-		{name: "USDC -> GHO", indexIn: 0, indexOut: 1, amountIn: "1000", amountOut: "0", poolSim: getPoolSim("1000000", "null")},
-		{name: "GHO -> USDC", indexIn: 1, indexOut: 0, amountIn: "2000", amountOut: "0", poolSim: getPoolSim("1000000", "null")},
-		{name: "USDC -> GHO", indexIn: 0, indexOut: 1, amountIn: "1000", amountOut: "0", poolSim: getPoolSim("null", "2000000")},
-		{name: "GHO -> USDC", indexIn: 1, indexOut: 0, amountIn: "2000", amountOut: "0", poolSim: getPoolSim("null", "1000000")},
+		{
+			name:        "USDC to GHO (1:1 rate)",
+			tokenIn:     "0xUSDC",
+			tokenOut:    "0xGHO",
+			amountIn:    big.NewInt(1000000), // 1 USDC
+			expectedOut: big.NewInt(1000000000000000000), // 1 GHO
+		},
+		{
+			name:        "GHO to USDC (depeg rate 1:0.95)",
+			tokenIn:     "0xGHO",
+			tokenOut:    "0xUSDC",
+			amountIn:    big.NewInt(1000000000000000000), // 1 GHO
+			expectedOut: big.NewInt(950000), // 0.95 USDC
+		},
+		{
+			name:        "USDC to GHO - larger amount",
+			tokenIn:     "0xUSDC",
+			tokenOut:    "0xGHO",
+			amountIn:    big.NewInt(100000000), // 100 USDC
+			expectedOut: new(big.Int).Mul(big.NewInt(100), big.NewInt(1000000000000000000)), // 100 GHO
+		},
 	}
-	for _, tc := range testCases {
-		testutil.TestCalcAmountOut(t, tc.poolSim, map[int]map[int]map[string]string{
-			tc.indexIn: {tc.indexOut: {tc.amountIn: tc.amountOut}},
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{
+					Token:  tc.tokenIn,
+					Amount: tc.amountIn,
+				},
+				TokenOut: tc.tokenOut,
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tc.expectedOut.String(), result.TokenAmountOut.Amount.String())
+		})
+	}
+}
+
+func TestPoolSimulator_CalcAmountOut_NoRate(t *testing.T) {
+	t.Parallel()
+
+	// Pool with no rates (Clear refuses swaps - no depeg)
+	sim := createTestPool(nil, nil, nil, nil)
+
+	result, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0xUSDC",
+			Amount: big.NewInt(1000000),
+		},
+		TokenOut: "0xGHO",
+	})
+
+	// Should return 0, not error
+	require.NoError(t, err)
+	assert.Equal(t, "0", result.TokenAmountOut.Amount.String())
+}
+
+func TestPoolSimulator_CalcAmountOut_ZeroRate(t *testing.T) {
+	t.Parallel()
+
+	// Pool with zero AmountOut (Clear returned 0)
+	sim := createTestPool(
+		big.NewInt(1000000),
+		big.NewInt(0), // Zero output
+		big.NewInt(1000000000000000000),
+		big.NewInt(0),
+	)
+
+	result, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0xUSDC",
+			Amount: big.NewInt(1000000),
+		},
+		TokenOut: "0xGHO",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "0", result.TokenAmountOut.Amount.String())
+}
+
+func TestPoolSimulator_CloneState(t *testing.T) {
+	t.Parallel()
+
+	sim := createTestPool(
+		big.NewInt(1000000),
+		big.NewInt(1000000000000000000),
+		big.NewInt(1000000000000000000),
+		big.NewInt(950000),
+	)
+
+	cloned := sim.CloneState()
+	require.NotNil(t, cloned)
+
+	clonedSim, ok := cloned.(*PoolSimulator)
+	require.True(t, ok)
+
+	// Verify it's a different instance
+	assert.NotSame(t, sim, clonedSim)
+	assert.NotSame(t, sim.RWMutex, clonedSim.RWMutex)
+
+	// Verify reserves are cloned (not shared)
+	assert.NotSame(t, sim.extra.Reserves[0][1], clonedSim.extra.Reserves[0][1])
+
+	// Verify values are equal
+	assert.Equal(t,
+		sim.extra.Reserves[0][1].AmountOut.String(),
+		clonedSim.extra.Reserves[0][1].AmountOut.String(),
+	)
+}
+
+func TestPoolSimulator_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	sim := createTestPool(
+		big.NewInt(1000000),
+		big.NewInt(1000000000000000000),
+		big.NewInt(1000000000000000000),
+		big.NewInt(950000),
+	)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0xINVALID",
+			Amount: big.NewInt(1000000),
+		},
+		TokenOut: "0xGHO",
+	})
+
+	assert.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestPoolSimulator_InvalidAmountIn(t *testing.T) {
+	t.Parallel()
+
+	sim := createTestPool(
+		big.NewInt(1000000),
+		big.NewInt(1000000000000000000),
+		big.NewInt(1000000000000000000),
+		big.NewInt(950000),
+	)
+
+	tests := []struct {
+		name     string
+		amountIn *big.Int
+	}{
+		{name: "nil amount", amountIn: nil},
+		{name: "zero amount", amountIn: big.NewInt(0)},
+		{name: "negative amount", amountIn: big.NewInt(-100)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{
+					Token:  "0xUSDC",
+					Amount: tc.amountIn,
+				},
+				TokenOut: "0xGHO",
+			})
+
+			assert.ErrorIs(t, err, ErrInvalidAmountIn)
 		})
 	}
 }

--- a/pkg/liquidity-source/clear/pool_tracker.go
+++ b/pkg/liquidity-source/clear/pool_tracker.go
@@ -47,9 +47,14 @@ func (d *PoolTracker) GetNewPoolState(
 
 	req := d.ethrpcClient.NewRequest().SetContext(ctx)
 	previewResult := make(map[int]map[int]*PreviewSwapResult)
-	for i := 0; i < len(p.Tokens)-1; i++ {
-		for j := i + 1; j < len(p.Tokens); j++ {
-			// Initialize previewResult[i] and previewResult[i][j] to avoid nil map dereference
+	// Test all pairs in BOTH directions (i→j AND j→i)
+	// Clear uses oracle pricing, so the rate is not symmetric
+	for i := 0; i < len(p.Tokens); i++ {
+		for j := 0; j < len(p.Tokens); j++ {
+			if i == j {
+				continue
+			}
+			// Initialize previewResult[i] if nil
 			if previewResult[i] == nil {
 				previewResult[i] = make(map[int]*PreviewSwapResult)
 			}


### PR DESCRIPTION
### **User description**
## Summary

Fixes issues in the Clear protocol integration:

- **Bidirectional rate tracking**: Clear uses oracle-based pricing which is not symmetric. The tracker now fetches rates for ALL directions (i→j AND j→i) instead of only i<j pairs
- **Proper CloneState**: Deep copy of nested `Reserves` map to avoid race conditions during parallel route simulations
- **No fallback pricing**: Returns 0 when no rate is available instead of assuming 1:1 (which doesn't make sense for a depeg arbitrage protocol)


___

### **PR Type**
Bug fix


___

### **Description**
- Implement bidirectional rate tracking for oracle-based pricing
  - Tracker now tests all swap directions (i→j AND j→i) instead of only i<j pairs
  - Clear protocol uses non-symmetric oracle pricing, requiring both directions

- Fix CloneState to properly deep copy nested Reserves map
  - Prevents race conditions during parallel route simulations
  - Creates independent instances of all nested structures

- Simplify estimateAmountOut to use stored directional rates
  - Removes index normalization logic that assumed symmetric pricing
  - Returns 0 when rate unavailable instead of assuming 1:1 conversion

- Expand test coverage with bidirectional rate scenarios
  - Tests depeg scenarios (1:0.95 rate asymmetry)
  - Validates CloneState independence and error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pool Tracker"] -->|"Test all directions i→j AND j→i"| B["Bidirectional Rates"]
  B -->|"Store in map[i][j]"| C["Extra.Reserves"]
  C -->|"Direct lookup tokenIn→tokenOut"| D["estimateAmountOut"]
  D -->|"Calculate output"| E["CalcAmountOut"]
  F["CloneState"] -->|"Deep copy"| C
  F -->|"Create new RWMutex"| G["Independent Clone"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Implement bidirectional rate tracking for all swap directions</code></dd></summary>
<hr>

pkg/liquidity-source/clear/pool_tracker.go

<ul><li>Changed loop structure to test all token pairs in both directions (i→j <br>AND j→i)<br> <li> Removed i<j constraint that only tested unidirectional pairs<br> <li> Added continue statement to skip same-token pairs (i==j)<br> <li> Updated comments to clarify oracle pricing is non-symmetric</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1237/files#diff-cb8a45f316e7b08cf0e17bbec5bf775c32ea61a68abca82a45fc56e0a20ceec2">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pool_simulator.go</strong><dd><code>Simplify rate lookup and implement proper deep cloning</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/clear/pool_simulator.go

<ul><li>Simplified estimateAmountOut to directly use <br>tokenInIndex→tokenOutIndex lookup without index normalization<br> <li> Removed logic that swapped indices for i>j cases, now stores both <br>directions explicitly<br> <li> Updated rate variable to directly access PreviewSwapResult from map<br> <li> Implemented proper CloneState with deep copy of Info.Reserves and <br>nested extra.Reserves map<br> <li> Added RWMutex initialization and independent cloning of all big.Int <br>values<br> <li> Added comment to UpdateBalance explaining oracle-based pricing doesn't <br>require state updates</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1237/files#diff-91a221a252ae94a9c45e88857805b102b95b2cc0ca78e28b821f79894f9b5777">+55/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pool_simulator_test.go</strong><dd><code>Rewrite tests for bidirectional rate format and edge cases</code></dd></summary>
<hr>

pkg/liquidity-source/clear/pool_simulator_test.go

<ul><li>Replaced old test helper with createTestPool that accepts <br>bidirectional rates<br> <li> Rewrote CalcAmountOut tests to use bidirectional rate format with <br>separate 0→1 and 1→0 rates<br> <li> Added test case demonstrating depeg scenario (1:0.95 rate asymmetry)<br> <li> Added new test for zero rates and missing rates returning 0<br> <li> Added CloneState test verifying deep copy independence<br> <li> Added tests for invalid token and invalid amount input validation</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1237/files#diff-0c8ab5a32b46f84a4dd4bee6f4e4f4b6737e59f7eaecd05b9a50cc9fc0e40ad4">+219/-29</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

