### PR TITLE
ft: support auto-calibrated hooks in uniswap v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KyberNetwork/kyberswap-dex-lib
 
-go 1.25.0
+go 1.25.10
 
 require (
 	github.com/KyberNetwork/blockchain-toolkit v0.8.2-0.20241123202223-0b77d465adc4

--- a/pkg/liquidity-source/algebra/integral/plugin.go
+++ b/pkg/liquidity-source/algebra/integral/plugin.go
@@ -1,13 +1,13 @@
 package integral
 
 import (
+	"cmp"
 	"sync"
 
 	"github.com/KyberNetwork/elastic-go-sdk/v2/utils"
 	v3Utils "github.com/KyberNetwork/uniswapv3-sdk-uint256/utils"
 	"github.com/holiman/uint256"
 	"github.com/samber/lo"
-	"golang.org/x/exp/constraints"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/algebra"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
@@ -608,6 +608,6 @@ func getNewPrice(
 // a <= c <  b | false
 // b <  a <= c | false
 // c <  b <  a | false
-func lteConsideringOverflow[T constraints.Ordered](a, b, currentTime T) bool {
+func lteConsideringOverflow[T cmp.Ordered](a, b, currentTime T) bool {
 	return algebra.LteConsideringOverflow(a, b, currentTime)
 }

--- a/pkg/liquidity-source/algebra/pool_tracker.go
+++ b/pkg/liquidity-source/algebra/pool_tracker.go
@@ -1,13 +1,13 @@
 package algebra
 
 import (
+	"cmp"
 	"context"
 	"math/big"
 	"sort"
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/logger"
-	"golang.org/x/exp/constraints"
 )
 
 const (
@@ -145,7 +145,7 @@ func (d *PoolTracker[Timepoint, TimepointRPC]) GetTimepoints(ctx context.Context
 // a <= c <  b | false
 // b <  a <= c | false
 // c <  b <  a | false
-func LteConsideringOverflow[T constraints.Ordered](a, b, currentTime T) bool {
+func LteConsideringOverflow[T cmp.Ordered](a, b, currentTime T) bool {
 	res := a > currentTime
 	if res == (b > currentTime) {
 		res = a <= b

--- a/pkg/liquidity-source/brownfi/v2/pool_tracker.go
+++ b/pkg/liquidity-source/brownfi/v2/pool_tracker.go
@@ -84,10 +84,6 @@ func (d *PoolTracker) GetNewPoolState(
 			ABI:    brownFiV2FactoryABI,
 			Target: d.config.FactoryAddress,
 			Method: factoryMethodPriceOracle,
-		}, []any{&priceOracle}).AddCall(&ethrpc.Call{
-			ABI:    brownFiV2FactoryABI,
-			Target: d.config.FactoryAddress,
-			Method: factoryMethodPriceOracle,
 		}, []any{&priceOracle}).Aggregate(); err != nil {
 			return p, errors.WithMessage(err, "fail to fetch price feed ids")
 		} else {

--- a/pkg/liquidity-source/uniswap/v4/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/constant.go
@@ -21,16 +21,32 @@ const (
 
 var (
 	PoolManager = map[valueobject.ChainID]common.Address{
-		valueobject.ChainIDArbitrumOne:     common.HexToAddress("0x360e68faccca8ca495c1b759fd9eee466db9fb32"),
-		valueobject.ChainIDAvalancheCChain: common.HexToAddress("0x06380c0e0912312b5150364b9dc4542ba0dbbc85"),
-		valueobject.ChainIDBase:            common.HexToAddress("0x498581ff718922c3f8e6a244956af099b2652b2b"),
-		valueobject.ChainIDBSC:             common.HexToAddress("0x28e2ea090877bf75740558f6bfb36a5ffee9e9df"),
+		valueobject.ChainIDArbitrumOne:     common.HexToAddress("0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32"),
+		valueobject.ChainIDAvalancheCChain: common.HexToAddress("0x06380C0e0912312B5150364B9DC4542BA0DbBc85"),
+		valueobject.ChainIDBase:            common.HexToAddress("0x498581fF718922c3f8e6A244956aF099B2652b2b"),
+		valueobject.ChainIDBSC:             common.HexToAddress("0x28e2Ea090877bF75740558f6BFB36A5ffeE9e9dF"),
 		valueobject.ChainIDEthereum:        common.HexToAddress("0x000000000004444c5dc75cB358380D2e3dE08A90"),
-		valueobject.ChainIDMonad:           common.HexToAddress("0x188d586ddcf52439676ca21a244753fa19f9ea8e"),
+		valueobject.ChainIDMonad:           common.HexToAddress("0x188d586Ddcf52439676Ca21A244753fA19F9Ea8e"),
 		valueobject.ChainIDMegaETH:         common.HexToAddress("0x58DD83c317B03e6eBD72C3e912adF60a8e97Aa95"),
-		valueobject.ChainIDOptimism:        common.HexToAddress("0x9a13f98cb987694c9f086b1f5eb990eea8264ec3"),
-		valueobject.ChainIDPolygon:         common.HexToAddress("0x67366782805870060151383f4bbff9dab53e5cd6"),
-		valueobject.ChainIDUnichain:        common.HexToAddress("0x1f98400000000000000000000000000000000004"),
+		valueobject.ChainIDOptimism:        common.HexToAddress("0x9a13F98Cb987694C9F086b1F5eB990EeA8264Ec3"),
+		valueobject.ChainIDPolygon:         common.HexToAddress("0x67366782805870060151383F4BbFF9daB53e5cD6"),
+		valueobject.ChainIDUnichain:        common.HexToAddress("0x1F98400000000000000000000000000000000004"),
+	}
+
+	// Quoter maps chainID to the deployed Uniswap V4 Quoter contract address.
+	// Used as fallback when HookQuoter is not available for a chain.
+	// Addresses: https://docs.uniswap.org/contracts/v4/deployments
+	Quoter = map[valueobject.ChainID]string{
+		valueobject.ChainIDArbitrumOne:     "0x3972C00F7ED34D3ba0aF431F0D790be4E8B1e6E8",
+		valueobject.ChainIDAvalancheCChain: "0x9F75dD27D6664c475B90e105573E550ff69437B0",
+		valueobject.ChainIDBase:            "0x0d5e0F971ED27FBfF6c2837bf31316121532048D",
+		valueobject.ChainIDBSC:             "0x9F75dD27D6664c475B90e105573E550ff69437B0",
+		valueobject.ChainIDEthereum:        "0x52F0E24D1c21C8A0cB1e5a5dD6198556BD9E1203",
+		valueobject.ChainIDMonad:           "0xa222Dd357A9076d1091Ed6Aa2e16C9742dD26891",
+		valueobject.ChainIDMegaETH:         "0x94bDC671f0c35F44a1DaA53143fd1f868D1623b9",
+		valueobject.ChainIDOptimism:        "0x9F75dD27D6664c475B90e105573E550ff69437B0",
+		valueobject.ChainIDPolygon:         "0x9F75dD27D6664c475B90e105573E550ff69437B0",
+		valueobject.ChainIDUnichain:        "0x333bA4e6c6c1Ae8E5BBa3a2c9C77d7c4Ea92f74b",
 	}
 
 	// NativeTokenAddress is the address that UniswapV4 uses to represent native token in pools.

--- a/pkg/liquidity-source/uniswap/v4/hooks.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks.go
@@ -141,9 +141,28 @@ func (x HookExtra) Unmarshal(dest any) error {
 	return json.Unmarshal(x, dest)
 }
 
+// Calibratable is implemented by hooks that use auto-detection. When a hook
+// returned by GetHook also implements this interface, the pool simulator will
+// allow it even if its address is not in HookFactories — provided that
+// IsCalibrated() returns true.
+type Calibratable interface {
+	IsCalibrated() bool
+}
+
 type HookFactory func(param *HookParam) Hook
 
 var HookFactories = map[common.Address]HookFactory{}
+
+// fallbackHookFactory is called when a hook address is not in HookFactories.
+// It is set by SetFallbackHookFactory (typically from the auto package init).
+var fallbackHookFactory HookFactory
+
+// SetFallbackHookFactory registers a factory that is used for any hook address
+// not explicitly registered in HookFactories. Only one fallback can be active;
+// subsequent calls replace the previous value.
+func SetFallbackHookFactory(f HookFactory) {
+	fallbackHookFactory = f
+}
 
 func RegisterHooks(hook Hook, addresses ...common.Address) bool {
 	return RegisterHooksFactory(func(*HookParam) Hook {
@@ -161,7 +180,15 @@ func RegisterHooksFactory(factory HookFactory, addresses ...common.Address) bool
 func GetHook(hookAddress common.Address, param *HookParam) (hook Hook, ok bool) {
 	hookFactory, ok := HookFactories[hookAddress]
 	if hookFactory == nil {
-		hook = (*BaseHook)(nil)
+		if fallbackHookFactory != nil {
+			if param == nil {
+				param = &HookParam{}
+			}
+			param.HookAddress = hookAddress
+			hook = fallbackHookFactory(param)
+		} else {
+			hook = (*BaseHook)(nil)
+		}
 	} else {
 		if param == nil {
 			param = &HookParam{}

--- a/pkg/liquidity-source/uniswap/v4/pool_simulator.go
+++ b/pkg/liquidity-source/uniswap/v4/pool_simulator.go
@@ -44,7 +44,11 @@ func NewPoolSimulator(entityPool entity.Pool, chainID valueobject.ChainID) (*Poo
 		HookExtra: HookExtra(extra.HookExtra),
 	})
 	if !ok && HasSwapPermissions(staticExtra.HooksAddress) {
-		return nil, shared.ErrUnsupportedHook
+		// If the hook implements Calibratable and has a valid model, allow it
+		// through. Otherwise, the pool is unsupported (unknown hook, no model).
+		if c, isCalibratable := hook.(Calibratable); !isCalibratable || !c.IsCalibrated() {
+			return nil, shared.ErrUnsupportedHook
+		}
 	}
 
 	allowEmptyTicks := hook.AllowEmptyTicks()

--- a/pkg/liquidity-source/uniswap/v4/pool_tracker.go
+++ b/pkg/liquidity-source/uniswap/v4/pool_tracker.go
@@ -99,21 +99,10 @@ func (t *PoolTracker) FetchRPCData(ctx context.Context, p *entity.Pool, blockNum
 	if result.Reserves, err = hook.GetReserves(ctx, hookParam); err != nil {
 		return nil, err
 	}
-	if result.Reserves == nil { // default implementation is to estimate from liquidity and sqrtPriceX96
-		var extra Extra
-		if err := json.Unmarshal([]byte(p.Extra), &extra); err != nil {
-			l.WithFields(logger.Fields{
-				"error": err,
-			}).Error("failed to unmarshal pool extra")
-			return nil, err
-		}
-
-		reserve0, reserve1 := EstimateReservesFromTicks(result.Slot0.SqrtPriceX96, extra.Ticks)
-		result.Reserves = entity.PoolReserves{reserve0.String(), reserve1.String()}
-	}
 
 	hookParam.BlockNumber = res.BlockNumber
 	result.HookExtra, err = hook.Track(ctx, hookParam)
+	p.Exchange = hook.GetExchange()
 	return result, err
 }
 
@@ -193,8 +182,14 @@ func (t *PoolTracker) BootstrapPoolState(
 			}).Error("failed to transform tickResp to tick")
 			continue
 		}
-
 		ticks = append(ticks, tick)
+	}
+
+	if rpcData.Reserves != nil {
+		p.Reserves = rpcData.Reserves
+	} else {
+		reserve0, reserve1 := EstimateReservesFromTicks(rpcData.Slot0.SqrtPriceX96, ticks)
+		p.Reserves = entity.PoolReserves{reserve0.String(), reserve1.String()}
 	}
 
 	extraBytes, err := json.Marshal(Extra{
@@ -215,7 +210,6 @@ func (t *PoolTracker) BootstrapPoolState(
 	}
 
 	p.Extra = string(extraBytes)
-	p.Reserves = rpcData.Reserves
 	p.BlockNumber = blockNumber
 	p.Timestamp = time.Now().Unix()
 
@@ -728,25 +722,6 @@ func (t *PoolTracker) updateState(
 
 	blockNumber := ticksBasedPool.BlockNumber
 
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
-	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
-	}
-
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
 	for _, tick := range ticksBasedPool.Ticks {
 		// skip uninitialized ticks
@@ -766,9 +741,33 @@ func (t *PoolTracker) updateState(
 		return entityPoolTicks[i].Index < entityPoolTicks[j].Index
 	})
 
-	if rpcState.Slot0.SqrtPriceX96.Sign() == 0 {
+	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	if err != nil {
+		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
+			rpcState, err = t.FetchRPCData(ctx, &p, 0)
+			if err != nil {
+				l.WithFields(logger.Fields{
+					"error": err,
+				}).Error("failed to fetch latest state from RPC")
+				return p, err
+			}
+		} else {
+			l.WithFields(logger.Fields{
+				"error":       err,
+				"blockNumber": blockNumber,
+			}).Error("failed to fetch state from RPC")
+			return p, err
+		}
+	} else if rpcState.Slot0.SqrtPriceX96.Sign() == 0 {
 		l.Error("sqrtPriceX96 is 0")
 		return p, errors.New("sqrtPriceX96 is 0")
+	}
+
+	if rpcState.Reserves != nil {
+		p.Reserves = rpcState.Reserves
+	} else {
+		reserve0, reserve1 := EstimateReservesFromTicks(rpcState.Slot0.SqrtPriceX96, entityPoolTicks)
+		p.Reserves = entity.PoolReserves{reserve0.String(), reserve1.String()}
 	}
 
 	extraBytes, err := json.Marshal(Extra{
@@ -790,26 +789,9 @@ func (t *PoolTracker) updateState(
 
 	p.SwapFee, _ = rpcState.Slot0.LpFee.Float64()
 	p.Extra = string(extraBytes)
-	p.Reserves = rpcState.Reserves
-	p.Exchange = t.getExchange(&p)
 	p.Timestamp = t.estimateLastActivityTime(&p, logs, blockHeaders)
 
 	return p, nil
-}
-
-func (t *PoolTracker) getExchange(p *entity.Pool) string {
-	var staticExtra StaticExtra
-	var hookAddress common.Address
-	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
-		logger.Errorf("failed to unmarshal static extra data")
-	} else {
-		hookAddress = staticExtra.HooksAddress
-	}
-
-	hookParam := &HookParam{Cfg: t.config, RpcClient: t.ethrpcClient, Pool: p}
-	hook, _ := GetHook(hookAddress, hookParam)
-
-	return hook.GetExchange()
 }
 
 func (t *PoolTracker) estimateLastActivityTime(p *entity.Pool, logs []ethtypes.Log,


### PR DESCRIPTION
- Add Calibratable interface and SetFallbackHookFactory so auto-detection
  hooks can be wired in without explicit address registration
- Pool simulator allows hooks that implement Calibratable and return
  IsCalibrated()=true, replacing the hard ErrUnsupportedHook reject
- Pool tracker: move reserve estimation into BootstrapPoolState/updateState,
  move exchange name assignment to hook.GetExchange() in FetchRPCData,
  remove now-redundant getExchange helper
- Add Quoter contract addresses for all supported v4 chains
- Checksum-fix PoolManager addresses in constant.go
- Replace golang.org/x/exp/constraints with stdlib cmp in algebra
- Remove extra priceOracle RPC call in brownfi v2
