### PR TITLE
ft: update bal-v3 to ethCall from AddrDummy

### DIFF
--- a/pkg/liquidity-source/balancer/v3/eclp/pool_tracker.go
+++ b/pkg/liquidity-source/balancer/v3/eclp/pool_tracker.go
@@ -123,7 +123,7 @@ func (t *PoolTracker) queryRPCData(ctx context.Context, p *entity.Pool, staticEx
 		isPoolInRecoveryMode bool
 	)
 
-	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides)
+	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides).SetFrom(shared.AddrDummy)
 
 	poolAddress := p.Address
 	paramsPool := []any{common.HexToAddress(poolAddress)}

--- a/pkg/liquidity-source/balancer/v3/quant-amm/pool_tracker.go
+++ b/pkg/liquidity-source/balancer/v3/quant-amm/pool_tracker.go
@@ -142,7 +142,7 @@ func (t *PoolTracker) queryRPCData(ctx context.Context, p *entity.Pool, staticEx
 		isVaultPaused bool
 	)
 
-	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides)
+	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides).SetFrom(shared.AddrDummy)
 
 	poolAddress := p.Address
 	paramsPool := []any{common.HexToAddress(poolAddress)}

--- a/pkg/liquidity-source/balancer/v3/reclamm/pool_tracker.go
+++ b/pkg/liquidity-source/balancer/v3/reclamm/pool_tracker.go
@@ -131,7 +131,7 @@ func (t *PoolTracker) queryRPCData(ctx context.Context, p *entity.Pool, staticEx
 		isPoolInRecoveryMode bool
 	)
 
-	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides)
+	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides).SetFrom(shared.AddrDummy)
 
 	poolAddress := p.Address
 	paramsPool := []any{common.HexToAddress(poolAddress)}

--- a/pkg/liquidity-source/balancer/v3/shared/constant.go
+++ b/pkg/liquidity-source/balancer/v3/shared/constant.go
@@ -31,6 +31,8 @@ var (
 		"":         common.HexToAddress("0xbA1333333333a1BA1108E8412f11850A5C319bA9"), // default
 		"coinhane": common.HexToAddress("0xb61cb1E8EF4BB1b74bB858B8B60d82d79488F13D"),
 	}
+
+	AddrDummy = common.HexToAddress("0x1371783000000000000000000000000001371760")
 )
 
 const (

--- a/pkg/liquidity-source/balancer/v3/stable/pool_tracker.go
+++ b/pkg/liquidity-source/balancer/v3/stable/pool_tracker.go
@@ -130,7 +130,7 @@ func (t *PoolTracker) queryRPCData(ctx context.Context, p *entity.Pool, staticEx
 		isPoolInRecoveryMode bool
 	)
 
-	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides)
+	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides).SetFrom(shared.AddrDummy)
 
 	poolAddress := p.Address
 	paramsPool := []any{common.HexToAddress(poolAddress)}

--- a/pkg/liquidity-source/balancer/v3/weighted/pool_tracker.go
+++ b/pkg/liquidity-source/balancer/v3/weighted/pool_tracker.go
@@ -123,7 +123,7 @@ func (t *PoolTracker) queryRPCData(ctx context.Context, p *entity.Pool, staticEx
 		isPoolInRecoveryMode bool
 	)
 
-	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides)
+	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides).SetFrom(shared.AddrDummy)
 
 	poolAddress := p.Address
 	paramsPool := []any{common.HexToAddress(poolAddress)}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add dummy address constant for Balancer V3 RPC calls

- Update all pool trackers to use SetFrom with AddrDummy

- Standardize ethCall sender across five pool types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AddrDummy Constant"] --> B["ECLP Pool Tracker"]
  A --> C["QuantAMM Pool Tracker"]
  A --> D["RecLAMM Pool Tracker"]
  A --> E["Stable Pool Tracker"]
  A --> F["Weighted Pool Tracker"]
  B -- "SetFrom" --> G["RPC Request"]
  C -- "SetFrom" --> G
  D -- "SetFrom" --> G
  E -- "SetFrom" --> G
  F -- "SetFrom" --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constant.go</strong><dd><code>Add AddrDummy constant for RPC calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/balancer/v3/shared/constant.go

<ul><li>Define new <code>AddrDummy</code> constant with hardcoded address<br> <li> Add dummy address for use in RPC call overrides</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1247/files#diff-4655218acd49801cc45cd33c2c22192bba3ff4590967dc5d8c03383972943801">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Set dummy address for ECLP pool tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/balancer/v3/eclp/pool_tracker.go

<ul><li>Add <code>.SetFrom(shared.AddrDummy)</code> to RPC request builder<br> <li> Standardize sender address for ethCall operations</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1247/files#diff-7be25cef2bce4e1fe1e06ba3903fc918325cd07248a950ef5aa54e95c6e305f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Set dummy address for QuantAMM pool tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/balancer/v3/quant-amm/pool_tracker.go

<ul><li>Add <code>.SetFrom(shared.AddrDummy)</code> to RPC request builder<br> <li> Standardize sender address for ethCall operations</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1247/files#diff-d4590949442e606136a0f4fbb4db299c0164dd71f97f6dc4dbd52bed632931cf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Set dummy address for RecLAMM pool tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/balancer/v3/reclamm/pool_tracker.go

<ul><li>Add <code>.SetFrom(shared.AddrDummy)</code> to RPC request builder<br> <li> Standardize sender address for ethCall operations</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1247/files#diff-6efb0085be9e4ac7c794edd5442b7f54bfd2f644df894d9043ee59a6fd5a609e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Set dummy address for stable pool tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/balancer/v3/stable/pool_tracker.go

<ul><li>Add <code>.SetFrom(shared.AddrDummy)</code> to RPC request builder<br> <li> Standardize sender address for ethCall operations</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1247/files#diff-a5c8a362b0b2489fb54f3feec76aaf08adfec15c60c039e1408a7b281088452f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pool_tracker.go</strong><dd><code>Set dummy address for weighted pool tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/liquidity-source/balancer/v3/weighted/pool_tracker.go

<ul><li>Add <code>.SetFrom(shared.AddrDummy)</code> to RPC request builder<br> <li> Standardize sender address for ethCall operations</ul>


</details>


  </td>
  <td><a href="https://github.com/KyberNetwork/kyberswap-dex-lib/pull/1247/files#diff-4aaff9e2e5dcd4eed5f8682607e9a1aa7921e7b1ea32228d8e43bde91df46dc6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

