### PR TITLE
feat: expose Baseline adapter route data

### DIFF
--- a/pkg/liquidity-source/baseline/pool_simulator.go
+++ b/pkg/liquidity-source/baseline/pool_simulator.go
@@ -209,6 +209,7 @@ func (p *PoolSimulator) GetMetaInfo(tokenIn, tokenOut string) any {
 
 	return PoolMeta{
 		Pool:        p.extra.RelayAddress,
+		BToken:      p.Info.Address,
 		IsBuyBase:   isBuy,
 		BlockNumber: p.Info.BlockNumber,
 	}

--- a/pkg/liquidity-source/baseline/quote_test.go
+++ b/pkg/liquidity-source/baseline/quote_test.go
@@ -15,6 +15,7 @@ import (
 const (
 	testReserveToken = "0x0000000000000000000000000000000000000001"
 	testBToken       = "0x0000000000000000000000000000000000000002"
+	testRelay        = "0x0000000000000000000000000000000000000003"
 )
 
 func TestCalcAmountOut_BuyExactInReportsOptimizedExecutionFee(t *testing.T) {
@@ -39,6 +40,51 @@ func TestCalcAmountOut_BuyExactInReportsOptimizedExecutionFee(t *testing.T) {
 	}
 	if result.RemainingTokenAmountIn.Amount.Cmp(dust) != 0 {
 		t.Fatalf("remaining input mismatch: want %s got %s", dust, result.RemainingTokenAmountIn.Amount)
+	}
+}
+
+func TestBuyRouteExposesOptimizedAdapterInputs(t *testing.T) {
+	sim := newBaselineQuoteTestSimulator(t, newBaselineQuoteTestState())
+	amountIn := mustTestBI(t, "1000000000000000000")
+
+	result, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testReserveToken, Amount: amountIn},
+		TokenOut:      testBToken,
+	})
+	if err != nil {
+		t.Fatalf("CalcAmountOut buy failed: %v", err)
+	}
+
+	metaInfo := sim.GetMetaInfo(testReserveToken, testBToken)
+	meta, ok := metaInfo.(PoolMeta)
+	if !ok {
+		t.Fatalf("GetMetaInfo returned %T, want PoolMeta", metaInfo)
+	}
+	if meta.Pool != testRelay {
+		t.Fatalf("PoolMeta.Pool = %s, want relay %s", meta.Pool, testRelay)
+	}
+	if meta.BToken != testBToken {
+		t.Fatalf("PoolMeta.BToken = %s, want %s", meta.BToken, testBToken)
+	}
+	if !meta.IsBuyBase {
+		t.Fatal("PoolMeta.IsBuyBase must be true for reserve -> bToken")
+	}
+
+	swapInfo, ok := result.SwapInfo.(SwapInfo)
+	if !ok {
+		t.Fatalf("SwapInfo is %T, want baseline.SwapInfo", result.SwapInfo)
+	}
+	if swapInfo.RelayAddress != testRelay {
+		t.Fatalf("SwapInfo.RelayAddress = %s, want %s", swapInfo.RelayAddress, testRelay)
+	}
+	if swapInfo.BToken != testBToken {
+		t.Fatalf("SwapInfo.BToken = %s, want %s", swapInfo.BToken, testBToken)
+	}
+	if !swapInfo.IsBuy {
+		t.Fatal("SwapInfo.IsBuy must be true for reserve -> bToken")
+	}
+	if swapInfo.AmountOut != result.TokenAmountOut.Amount.String() {
+		t.Fatalf("SwapInfo.AmountOut = %s, want TokenAmountOut %s", swapInfo.AmountOut, result.TokenAmountOut.Amount)
 	}
 }
 
@@ -139,7 +185,7 @@ func quoteBuyExactInWithDust(
 func newBaselineQuoteTestSimulator(t *testing.T, state *QuoteState) *PoolSimulator {
 	t.Helper()
 
-	extra, err := json.Marshal(Extra{QuoteState: state})
+	extra, err := json.Marshal(Extra{RelayAddress: testRelay, QuoteState: state})
 	if err != nil {
 		t.Fatalf("marshal extra: %v", err)
 	}

--- a/pkg/liquidity-source/baseline/types.go
+++ b/pkg/liquidity-source/baseline/types.go
@@ -63,6 +63,7 @@ type quoteResult struct {
 
 type PoolMeta struct {
 	Pool        string `json:"p"`
+	BToken      string `json:"bToken,omitempty"`
 	BlockNumber uint64 `json:"bN"`
 	IsBuyBase   bool   `json:"isBuyBase,omitempty"`
 }


### PR DESCRIPTION
## Summary
- include the Baseline bToken address in PoolMeta so downstream route encoders have the static adapter input
- add a deterministic regression that verifies Baseline buy routes expose relay, bToken, buy direction, and exact buy output amount
- keep the existing optimized buy amount in SwapInfo.AmountOut for the buyTokensExactOut adapter path

## Root Cause
The simulator computed the optimized Baseline buy output, but route metadata only exposed the relay address. Downstream adapter calldata builders could therefore keep emitting relay-only data, which is insufficient for the new Baseline adapter payload.

## Validation
- go test ./pkg/liquidity-source/baseline