### PR TITLE
feat: integrate wasabi-prop AMM

### DIFF
--- a/pkg/liquidity-source/wasabi-prop/abis.go
+++ b/pkg/liquidity-source/wasabi-prop/abis.go
@@ -1,0 +1,30 @@
+package wasabiprop
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	factoryABI abi.ABI
+	poolABI    abi.ABI
+)
+
+func init() {
+	builder := []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{&factoryABI, factoryABIData},
+		{&poolABI, poolABIData},
+	}
+
+	for _, b := range builder {
+		parsed, err := abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+		*b.ABI = parsed
+	}
+}

--- a/pkg/liquidity-source/wasabi-prop/abis/Factory.json
+++ b/pkg/liquidity-source/wasabi-prop/abis/Factory.json
@@ -1,0 +1,16 @@
+[
+  {
+    "inputs": [],
+    "name": "getListedTokens",
+    "outputs": [{"internalType": "address[]", "name": "", "type": "address[]"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "token", "type": "address"}],
+    "name": "getPropPool",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/wasabi-prop/abis/Pool.json
+++ b/pkg/liquidity-source/wasabi-prop/abis/Pool.json
@@ -1,0 +1,36 @@
+[
+  {
+    "inputs": [
+      {"internalType": "address", "name": "tokenIn", "type": "address"},
+      {"internalType": "uint256", "name": "amountIn", "type": "uint256"}
+    ],
+    "name": "quoteExactInput",
+    "outputs": [{"internalType": "uint256", "name": "amountOut", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      {"internalType": "uint256", "name": "baseTokenReserves", "type": "uint256"},
+      {"internalType": "uint256", "name": "quoteTokenReserves", "type": "uint256"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBaseToken",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getQuoteToken",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/wasabi-prop/config.go
+++ b/pkg/liquidity-source/wasabi-prop/config.go
@@ -1,0 +1,9 @@
+package wasabiprop
+
+type Config struct {
+	DexID          string `json:"dexID"`
+	ChainID        int    `json:"chainID"`
+	FactoryAddress string `json:"factoryAddress"`
+	RouterAddress  string `json:"routerAddress"`
+	Buffer         int64  `json:"buffer"`
+}

--- a/pkg/liquidity-source/wasabi-prop/constant.go
+++ b/pkg/liquidity-source/wasabi-prop/constant.go
@@ -1,0 +1,14 @@
+package wasabiprop
+
+import "errors"
+
+const (
+	DexType    = "wasabi-prop"
+	defaultGas = 200_000
+	sampleSize = 15
+)
+
+var (
+	ErrInvalidToken          = errors.New("invalid token")
+	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
+)

--- a/pkg/liquidity-source/wasabi-prop/debug_test.go
+++ b/pkg/liquidity-source/wasabi-prop/debug_test.go
@@ -1,0 +1,163 @@
+package wasabiprop
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+func TestWasabiPropDebug(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip()
+	}
+
+	rpcURL := os.Getenv("BASE_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("BASE_RPC_URL not set")
+	}
+
+	const (
+		factoryAddr = "0x851fc799c9f1443a2c1e6b966605a80f8a1b1bf2"
+		routerAddr  = "0xfc81dfde25083a286723b7c9dd7213f8723369fe"
+		weth        = "0x4200000000000000000000000000000000000006"
+		usdc        = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+	)
+
+	cfg := Config{
+		DexID:          DexType,
+		ChainID:        8453,
+		FactoryAddress: factoryAddr,
+		RouterAddress:  routerAddr,
+		Buffer:         9900,
+	}
+
+	rpcClient := ethrpc.New(rpcURL).
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+
+	// Discover pool address for WETH
+	var poolAddr common.Address
+	req := rpcClient.NewRequest().SetContext(context.Background())
+	req.AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: factoryAddr,
+		Method: "getPropPool",
+		Params: []any{common.HexToAddress(weth)},
+	}, []any{&poolAddr})
+	_, err := req.TryAggregate()
+	require.NoError(t, err)
+	require.NotEqual(t, common.Address{}, poolAddr)
+
+	t.Logf("Pool address: %s", poolAddr.Hex())
+
+	inputPool := entity.Pool{
+		Address: strings.ToLower(poolAddr.Hex()),
+		Tokens: []*entity.PoolToken{
+			{Address: strings.ToLower(weth), Decimals: 18, Swappable: true},
+			{Address: strings.ToLower(usdc), Decimals: 6, Swappable: true},
+		},
+		Reserves:    []string{"0", "0"},
+		StaticExtra: `{"routerAddress":"` + routerAddr + `"}`,
+	}
+
+	tracker := NewPoolTracker(&cfg, rpcClient)
+	p, err := tracker.GetNewPoolState(context.Background(), inputPool, pool.GetNewPoolStateParams{})
+	require.NoError(t, err)
+
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	type direction struct {
+		label    string
+		tokenIn  common.Address
+		tokenOut common.Address
+	}
+
+	directions := []direction{
+		{"0=>1", common.HexToAddress(weth), common.HexToAddress(usdc)},
+		{"1=>0", common.HexToAddress(usdc), common.HexToAddress(weth)},
+	}
+
+	src := rand.New(rand.NewSource(time.Now().Unix()))
+	amounts := make([]*big.Int, 0, 9)
+	for _, exp := range []int{6, 12, 18} {
+		for i := 0; i < 3; i++ {
+			n := src.Int63n(9_000_000) + 1_000_000
+			base := new(big.Int).Mul(
+				big.NewInt(n),
+				bignumber.TenPowInt(exp-6),
+			)
+			amounts = append(amounts, base)
+		}
+	}
+
+	for _, dir := range directions {
+		for _, amt := range amounts {
+			t.Run(fmt.Sprintf("%s_%s", dir.label, amt.String()), func(t *testing.T) {
+				// On-chain quote via pool's quoteExactInput
+				var quoterOut *big.Int
+				req := rpcClient.NewRequest().SetContext(context.Background())
+				if p.BlockNumber > 0 {
+					req.SetBlockNumber(new(big.Int).SetUint64(p.BlockNumber))
+				}
+				req.AddCall(&ethrpc.Call{
+					ABI:    poolABI,
+					Target: p.Address,
+					Method: "quoteExactInput",
+					Params: []any{dir.tokenIn, amt},
+				}, []any{&quoterOut})
+
+				_, qErr := req.Call()
+
+				// Simulator
+				simRes, simErr := sim.CalcAmountOut(pool.CalcAmountOutParams{
+					TokenAmountIn: pool.TokenAmount{
+						Token:  dir.tokenIn.Hex(),
+						Amount: amt,
+					},
+					TokenOut: dir.tokenOut.Hex(),
+				})
+
+				if qErr != nil || quoterOut == nil || quoterOut.Sign() == 0 {
+					if simErr == nil && simRes != nil && simRes.TokenAmountOut.Amount.Sign() > 0 {
+						// Quoter reverts for amounts exceeding pool capacity; simulator may still
+						// extrapolate from samples. In production, swap limits prevent over-quoting.
+						t.Logf("quoter reverted but simulator returned %s (expected for out-of-range amounts)", simRes.TokenAmountOut.Amount)
+					}
+					return
+				}
+
+				if simErr != nil || simRes == nil {
+					t.Errorf("quoter OK but simulator failed: %v", simErr)
+					return
+				}
+
+				bps := calculateBPS(quoterOut, simRes.TokenAmountOut.Amount)
+				t.Logf("amt=%s quote=%s sim=%s bps=%d", amt, quoterOut, simRes.TokenAmountOut.Amount, bps)
+				if bps > 200 {
+					t.Errorf("high BPS diff: %d (quote=%s, sim=%s)", bps, quoterOut, simRes.TokenAmountOut.Amount)
+				}
+			})
+		}
+	}
+}
+
+func calculateBPS(quoter, sim *big.Int) int64 {
+	if quoter.Sign() == 0 {
+		return 0
+	}
+	diff := new(big.Int).Abs(new(big.Int).Sub(quoter, sim))
+	return new(big.Int).Div(new(big.Int).Mul(diff, bignumber.BasisPoint), quoter).Int64()
+}

--- a/pkg/liquidity-source/wasabi-prop/embed.go
+++ b/pkg/liquidity-source/wasabi-prop/embed.go
@@ -1,0 +1,9 @@
+package wasabiprop
+
+import _ "embed"
+
+//go:embed abis/Factory.json
+var factoryABIData []byte
+
+//go:embed abis/Pool.json
+var poolABIData []byte

--- a/pkg/liquidity-source/wasabi-prop/pool_simulator.go
+++ b/pkg/liquidity-source/wasabi-prop/pool_simulator.go
@@ -1,0 +1,139 @@
+package wasabiprop
+
+import (
+	"encoding/json"
+	"math/big"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+	Extra
+	StaticExtra
+}
+
+var (
+	_ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+	_ = pool.RegisterUseSwapLimit(valueobject.ExchangeWasabiProp)
+)
+
+func NewPoolSimulator(p entity.Pool) (*PoolSimulator, error) {
+	var extra Extra
+	if err := json.Unmarshal([]byte(p.Extra), &extra); err != nil {
+		return nil, err
+	}
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return nil, err
+	}
+
+	tokens := lo.Map(p.Tokens, func(e *entity.PoolToken, _ int) string { return strings.ToLower(e.Address) })
+	reserves := lo.Map(p.Reserves, func(e string, _ int) *big.Int { return bignumber.NewBig(e) })
+
+	return &PoolSimulator{
+		Pool: pool.Pool{Info: pool.PoolInfo{
+			Address:     p.Address,
+			Exchange:    p.Exchange,
+			Type:        p.Type,
+			Tokens:      tokens,
+			Reserves:    reserves,
+			BlockNumber: p.BlockNumber,
+		}},
+		Extra:       extra,
+		StaticExtra: staticExtra,
+	}, nil
+}
+
+func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	tokenAmountIn := params.TokenAmountIn
+	tokenOut := strings.ToLower(params.TokenOut)
+	tokenIn := strings.ToLower(tokenAmountIn.Token)
+
+	indexIn, indexOut := s.GetTokenIndex(tokenIn), s.GetTokenIndex(tokenOut)
+	if indexIn < 0 || indexOut < 0 || len(s.Info.Tokens) != 2 {
+		return nil, ErrInvalidToken
+	}
+
+	if len(s.Samples[indexIn]) == 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	samples := s.Samples[indexIn]
+	idx := sort.Search(len(samples), func(i int) bool {
+		return samples[i][0].Cmp(tokenAmountIn.Amount) > 0
+	})
+	sampleIndex := max(idx-1, 0)
+
+	var amountOut = new(big.Int)
+	bignumber.MulDivDown(amountOut, tokenAmountIn.Amount, samples[sampleIndex][1], samples[sampleIndex][0])
+
+	if limit := params.Limit; limit != nil {
+		inventoryLimit := limit.GetLimit(tokenOut)
+		if amountOut.Cmp(inventoryLimit) > 0 {
+			return nil, pool.ErrNotEnoughInventory
+		}
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: tokenOut, Amount: amountOut},
+		Fee:            &pool.TokenAmount{Token: tokenAmountIn.Token, Amount: big.NewInt(0)},
+		Gas:            defaultGas,
+	}, nil
+}
+
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	indexIn, indexOut := s.GetTokenIndex(params.TokenAmountIn.Token), s.GetTokenIndex(params.TokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 {
+		return
+	}
+	s.Info.Reserves[indexIn] = new(big.Int).Add(s.Info.Reserves[indexIn], params.TokenAmountIn.Amount)
+	s.Info.Reserves[indexOut] = new(big.Int).Sub(s.Info.Reserves[indexOut], params.TokenAmountOut.Amount)
+
+	if limit := params.SwapLimit; limit != nil {
+		_, _, _ = limit.UpdateLimit(
+			params.TokenAmountOut.Token,
+			params.TokenAmountIn.Token,
+			params.TokenAmountOut.Amount,
+			params.TokenAmountIn.Amount,
+		)
+	}
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.Info.Reserves = slices.Clone(s.Info.Reserves)
+	cloned.Samples = make([][][2]*big.Int, len(s.Samples))
+	for i, dir := range s.Samples {
+		cloned.Samples[i] = make([][2]*big.Int, len(dir))
+		for j, pair := range dir {
+			cloned.Samples[i][j] = [2]*big.Int{
+				new(big.Int).Set(pair[0]),
+				new(big.Int).Set(pair[1]),
+			}
+		}
+	}
+	return &cloned
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return pool.ApprovalInfo{ApprovalAddress: s.RouterAddress}
+}
+
+func (s *PoolSimulator) CalculateLimit() map[string]*big.Int {
+	tokens, reserves := s.GetTokens(), s.GetReserves()
+	inventory := make(map[string]*big.Int, len(tokens))
+	for i, token := range tokens {
+		inventory[token] = reserves[i]
+	}
+	return inventory
+}

--- a/pkg/liquidity-source/wasabi-prop/pool_tracker.go
+++ b/pkg/liquidity-source/wasabi-prop/pool_tracker.go
@@ -1,0 +1,122 @@
+package wasabiprop
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+type PoolTracker struct {
+	cfg          *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
+	return &PoolTracker{
+		cfg:          cfg,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+	samples := make([][][2]*big.Int, 2)
+	for i := range p.Tokens {
+		samples[i] = make([][2]*big.Int, sampleSize)
+		start := lo.Ternary(p.Tokens[i].Decimals < sampleSize/2, 0, p.Tokens[i].Decimals-sampleSize/2)
+		idx := 0
+		for k := start; k <= start+sampleSize-1 && idx < sampleSize; k++ {
+			samples[i][idx] = [2]*big.Int{bignumber.TenPowInt(k), big.NewInt(0)}
+			req.AddCall(&ethrpc.Call{
+				ABI:    poolABI,
+				Target: p.Address,
+				Method: "quoteExactInput",
+				Params: []any{
+					common.HexToAddress(p.Tokens[i].Address),
+					samples[i][idx][0],
+				},
+			}, []any{&samples[i][idx][1]})
+			idx++
+		}
+	}
+
+	res, err := req.TryBlockAndAggregate()
+	if err != nil {
+		return p, err
+	}
+
+	if t.cfg.Buffer > 0 {
+		buf := big.NewInt(t.cfg.Buffer)
+		for i := range samples {
+			for j := range samples[i] {
+				if samples[i][j][1] != nil {
+					samples[i][j][1].Mul(samples[i][j][1], buf)
+					samples[i][j][1].Div(samples[i][j][1], bignumber.BasisPoint)
+				}
+			}
+		}
+	}
+
+	for i := range samples {
+		valid := samples[i][:0]
+		for _, s := range samples[i] {
+			if s[0] != nil && s[1] != nil {
+				valid = append(valid, s)
+			}
+		}
+		samples[i] = valid
+	}
+
+	extra := Extra{
+		Samples: samples,
+	}
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return p, err
+	}
+
+	p.Extra = string(extraBytes)
+
+	// Get reserves from pool (returns a struct/tuple)
+	var reserves getReservesResult
+	reqRes := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(res.BlockNumber)
+	reqRes.AddCall(&ethrpc.Call{
+		ABI:    poolABI,
+		Target: p.Address,
+		Method: "getReserves",
+	}, []any{&reserves})
+
+	if _, err := reqRes.Call(); err != nil {
+		return p, err
+	}
+
+	if reserves.BaseTokenReserves == nil || reserves.QuoteTokenReserves == nil {
+		return p, ErrInsufficientLiquidity
+	}
+
+	p.Reserves = []string{
+		reserves.BaseTokenReserves.String(),
+		reserves.QuoteTokenReserves.String(),
+	}
+
+	p.Timestamp = time.Now().Unix()
+	p.BlockNumber = res.BlockNumber.Uint64()
+
+	return p, nil
+}

--- a/pkg/liquidity-source/wasabi-prop/pools_list_updater.go
+++ b/pkg/liquidity-source/wasabi-prop/pools_list_updater.go
@@ -1,0 +1,164 @@
+package wasabiprop
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type (
+	PoolsListUpdater struct {
+		cfg          *Config
+		ethrpcClient *ethrpc.Client
+	}
+
+	PoolsListUpdaterMetadata struct {
+		Offset int `json:"offset"`
+	}
+)
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{
+		cfg:          cfg,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	log := logger.WithFields(logger.Fields{"dexId": u.cfg.DexID})
+	log.Info("wasabi-prop: start get pools")
+
+	metadata, err := u.getMetadata(metadataBytes)
+	if err != nil {
+		log.Warnf("wasabi-prop: getMetadata failed: %v", err)
+	}
+
+	// 1. Get listed tokens from factory
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	var listed []common.Address
+	req.AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: u.cfg.FactoryAddress,
+		Method: "getListedTokens",
+	}, []any{&listed})
+
+	if _, err := req.TryAggregate(); err != nil {
+		log.Errorf("wasabi-prop: getListedTokens failed: %v", err)
+		return nil, metadataBytes, err
+	}
+
+	if metadata.Offset > len(listed) {
+		metadata.Offset = 0
+	}
+	if metadata.Offset == len(listed) {
+		return nil, metadataBytes, nil
+	}
+
+	tokens := listed[metadata.Offset:]
+
+	// 2. Get pool address for each token
+	req2 := u.ethrpcClient.NewRequest().SetContext(ctx)
+	poolAddrs := make([]common.Address, len(tokens))
+	for i, tok := range tokens {
+		req2.AddCall(&ethrpc.Call{
+			ABI:    factoryABI,
+			Target: u.cfg.FactoryAddress,
+			Method: "getPropPool",
+			Params: []any{tok},
+		}, []any{&poolAddrs[i]})
+	}
+
+	if _, err := req2.TryAggregate(); err != nil {
+		log.Errorf("wasabi-prop: getPropPool calls failed: %v", err)
+		return nil, metadataBytes, err
+	}
+
+	// 3. Find first valid pool and get quote token
+	var firstPoolAddr string
+	for _, addr := range poolAddrs {
+		if addr != (common.Address{}) {
+			firstPoolAddr = addr.Hex()
+			break
+		}
+	}
+	if firstPoolAddr == "" {
+		log.Warn("wasabi-prop: no valid pools found")
+		newMeta, _ := u.newMetadata(metadata.Offset + len(tokens))
+		return nil, newMeta, nil
+	}
+
+	req3 := u.ethrpcClient.NewRequest().SetContext(ctx)
+	var quoteToken common.Address
+	req3.AddCall(&ethrpc.Call{
+		ABI:    poolABI,
+		Target: firstPoolAddr,
+		Method: "getQuoteToken",
+	}, []any{&quoteToken})
+
+	if _, err := req3.TryAggregate(); err != nil {
+		log.Errorf("wasabi-prop: getQuoteToken failed: %v", err)
+		return nil, metadataBytes, err
+	}
+
+	// 4. Create pools
+	staticExtraBytes, _ := json.Marshal(StaticExtra{
+		RouterAddress: strings.ToLower(u.cfg.RouterAddress),
+	})
+
+	pools := make([]entity.Pool, 0, len(tokens))
+	now := time.Now().Unix()
+
+	for i, token := range tokens {
+		if poolAddrs[i] == (common.Address{}) {
+			continue
+		}
+		p := entity.Pool{
+			Address:   strings.ToLower(poolAddrs[i].Hex()),
+			Exchange:  u.cfg.DexID,
+			Type:      DexType,
+			Timestamp: now,
+			Reserves:  entity.PoolReserves{"0", "0"},
+			Tokens: []*entity.PoolToken{
+				{Address: strings.ToLower(token.Hex()), Swappable: true},
+				{Address: strings.ToLower(quoteToken.Hex()), Swappable: true},
+			},
+			Extra:       "{}",
+			StaticExtra: string(staticExtraBytes),
+		}
+		pools = append(pools, p)
+	}
+
+	newMetadata, err := u.newMetadata(metadata.Offset + len(tokens))
+	if err != nil {
+		log.Warnf("wasabi-prop: newMetadata failed: %v", err)
+		return pools, metadataBytes, nil
+	}
+
+	return pools, newMetadata, nil
+}
+
+func (u *PoolsListUpdater) getMetadata(metadataBytes []byte) (PoolsListUpdaterMetadata, error) {
+	if len(metadataBytes) == 0 {
+		return PoolsListUpdaterMetadata{}, nil
+	}
+	var metadata PoolsListUpdaterMetadata
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		return PoolsListUpdaterMetadata{}, err
+	}
+	return metadata, nil
+}
+
+func (u *PoolsListUpdater) newMetadata(offset int) ([]byte, error) {
+	metadata := PoolsListUpdaterMetadata{Offset: offset}
+	return json.Marshal(metadata)
+}

--- a/pkg/liquidity-source/wasabi-prop/type.go
+++ b/pkg/liquidity-source/wasabi-prop/type.go
@@ -1,0 +1,21 @@
+package wasabiprop
+
+import "math/big"
+
+type Extra struct {
+	Samples [][][2]*big.Int `json:"samples"` // [tokenInIndex][]{amountIn, amountOut}
+}
+
+type StaticExtra struct {
+	RouterAddress string `json:"routerAddress"`
+}
+
+type PoolMetaInfo struct {
+	BlockNumber   uint64 `json:"blockNumber"`
+	RouterAddress string `json:"routerAddress"`
+}
+
+type getReservesResult struct {
+	BaseTokenReserves  *big.Int `json:"baseTokenReserves"`
+	QuoteTokenReserves *big.Int `json:"quoteTokenReserves"`
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -158,6 +158,7 @@ import (
 	pkg_liquiditysource_velodromev1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/velodrome-v1"
 	pkg_liquiditysource_velodromev2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/velodrome-v2"
 	pkg_liquiditysource_virtualfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/virtual-fun"
+	pkg_liquiditysource_wasabiprop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/wasabi-prop"
 	pkg_liquiditysource_wildcard "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/wildcard"
 	pkg_liquiditysource_woofiv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/woofi-v2"
 	pkg_liquiditysource_woofiv21 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/woofi-v21"
@@ -363,6 +364,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_velodromev1.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_velodromev2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_virtualfun.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_wasabiprop.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_wildcard.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_woofiv2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_woofiv21.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -132,6 +132,7 @@ import (
 	velodrome "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/velodrome-v1"
 	velodromev2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/velodrome-v2"
 	virtualfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/virtual-fun"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/wasabi-prop"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/wildcard"
 	woofiv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/woofi-v2"
 	woofiv21 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/woofi-v21"
@@ -381,6 +382,7 @@ type Types struct {
 	KipseliProp                string
 	SomeswapV1                 string
 	SomeswapV2                 string
+	WasabiProp                 string
 }
 
 var (
@@ -583,5 +585,6 @@ var (
 		KipseliProp:                kipseliprop.DexType,
 		SomeswapV1:                 someswapv1.DexType,
 		SomeswapV2:                 someswapv2.DexType,
+		WasabiProp:                 wasabiprop.DexType,
 	}
 )

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -260,6 +260,7 @@ const (
 	ExchangeVirtualFun                 = "virtual-fun"
 	ExchangeVooi                       = "vooi"
 	ExchangeWagyuSwap                  = "wagyuswap"
+	ExchangeWasabiProp                 = "wasabi-prop"
 	ExchangeWault                      = "wault"
 	ExchangeWBETH                      = "wbeth"
 	ExchangeWildcard                   = "wildcard"


### PR DESCRIPTION
Add Wasabi Prop AMM integration for Base chain using sample-based quoting pattern. Pools are discovered via the on-chain Factory contract and quotes are sampled from each pool's quoteExactInput() with a 1% safety buffer (9900 bps).

## Why did we need it?
Integrate Wasabi Prop AMM.

## Related Issue
N/A

## Release Note
  Requires adding wasabi-prop DEX configuration in kyber-application for Base (chain 8453) with the following parameters:                                 
  - factoryAddress: 0x851fc799c9f1443a2c1e6b966605a80f8a1b1bf2                                                                                            
  - routerAddress: 0xfc81dfde25083a286723b7c9dd7213f8723369fe
  - buffer: 9900

## How Has This Been Tested?
  - go build ./... passes with no errors
  - go test ./pkg/liquidity-source/wasabi-prop/... passes (debug test skipped in CI)
  - Debug test run manually against Base mainnet via QuickNode RPC (BASE_RPC_URL env var), comparing simulator quotes vs on-chain quoteExactInput() at the same block number. Results show ~100 bps difference, consistent with the 1% safety buffer. Both swap directions tested (WETH→USDC and USDC→WETH) across 9 random amounts per direction.

## Screenshots (if appropriate):
