### PR TITLE
fix: handle reverted prefetch rate

### DIFF
--- a/pkg/liquidity-source/tessera/pool_tracker.go
+++ b/pkg/liquidity-source/tessera/pool_tracker.go
@@ -210,6 +210,10 @@ func (d *PoolTracker) GetNewPoolState(
 
 	baseToQuotePrefetches := make([]PrefetchRate, len(baseToQuoteResults))
 	for i, res := range baseToQuoteResults {
+		if res.AmountOut == nil {
+			baseToQuotePrefetches = baseToQuotePrefetches[:i]
+			break
+		}
 		var rate *uint256.Int
 		if res.AmountIn != nil && res.AmountIn.Sign() != 0 {
 			rate = uint256.MustFromBig(res.AmountOut)
@@ -222,6 +226,10 @@ func (d *PoolTracker) GetNewPoolState(
 
 	quoteToBasePrefetches := make([]PrefetchRate, len(quoteToBaseResults))
 	for i, res := range quoteToBaseResults {
+		if res.AmountOut == nil {
+			quoteToBasePrefetches = quoteToBasePrefetches[:i]
+			break
+		}
 		var rate *uint256.Int
 		if res.AmountIn != nil && res.AmountIn.Sign() != 0 {
 			rate = uint256.MustFromBig(res.AmountOut)
@@ -233,11 +241,11 @@ func (d *PoolTracker) GetNewPoolState(
 	}
 
 	var maxB2Q, maxQ2B *uint256.Int
-	if len(baseToQuoteAmounts) > 0 {
-		maxB2Q = baseToQuoteAmounts[len(baseToQuoteAmounts)-1]
+	if len(baseToQuotePrefetches) > 0 {
+		maxB2Q = baseToQuoteAmounts[len(baseToQuotePrefetches)-1]
 	}
-	if len(quoteToBaseAmounts) > 0 {
-		maxQ2B = quoteToBaseAmounts[len(quoteToBaseAmounts)-1]
+	if len(quoteToBasePrefetches) > 0 {
+		maxQ2B = quoteToBaseAmounts[len(quoteToBasePrefetches)-1]
 	}
 
 	extra := Extra{


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Handle nil AmountOut in prefetch results by truncating slices

- Fix index bounds checking to use prefetch slice lengths

- Prevent nil pointer dereference and array index errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Prefetch Results"] --> B["Check AmountOut nil"]
  B --> C["Truncate Slice at nil"]
  C --> D["Use Prefetch Slice Length"]
  D --> E["Calculate Max Rates"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Handle nil prefetch results and fix bounds checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/tessera/pool_tracker.go

<ul><li>Added nil check for <code>res.AmountOut</code> in baseToQuote loop to truncate <br>slice when nil encountered<br> <li> Added nil check for <code>res.AmountOut</code> in quoteToBase loop to truncate <br>slice when nil encountered<br> <li> Fixed max rate calculation to use <code>baseToQuotePrefetches</code> length instead <br>of <code>baseToQuoteAmounts</code><br> <li> Fixed max rate calculation to use <code>quoteToBasePrefetches</code> length instead <br>of <code>quoteToBaseAmounts</code></ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1243/files#diff-ef48d8a8fb8031a0b1143d52af4f7d6b3c9e278348a5c984dda743c1ccb1f465">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

