### PR TITLE
feat: integrate UniPool dex adapter

### DIFF
--- a/pkg/liquidity-source/unipool/abis.go
+++ b/pkg/liquidity-source/unipool/abis.go
@@ -1,0 +1,28 @@
+package unipool
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	uniPoolFactoryABI abi.ABI
+	uniPoolPairABI    abi.ABI
+)
+
+func init() {
+	for _, b := range []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{&uniPoolFactoryABI, factoryABIJson},
+		{&uniPoolPairABI, pairABIJson},
+	} {
+		parsed, err := abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+		*b.ABI = parsed
+	}
+}

--- a/pkg/liquidity-source/unipool/abis/UniPoolFactory.json
+++ b/pkg/liquidity-source/unipool/abis/UniPoolFactory.json
@@ -1,0 +1,27 @@
+[
+  {
+    "inputs": [],
+    "name": "getAllPairsLength",
+    "outputs": [{ "internalType": "uint256", "name": "length", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "index", "type": "uint256" }],
+    "name": "getPairAtIndex",
+    "outputs": [{ "internalType": "address", "name": "pair", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "token0",     "type": "address" },
+      { "indexed": true,  "internalType": "address", "name": "token1",     "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "pair",       "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "totalPairs", "type": "uint256" }
+    ],
+    "name": "PairCreated",
+    "type": "event"
+  }
+]

--- a/pkg/liquidity-source/unipool/abis/UniPoolPair.json
+++ b/pkg/liquidity-source/unipool/abis/UniPoolPair.json
@@ -1,0 +1,87 @@
+[
+  {
+    "inputs": [],
+    "name": "getTokens",
+    "outputs": [
+      { "internalType": "address", "name": "token0", "type": "address" },
+      { "internalType": "address", "name": "token1", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      { "internalType": "uint256", "name": "reserve0", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserve1", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVirtualReserves",
+    "outputs": [
+      {
+        "internalType": "struct VirtualReserves",
+        "name": "reserves",
+        "type": "tuple",
+        "components": [
+          { "internalType": "uint128", "name": "virtualReserve0In",  "type": "uint128" },
+          { "internalType": "uint128", "name": "virtualReserve0Out", "type": "uint128" },
+          { "internalType": "uint128", "name": "virtualReserve1In",  "type": "uint128" },
+          { "internalType": "uint128", "name": "virtualReserve1Out", "type": "uint128" }
+        ]
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastUpdateTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "timestamp", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPriceDecay",
+    "outputs": [{ "internalType": "uint128", "name": "decay", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeesBps",
+    "outputs": [
+      { "internalType": "uint16", "name": "feeLpBps",   "type": "uint16" },
+      { "internalType": "uint16", "name": "feePoolBps", "type": "uint16" },
+      { "internalType": "uint16", "name": "burnFeeBps", "type": "uint16" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTotalBorrowed0",
+    "outputs": [{ "internalType": "uint256", "name": "borrowed0", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTotalBorrowed1",
+    "outputs": [{ "internalType": "uint256", "name": "borrowed1", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSwapPriceToleranceBps",
+    "outputs": [{ "internalType": "uint16", "name": "toleranceBps", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/unipool/abis/UniPoolQuoter.json
+++ b/pkg/liquidity-source/unipool/abis/UniPoolQuoter.json
@@ -1,0 +1,24 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenIn", "type": "address" },
+      { "internalType": "address", "name": "tokenOut", "type": "address" },
+      { "internalType": "uint128", "name": "amountIn", "type": "uint128" }
+    ],
+    "name": "getAmountOut",
+    "outputs": [{ "internalType": "uint128", "name": "amountOut", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenIn", "type": "address" },
+      { "internalType": "address", "name": "tokenOut", "type": "address" },
+      { "internalType": "uint128", "name": "amountOut", "type": "uint128" }
+    ],
+    "name": "getAmountIn",
+    "outputs": [{ "internalType": "uint128", "name": "amountIn", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/unipool/config.go
+++ b/pkg/liquidity-source/unipool/config.go
@@ -1,0 +1,7 @@
+package unipool
+
+type Config struct {
+	DexID          string `json:"dexID"`
+	FactoryAddress string `json:"factoryAddress"`
+	NewPoolLimit   int    `json:"newPoolLimit"`
+}

--- a/pkg/liquidity-source/unipool/constant.go
+++ b/pkg/liquidity-source/unipool/constant.go
@@ -1,0 +1,32 @@
+package unipool
+
+const (
+	DexType = "unipool"
+
+	// defaultGas is a conservative placeholder for routing cost estimation.
+	// Realistic mainnet measurements suggest 100-140k for a clean swap; we keep
+	// 150k as a safe upper bound. TODO: refine empirically once Unipool is
+	// deployed (forge test --gas-report on /test or measured swaps on-chain).
+	defaultGas = 150_000
+
+	bpsDivisor = 10_000
+
+	factoryMethodGetAllPairsLength = "getAllPairsLength"
+	factoryMethodGetPairAtIndex    = "getPairAtIndex"
+
+	pairMethodGetTokens                = "getTokens"
+	pairMethodGetReserves              = "getReserves"
+	pairMethodGetVirtualReserves       = "getVirtualReserves"
+	pairMethodGetLastUpdateTimestamp   = "getLastUpdateTimestamp"
+	pairMethodGetPriceDecay            = "getPriceDecay"
+	pairMethodGetFeesBps               = "getFeesBps"
+	pairMethodGetTotalBorrowed0        = "getTotalBorrowed0"
+	pairMethodGetTotalBorrowed1        = "getTotalBorrowed1"
+	pairMethodGetSwapPriceToleranceBps = "getSwapPriceToleranceBps"
+
+	factoryEventPairCreated = "PairCreated"
+)
+
+// swapPriceToleranceDisabled mirrors the on-chain `type(uint16).max` sentinel
+// for which UniPoolPairSwap.swap skips the _validateSpreads check.
+const swapPriceToleranceDisabled uint16 = 0xFFFF

--- a/pkg/liquidity-source/unipool/embed.go
+++ b/pkg/liquidity-source/unipool/embed.go
@@ -1,0 +1,9 @@
+package unipool
+
+import _ "embed"
+
+//go:embed abis/UniPoolFactory.json
+var factoryABIJson []byte
+
+//go:embed abis/UniPoolPair.json
+var pairABIJson []byte

--- a/pkg/liquidity-source/unipool/errors.go
+++ b/pkg/liquidity-source/unipool/errors.go
@@ -1,0 +1,15 @@
+package unipool
+
+import "errors"
+
+var (
+	ErrInvalidToken              = errors.New("invalid token")
+	ErrInvalidReserve            = errors.New("invalid reserve")
+	ErrInvalidAmountIn           = errors.New("invalid amount in")
+	ErrInvalidAmountOut          = errors.New("invalid amount out")
+	ErrInsufficientLiquidity     = errors.New("INSUFFICIENT_LIQUIDITY")
+	ErrInsufficientOutputAmount  = errors.New("INSUFFICIENT_OUTPUT_AMOUNT")
+	ErrInsufficientSwapLiquidity = errors.New("INSUFFICIENT_SWAP_LIQUIDITY")
+	ErrFeeExceedsMax             = errors.New("FEE_EXCEEDS_MAX")
+	ErrExcessiveSpread           = errors.New("EXCESSIVE_SPREAD")
+)

--- a/pkg/liquidity-source/unipool/pool_factory.go
+++ b/pkg/liquidity-source/unipool/pool_factory.go
@@ -1,0 +1,111 @@
+package unipool
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/poolfactory"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/eth"
+)
+
+var _ = poolfactory.RegisterFactoryC(DexType, NewPoolFactory)
+
+type PoolFactory struct {
+	config *Config
+}
+
+func NewPoolFactory(config *Config) *PoolFactory {
+	return &PoolFactory{config: config}
+}
+
+func (f *PoolFactory) IsEventSupported(event common.Hash) bool {
+	return event == uniPoolFactoryABI.Events[factoryEventPairCreated].ID
+}
+
+func (f *PoolFactory) DecodePoolCreated(event types.Log) (*entity.Pool, error) {
+	token0, token1, pair, err := f.parsePairCreated(event)
+	if err != nil {
+		return nil, err
+	}
+	return f.newPool(token0, token1, pair, event.BlockNumber)
+}
+
+// DecodePoolAddressesFromFactoryLog returns the pool address(es) touched by a
+// factory log without building the full entity.Pool. Used by indexer services
+// that only need to know which pools need re-tracking after a block.
+func (f *PoolFactory) DecodePoolAddressesFromFactoryLog(_ context.Context, event types.Log) ([]string, error) {
+	_, _, pair, err := f.parsePairCreated(event)
+	if err != nil {
+		return nil, err
+	}
+	return []string{hexutil.Encode(pair[:])}, nil
+}
+
+// parsePairCreated decodes a PairCreated event:
+//
+//	event PairCreated(address indexed token0, address indexed token1, address pair, uint256 totalPairs)
+func (f *PoolFactory) parsePairCreated(log types.Log) (token0, token1, pair common.Address, err error) {
+	if len(log.Topics) != 3 ||
+		eth.IsZeroAddress(log.Address) ||
+		!strings.EqualFold(log.Address.Hex(), f.config.FactoryAddress) ||
+		log.Topics[0] != uniPoolFactoryABI.Events[factoryEventPairCreated].ID {
+		err = errors.New("event is not supported")
+		return
+	}
+
+	token0 = common.BytesToAddress(log.Topics[1].Bytes())
+	token1 = common.BytesToAddress(log.Topics[2].Bytes())
+
+	unpacked, err := uniPoolFactoryABI.Events[factoryEventPairCreated].Inputs.NonIndexed().Unpack(log.Data)
+	if err != nil {
+		return
+	}
+	if len(unpacked) < 1 {
+		err = errors.New("malformed PairCreated event data")
+		return
+	}
+	addr, ok := unpacked[0].(common.Address)
+	if !ok {
+		err = errors.New("malformed PairCreated event pair field")
+		return
+	}
+	pair = addr
+	return
+}
+
+func (f *PoolFactory) newPool(token0, token1, pair common.Address, blockNumber uint64) (*entity.Pool, error) {
+	staticExtra := StaticExtra{FactoryAddress: f.config.FactoryAddress}
+	staticExtraBytes, err := json.Marshal(staticExtra)
+	if err != nil {
+		return nil, err
+	}
+
+	extra := zeroExtra()
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entity.Pool{
+		Address:   hexutil.Encode(pair[:]),
+		Exchange:  f.config.DexID,
+		Type:      DexType,
+		Timestamp: time.Now().Unix(),
+		Reserves:  entity.PoolReserves{"0", "0"},
+		Tokens: []*entity.PoolToken{
+			{Address: hexutil.Encode(token0[:]), Swappable: true},
+			{Address: hexutil.Encode(token1[:]), Swappable: true},
+		},
+		Extra:       string(extraBytes),
+		StaticExtra: string(staticExtraBytes),
+		BlockNumber: blockNumber,
+	}, nil
+}

--- a/pkg/liquidity-source/unipool/pool_factory_test.go
+++ b/pkg/liquidity-source/unipool/pool_factory_test.go
@@ -1,0 +1,200 @@
+package unipool
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+const (
+	testFactoryAddress = "0x1234567890123456789012345678901234567890"
+	testDexID          = "unipool"
+	testToken0Address  = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testToken1Address  = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testPairAddress    = "0xcccccccccccccccccccccccccccccccccccccccc"
+	testTotalPairs     = uint64(7)
+	testBlockNumber    = uint64(1_234_567)
+)
+
+func newTestFactory() *PoolFactory {
+	return NewPoolFactory(&Config{
+		DexID:          testDexID,
+		FactoryAddress: testFactoryAddress,
+	})
+}
+
+// pairCreatedLog builds a synthetic PairCreated log:
+//
+//	event PairCreated(address indexed token0, address indexed token1, address pair, uint256 totalPairs)
+func pairCreatedLog(t *testing.T, factory, token0, token1, pair string, totalPairs uint64) types.Log {
+	t.Helper()
+	data := make([]byte, 0, 64)
+	data = append(data, leftPad32(common.HexToAddress(pair).Bytes())...)
+	data = append(data, leftPad32(new(big.Int).SetUint64(totalPairs).Bytes())...)
+	return types.Log{
+		Address: common.HexToAddress(factory),
+		Topics: []common.Hash{
+			uniPoolFactoryABI.Events[factoryEventPairCreated].ID,
+			common.BytesToHash(common.HexToAddress(token0).Bytes()),
+			common.BytesToHash(common.HexToAddress(token1).Bytes()),
+		},
+		Data:        data,
+		BlockNumber: testBlockNumber,
+	}
+}
+
+func leftPad32(b []byte) []byte {
+	if len(b) >= 32 {
+		return b
+	}
+	out := make([]byte, 32)
+	copy(out[32-len(b):], b)
+	return out
+}
+
+func TestPoolFactory_IsEventSupported(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+
+	assert.True(t,
+		f.IsEventSupported(uniPoolFactoryABI.Events[factoryEventPairCreated].ID),
+		"PairCreated event should be supported")
+
+	unknown := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	assert.False(t, f.IsEventSupported(unknown), "random hash must not be supported")
+}
+
+func TestPoolFactory_DecodePoolCreated_Valid(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	log := pairCreatedLog(t, testFactoryAddress, testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+
+	p, err := f.DecodePoolCreated(log)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	assert.Equal(t, strings.ToLower(testPairAddress), strings.ToLower(p.Address))
+	assert.Equal(t, testDexID, p.Exchange)
+	assert.Equal(t, DexType, p.Type)
+	assert.Equal(t, testBlockNumber, p.BlockNumber)
+	assert.Equal(t, entity.PoolReserves{"0", "0"}, p.Reserves)
+	require.Len(t, p.Tokens, 2)
+	assert.Equal(t, strings.ToLower(testToken0Address), strings.ToLower(p.Tokens[0].Address))
+	assert.Equal(t, strings.ToLower(testToken1Address), strings.ToLower(p.Tokens[1].Address))
+	assert.True(t, p.Tokens[0].Swappable)
+	assert.True(t, p.Tokens[1].Swappable)
+
+	// StaticExtra should round-trip the configured factory address.
+	assert.Contains(t, p.StaticExtra, strings.ToLower(testFactoryAddress))
+}
+
+func TestPoolFactory_DecodePoolCreated_WrongFactory(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	otherFactory := "0x0000000000000000000000000000000000000099"
+	log := pairCreatedLog(t, otherFactory, testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+
+	_, err := f.DecodePoolCreated(log)
+	require.Error(t, err, "log from a different factory must be rejected")
+}
+
+func TestPoolFactory_DecodePoolCreated_WrongEventHash(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	log := pairCreatedLog(t, testFactoryAddress, testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+	// Replace event topic with a random one.
+	log.Topics[0] = common.HexToHash("0xaaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999")
+
+	_, err := f.DecodePoolCreated(log)
+	require.Error(t, err)
+}
+
+func TestPoolFactory_DecodePoolCreated_TooFewTopics(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	log := pairCreatedLog(t, testFactoryAddress, testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+	log.Topics = log.Topics[:2] // drop the second indexed token
+
+	_, err := f.DecodePoolCreated(log)
+	require.Error(t, err)
+}
+
+func TestPoolFactory_DecodePoolCreated_ZeroFactoryAddress(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	log := pairCreatedLog(t, testFactoryAddress, testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+	log.Address = common.Address{} // zero address
+
+	_, err := f.DecodePoolCreated(log)
+	require.Error(t, err)
+}
+
+func TestPoolFactory_DecodePoolAddressesFromFactoryLog_Valid(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	log := pairCreatedLog(t, testFactoryAddress, testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+
+	addrs, err := f.DecodePoolAddressesFromFactoryLog(context.Background(), log)
+	require.NoError(t, err)
+	require.Len(t, addrs, 1)
+	assert.Equal(t, strings.ToLower(testPairAddress), strings.ToLower(addrs[0]))
+}
+
+func TestPoolFactory_DecodePoolAddressesFromFactoryLog_Invalid(t *testing.T) {
+	t.Parallel()
+	f := newTestFactory()
+	log := pairCreatedLog(t, "0x0000000000000000000000000000000000000099", testToken0Address, testToken1Address, testPairAddress, testTotalPairs)
+
+	_, err := f.DecodePoolAddressesFromFactoryLog(context.Background(), log)
+	require.Error(t, err)
+}
+
+func TestPoolFactory_FactoryAddressCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	// Config has lowercased address; log has checksummed/uppercased.
+	checksummed := strings.ToUpper(testFactoryAddress)
+	f := NewPoolFactory(&Config{
+		DexID:          testDexID,
+		FactoryAddress: checksummed, // mixed case
+	})
+	log := pairCreatedLog(t, testFactoryAddress, testToken0Address, testToken1Address, testPairAddress, 1)
+
+	_, err := f.DecodePoolCreated(log)
+	require.NoError(t, err, "factory address comparison must be case-insensitive")
+}
+
+// Sanity: the ABI must expose the PairCreated event; otherwise nothing works.
+func TestPoolFactory_ABISanity(t *testing.T) {
+	t.Parallel()
+	ev, ok := uniPoolFactoryABI.Events[factoryEventPairCreated]
+	require.True(t, ok, "PairCreated must be in the embedded factory ABI")
+	require.Len(t, ev.Inputs, 4, "PairCreated must have 4 inputs (token0, token1, pair, totalPairs)")
+
+	// Document the canonical event signature so the hash binding is auditable.
+	sig := fmt.Sprintf("%s(%s,%s,%s,%s)",
+		factoryEventPairCreated,
+		ev.Inputs[0].Type.String(),
+		ev.Inputs[1].Type.String(),
+		ev.Inputs[2].Type.String(),
+		ev.Inputs[3].Type.String(),
+	)
+	assert.Equal(t, "PairCreated(address,address,address,uint256)", sig)
+
+	// Topics layout: ID + 2 indexed args (token0, token1).
+	indexed := 0
+	for _, input := range ev.Inputs {
+		if input.Indexed {
+			indexed++
+		}
+	}
+	assert.Equal(t, 2, indexed, "exactly 2 args should be indexed")
+}

--- a/pkg/liquidity-source/unipool/pool_list_tracker_integration_test.go
+++ b/pkg/liquidity-source/unipool/pool_list_tracker_integration_test.go
@@ -1,0 +1,370 @@
+package unipool
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/test"
+)
+
+//go:embed abis/UniPoolQuoter.json
+var quoterABIJsonForTest []byte
+
+// Live RPC integration tests against UniPool on Arbitrum.
+//
+// These tests follow the repo convention (cf. ekubo, nabla): they are committed
+// to the package but skipped when the CI env var is set (test.SkipCI), so they
+// run only on developer machines. To target a private RPC (Alchemy etc.), set:
+//
+//	export ARBITRUM_RPC_URL="https://arb-mainnet.g.alchemy.com/v2/<KEY>"
+//
+// Default falls back to KyberSwap's public Arbitrum endpoint.
+
+const (
+	arbitrumDefaultRPC     = "https://arbitrum-rpc.kyberswap.com"
+	arbitrumMulticall3     = "0xcA11bde05977b3631167028862bE2a173976CA11"
+	uniPoolArbFactoryAddr  = "0xa88216E6Cf409a25c719234C4817628Ae406b6A7"
+	uniPoolArbQuoterAddr   = "0xc264944e9e7073f8f98fef7338cda973914fca44"
+	uniPoolArbWETHUSDTPair = "0x6Ce2b09bB578137130E17A0476a6adcf0ac7b0da"
+	uniPoolArbEVUSDTPair   = "0xfa896ef9659ea0dcf42c751e2b1f78f626fe8f56"
+	arbWETHAddr            = "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
+	arbUSDTAddr            = "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"
+)
+
+type PoolListTrackerIntegrationSuite struct {
+	suite.Suite
+
+	client  *ethrpc.Client
+	lister  *PoolsListUpdater
+	tracker *PoolTracker
+}
+
+func (ts *PoolListTrackerIntegrationSuite) SetupSuite() {
+	rpcURL := os.Getenv("ARBITRUM_RPC_URL")
+	if rpcURL == "" {
+		rpcURL = arbitrumDefaultRPC
+	}
+	rpcClient := ethrpc.New(rpcURL).
+		SetMulticallContract(common.HexToAddress(arbitrumMulticall3))
+	ts.client = rpcClient
+
+	cfg := &Config{
+		DexID:          DexType,
+		FactoryAddress: uniPoolArbFactoryAddr,
+		NewPoolLimit:   50,
+	}
+	ts.lister = NewPoolsListUpdater(cfg, rpcClient)
+
+	tracker, err := NewPoolTracker(cfg, rpcClient)
+	ts.Require().NoError(err)
+	ts.tracker = tracker
+}
+
+// TestListPools_ReturnsNonEmptyBatch verifies the factory pagination path.
+func (ts *PoolListTrackerIntegrationSuite) TestListPools_ReturnsNonEmptyBatch() {
+	pools, meta, err := ts.lister.GetNewPools(context.Background(), nil)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(pools, "factory should expose at least one pair")
+	ts.Require().NotEmpty(meta, "metadata should advance offset")
+
+	for i, p := range pools {
+		ts.Require().NotEmptyf(p.Address, "pool[%d].Address empty", i)
+		ts.Require().Equalf(2, len(p.Tokens), "pool[%d] must have 2 tokens", i)
+		ts.Require().NotEmptyf(p.Tokens[0].Address, "pool[%d].Tokens[0] empty", i)
+		ts.Require().NotEmptyf(p.Tokens[1].Address, "pool[%d].Tokens[1] empty", i)
+		ts.Require().Equalf(DexType, p.Type, "pool[%d].Type", i)
+		ts.Require().Equalf(DexType, p.Exchange, "pool[%d].Exchange", i)
+
+		// StaticExtra should embed our factory address.
+		ts.Require().Containsf(strings.ToLower(p.StaticExtra),
+			strings.ToLower(uniPoolArbFactoryAddr),
+			"pool[%d].StaticExtra missing factory address", i)
+	}
+}
+
+// TestListPools_PaginationAdvances verifies metadata-driven incremental paging.
+// On a small factory we may exhaust everything in the first call; in that case
+// the second call returns 0 pools and the offset must stay (not regress).
+func (ts *PoolListTrackerIntegrationSuite) TestListPools_PaginationAdvances() {
+	pools1, meta1, err := ts.lister.GetNewPools(context.Background(), nil)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(pools1)
+
+	pools2, meta2, err := ts.lister.GetNewPools(context.Background(), meta1)
+	ts.Require().NoError(err)
+
+	if len(pools2) > 0 {
+		// More pages exist: first address must change AND metadata must advance.
+		ts.Require().NotEqual(pools1[0].Address, pools2[0].Address,
+			"pagination should advance, got the same first pool twice")
+		ts.Require().NotEqualf(string(meta1), string(meta2),
+			"metadata must advance when new pools are returned")
+	} else {
+		// Factory exhausted: metadata must NOT regress (offset stays put).
+		var m1, m2 PoolsListUpdaterMetadata
+		ts.Require().NoError(json.Unmarshal(meta1, &m1))
+		ts.Require().NoError(json.Unmarshal(meta2, &m2))
+		ts.Require().Equalf(m1.Offset, m2.Offset,
+			"empty second batch must leave offset unchanged, got %d -> %d",
+			m1.Offset, m2.Offset)
+	}
+}
+
+// TestTrackWETHUSDT verifies the tracker populates Extra on a live pair with
+// reserves > 0. WETH/USDT on Arbitrum should always have liquidity.
+func (ts *PoolListTrackerIntegrationSuite) TestTrackWETHUSDT() {
+	updated, err := ts.tracker.GetNewPoolState(
+		context.Background(),
+		entity.Pool{
+			Address:  uniPoolArbWETHUSDTPair,
+			Type:     DexType,
+			Reserves: entity.PoolReserves{"0", "0"},
+			Tokens: []*entity.PoolToken{
+				{Address: arbWETHAddr, Swappable: true},
+				{Address: arbUSDTAddr, Swappable: true},
+			},
+		},
+		pool.GetNewPoolStateParams{},
+	)
+	ts.Require().NoError(err)
+
+	var extra Extra
+	ts.Require().NoError(json.Unmarshal([]byte(updated.Extra), &extra))
+
+	ts.assertNonZeroReserves(extra, "WETH/USDT")
+	ts.assertValidExtra(extra, "WETH/USDT")
+
+	// pool.Reserves slice should also reflect the on-chain reserves.
+	ts.Require().Equal(extra.Reserve0.String(), string(updated.Reserves[0]))
+	ts.Require().Equal(extra.Reserve1.String(), string(updated.Reserves[1]))
+
+	// The simulator should accept this snapshot and quote a small swap.
+	sim, err := NewPoolSimulator(updated)
+	ts.Require().NoError(err)
+
+	// 0.001 WETH (1e15) in -> some USDT out.
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: arbWETHAddr, Amount: big.NewInt(1e15)},
+		TokenOut:      arbUSDTAddr,
+	})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(res.TokenAmountOut)
+	ts.Require().Equal(1, res.TokenAmountOut.Amount.Sign(), "amountOut must be > 0")
+	ts.T().Logf("[WETH/USDT] quote: 1e15 WETH -> %s USDT (gas=%d)",
+		res.TokenAmountOut.Amount.String(), res.Gas)
+}
+
+// TestTrackEVUSDT verifies the tracker on the second known pair. EV/USDT may
+// have lower or zero liquidity depending on the moment — we only assert
+// structural validity, not reserve values.
+func (ts *PoolListTrackerIntegrationSuite) TestTrackEVUSDT() {
+	updated, err := ts.tracker.GetNewPoolState(
+		context.Background(),
+		entity.Pool{
+			Address:  uniPoolArbEVUSDTPair,
+			Type:     DexType,
+			Reserves: entity.PoolReserves{"0", "0"},
+		},
+		pool.GetNewPoolStateParams{},
+	)
+	ts.Require().NoError(err)
+
+	var extra Extra
+	ts.Require().NoError(json.Unmarshal([]byte(updated.Extra), &extra))
+
+	ts.assertValidExtra(extra, "EV/USDT")
+	ts.T().Logf("[EV/USDT] reserve0=%s reserve1=%s priceDecay=%d lastUpdate=%d fees=(%d+%d)",
+		extra.Reserve0, extra.Reserve1,
+		extra.PriceDecay, extra.LastUpdateTimestamp,
+		extra.FeeLpBps, extra.FeePoolBps)
+}
+
+// TestEndToEnd_QuoteFromListedPool exercises the full lifecycle: discover via
+// the lister, refresh via the tracker, build a simulator, run a quote.
+func (ts *PoolListTrackerIntegrationSuite) TestEndToEnd_QuoteFromListedPool() {
+	pools, _, err := ts.lister.GetNewPools(context.Background(), nil)
+	ts.Require().NoError(err)
+
+	var found *entity.Pool
+	for i := range pools {
+		if strings.EqualFold(pools[i].Address, uniPoolArbWETHUSDTPair) {
+			found = &pools[i]
+			break
+		}
+	}
+	if found == nil {
+		// WETH/USDT may be past the first page; fetch more pages until we hit it.
+		meta, _ := json.Marshal(PoolsListUpdaterMetadata{Offset: ts.lister.config.NewPoolLimit})
+		for round := 0; round < 5 && found == nil; round++ {
+			next, m, err := ts.lister.GetNewPools(context.Background(), meta)
+			ts.Require().NoError(err)
+			if len(next) == 0 {
+				break
+			}
+			for i := range next {
+				if strings.EqualFold(next[i].Address, uniPoolArbWETHUSDTPair) {
+					found = &next[i]
+					break
+				}
+			}
+			meta = m
+		}
+	}
+	ts.Require().NotNil(found, "WETH/USDT pair not exposed by factory pagination")
+
+	tracked, err := ts.tracker.GetNewPoolState(context.Background(), *found,
+		pool.GetNewPoolStateParams{})
+	ts.Require().NoError(err)
+
+	sim, err := NewPoolSimulator(tracked)
+	ts.Require().NoError(err)
+
+	// Quote both directions.
+	for _, dir := range []struct {
+		in, out string
+		amount  *big.Int
+	}{
+		{found.Tokens[0].Address, found.Tokens[1].Address, big.NewInt(1e15)},
+		{found.Tokens[1].Address, found.Tokens[0].Address, big.NewInt(1e9)},
+	} {
+		res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: dir.in, Amount: dir.amount},
+			TokenOut:      dir.out,
+		})
+		ts.Require().NoErrorf(err, "quote %s->%s failed", dir.in[:8], dir.out[:8])
+		ts.Require().Equal(1, res.TokenAmountOut.Amount.Sign())
+		ts.T().Logf("[E2E] %s -> %s : %s -> %s",
+			dir.in[:8], dir.out[:8], dir.amount, res.TokenAmountOut.Amount)
+	}
+}
+
+// ---- helpers --------------------------------------------------------------
+
+func (ts *PoolListTrackerIntegrationSuite) assertNonZeroReserves(e Extra, label string) {
+	ts.Require().Equalf(1, e.Reserve0.Sign(), "%s: reserve0 should be > 0", label)
+	ts.Require().Equalf(1, e.Reserve1.Sign(), "%s: reserve1 should be > 0", label)
+}
+
+func (ts *PoolListTrackerIntegrationSuite) assertValidExtra(e Extra, label string) {
+	ts.Require().NotNilf(e.Reserve0, "%s: Reserve0 nil", label)
+	ts.Require().NotNilf(e.Reserve1, "%s: Reserve1 nil", label)
+	ts.Require().NotNilf(e.VirtualReserve0In, "%s: VR0In nil", label)
+	ts.Require().NotNilf(e.VirtualReserve0Out, "%s: VR0Out nil", label)
+	ts.Require().NotNilf(e.VirtualReserve1In, "%s: VR1In nil", label)
+	ts.Require().NotNilf(e.VirtualReserve1Out, "%s: VR1Out nil", label)
+	ts.Require().NotNilf(e.TotalBorrowed0, "%s: TotalBorrowed0 nil", label)
+	ts.Require().NotNilf(e.TotalBorrowed1, "%s: TotalBorrowed1 nil", label)
+
+	// Fees should be in a sane range (sum strictly < BPS_DIVISOR).
+	totalFee := uint32(e.FeeLpBps) + uint32(e.FeePoolBps)
+	ts.Require().Lessf(totalFee, uint32(bpsDivisor),
+		"%s: feeLpBps+feePoolBps must be < %d, got %d", label, bpsDivisor, totalFee)
+
+	// Borrowed must never exceed reserves on-chain.
+	if e.Reserve0.Sign() > 0 {
+		ts.Require().NotEqualf(1, e.TotalBorrowed0.Cmp(e.Reserve0),
+			"%s: totalBorrowed0 > reserve0 (impossible on-chain)", label)
+	}
+	if e.Reserve1.Sign() > 0 {
+		ts.Require().NotEqualf(1, e.TotalBorrowed1.Cmp(e.Reserve1),
+			"%s: totalBorrowed1 > reserve1 (impossible on-chain)", label)
+	}
+}
+
+// TestCrossCheckQuoter is the strongest correctness check: for the same
+// (tokenIn, tokenOut, amountIn) we ask the on-chain UniPoolQuoter and our
+// off-chain simulator. The two amountsOut should match exactly when the pool
+// has no pending liquidations (the only piece our simulator skips).
+func (ts *PoolListTrackerIntegrationSuite) TestCrossCheckQuoter_WETHUSDT() {
+	quoterABI, err := abi.JSON(bytes.NewReader(quoterABIJsonForTest))
+	ts.Require().NoError(err)
+
+	// Track the pair so we have the same Extra a production simulator would see.
+	updated, err := ts.tracker.GetNewPoolState(
+		context.Background(),
+		entity.Pool{
+			Address: uniPoolArbWETHUSDTPair,
+			Type:    DexType,
+			Tokens: []*entity.PoolToken{
+				{Address: arbWETHAddr, Swappable: true},
+				{Address: arbUSDTAddr, Swappable: true},
+			},
+			Reserves: entity.PoolReserves{"0", "0"},
+		},
+		pool.GetNewPoolStateParams{},
+	)
+	ts.Require().NoError(err)
+
+	sim, err := NewPoolSimulator(updated)
+	ts.Require().NoError(err)
+
+	// Probe with several input sizes / both directions.
+	cases := []struct {
+		name        string
+		tokenIn     string
+		tokenOut    string
+		amountIn    *big.Int
+		maxAbsDiff  *big.Int // tolerance (wei) for rounding-only / micro-timing drift
+	}{
+		{"0.001 WETH -> USDT", arbWETHAddr, arbUSDTAddr, big.NewInt(1e15), big.NewInt(2)},
+		{"0.1 WETH -> USDT", arbWETHAddr, arbUSDTAddr, big.NewInt(1e17), big.NewInt(2)},
+		{"1 USDT -> WETH", arbUSDTAddr, arbWETHAddr, big.NewInt(1e6), big.NewInt(2)},
+		{"1000 USDT -> WETH", arbUSDTAddr, arbWETHAddr, big.NewInt(1e9), big.NewInt(2)},
+	}
+
+	for _, tc := range cases {
+		ts.Run(tc.name, func() {
+			// Off-chain quote.
+			ours, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{Token: tc.tokenIn, Amount: tc.amountIn},
+				TokenOut:      tc.tokenOut,
+			})
+			ts.Require().NoError(err)
+
+			// On-chain quote via UniPoolQuoter.getAmountOut(tokenIn, tokenOut, amountIn).
+			var onchain *big.Int
+			req := ts.client.NewRequest().SetContext(context.Background())
+			req.AddCall(&ethrpc.Call{
+				ABI:    quoterABI,
+				Target: uniPoolArbQuoterAddr,
+				Method: "getAmountOut",
+				Params: []any{
+					common.HexToAddress(tc.tokenIn),
+					common.HexToAddress(tc.tokenOut),
+					tc.amountIn,
+				},
+			}, []any{&onchain})
+			_, err = req.Call()
+			ts.Require().NoError(err)
+
+			diff := new(big.Int).Sub(ours.TokenAmountOut.Amount, onchain)
+			absDiff := new(big.Int).Abs(diff)
+
+			ts.T().Logf("[xcheck] %-22s simulator=%s on-chain=%s diff=%s",
+				tc.name, ours.TokenAmountOut.Amount, onchain, diff)
+
+			ts.Require().LessOrEqualf(absDiff.Cmp(tc.maxAbsDiff), 0,
+				"%s: off-chain vs on-chain quote diverges by %s wei (> tolerance %s)",
+				tc.name, absDiff, tc.maxAbsDiff)
+		})
+	}
+}
+
+func TestPoolListTrackerIntegrationSuite(t *testing.T) {
+	t.Parallel()
+	test.SkipCI(t)
+	suite.Run(t, new(PoolListTrackerIntegrationSuite))
+}

--- a/pkg/liquidity-source/unipool/pool_simulator.go
+++ b/pkg/liquidity-source/unipool/pool_simulator.go
@@ -1,0 +1,616 @@
+package unipool
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+var bpsDivisorU = uint256.NewInt(bpsDivisor)
+
+// PoolSimulator replays UniPool's swap math fully off-chain.
+//
+// State stored: real reserves at lastUpdateTimestamp, the 4 virtual reserves at
+// the same instant, plus priceDecay so we can interpolate forward at quote time
+// (mirroring UniPoolPairGetters.previewVirtualReservesElapsed). Liquidations are
+// NOT replayed (would require porting the tick state).
+type PoolSimulator struct {
+	pool.Pool
+
+	reserve0 *uint256.Int
+	reserve1 *uint256.Int
+
+	vr0In  *uint256.Int
+	vr0Out *uint256.Int
+	vr1In  *uint256.Int
+	vr1Out *uint256.Int
+
+	lastUpdateTimestamp uint64
+	priceDecay          uint64
+
+	feeLpBps   *uint256.Int
+	feePoolBps *uint256.Int
+
+	totalBorrowed0 *uint256.Int
+	totalBorrowed1 *uint256.Int
+
+	swapPriceToleranceBps uint16
+
+	gas int64
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
+	var extra Extra
+	if err := json.Unmarshal([]byte(entityPool.Extra), &extra); err != nil {
+		return nil, err
+	}
+
+	reserve0, err := fromBig(extra.Reserve0)
+	if err != nil {
+		return nil, err
+	}
+	reserve1, err := fromBig(extra.Reserve1)
+	if err != nil {
+		return nil, err
+	}
+	vr0In, err := fromBig(extra.VirtualReserve0In)
+	if err != nil {
+		return nil, err
+	}
+	vr0Out, err := fromBig(extra.VirtualReserve0Out)
+	if err != nil {
+		return nil, err
+	}
+	vr1In, err := fromBig(extra.VirtualReserve1In)
+	if err != nil {
+		return nil, err
+	}
+	vr1Out, err := fromBig(extra.VirtualReserve1Out)
+	if err != nil {
+		return nil, err
+	}
+	tb0, err := fromBig(extra.TotalBorrowed0)
+	if err != nil {
+		return nil, err
+	}
+	tb1, err := fromBig(extra.TotalBorrowed1)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := lo.Map(entityPool.Tokens, func(t *entity.PoolToken, _ int) string { return t.Address })
+	reserves := []*big.Int{reserve0.ToBig(), reserve1.ToBig()}
+
+	return &PoolSimulator{
+		Pool: pool.Pool{Info: pool.PoolInfo{
+			Address:     entityPool.Address,
+			Exchange:    entityPool.Exchange,
+			Type:        entityPool.Type,
+			Tokens:      tokens,
+			Reserves:    reserves,
+			BlockNumber: entityPool.BlockNumber,
+		}},
+		reserve0:              reserve0,
+		reserve1:              reserve1,
+		vr0In:                 vr0In,
+		vr0Out:                vr0Out,
+		vr1In:                 vr1In,
+		vr1Out:                vr1Out,
+		lastUpdateTimestamp:   extra.LastUpdateTimestamp,
+		priceDecay:            extra.PriceDecay,
+		feeLpBps:              uint256.NewInt(uint64(extra.FeeLpBps)),
+		feePoolBps:            uint256.NewInt(uint64(extra.FeePoolBps)),
+		totalBorrowed0:        tb0,
+		totalBorrowed1:        tb1,
+		swapPriceToleranceBps: extra.SwapPriceToleranceBps,
+		gas:                   defaultGas,
+	}, nil
+}
+
+func fromBig(v *big.Int) (*uint256.Int, error) {
+	if v == nil {
+		return new(uint256.Int), nil
+	}
+	out, overflow := uint256.FromBig(v)
+	if overflow {
+		return nil, ErrInvalidReserve
+	}
+	return out, nil
+}
+
+func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	tokenAmountIn, tokenOut := params.TokenAmountIn, params.TokenOut
+	indexIn, indexOut := s.GetTokenIndex(tokenAmountIn.Token), s.GetTokenIndex(tokenOut)
+	if indexIn < 0 || indexOut < 0 {
+		return nil, ErrInvalidToken
+	}
+
+	amountIn, overflow := uint256.FromBig(tokenAmountIn.Amount)
+	if overflow || amountIn.Sign() <= 0 {
+		return nil, ErrInvalidAmountIn
+	}
+
+	totalFee := new(uint256.Int).Add(s.feeLpBps, s.feePoolBps)
+	if totalFee.Cmp(bpsDivisorU) >= 0 {
+		return nil, ErrFeeExceedsMax
+	}
+
+	// Project the 4 VRs forward in time (port of previewVirtualReservesElapsed).
+	now := uint64(time.Now().Unix())
+	vr0In, vr0Out, vr1In, vr1Out := s.projectVirtualReserves(now)
+
+	// Pick the effective reserves used by the AMM (port of getSwapInfo).
+	//
+	// isToken0Out is mapped from the route direction:
+	//   if indexOut == 0 -> token0 is output -> isToken0Out = true
+	isToken0Out := indexOut == 0
+	var effIn, effOut, realIn, realOut, totalBorrowedOut *uint256.Int
+	if isToken0Out {
+		// token1 in, token0 out
+		realIn, realOut = s.reserve1, s.reserve0
+		effIn = max256(vr1In, realIn)
+		effOut = min256(vr0Out, realOut)
+		totalBorrowedOut = s.totalBorrowed0
+	} else {
+		// token0 in, token1 out
+		realIn, realOut = s.reserve0, s.reserve1
+		effIn = max256(vr0In, realIn)
+		effOut = min256(vr1Out, realOut)
+		totalBorrowedOut = s.totalBorrowed1
+	}
+
+	// Compute amountOut on the EFFECTIVE reserves (the curve the contract uses).
+	amountOut := getAmountOut(amountIn, effIn, effOut, totalFee)
+	if amountOut.Sign() <= 0 {
+		return nil, ErrInsufficientOutputAmount
+	}
+	if amountOut.Cmp(effOut) >= 0 {
+		return nil, ErrInsufficientSwapLiquidity
+	}
+
+	// Available liquidity cap: amountOut < realReserveOut - totalBorrowedOut.
+	// Borrowed tokens are physically lent out and cannot be transferred.
+	cap := new(uint256.Int)
+	if realOut.Cmp(totalBorrowedOut) <= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+	cap.Sub(realOut, totalBorrowedOut)
+	if amountOut.Cmp(cap) >= 0 {
+		return nil, ErrInsufficientSwapLiquidity
+	}
+
+	// Spread validation (port of UniPoolPairSwap._validateSpreads). The contract
+	// runs it with: post-swap reserves, the pre-swap projected VRs, and the
+	// NET amountIn (= amountIn - poolFee).
+	netAmountIn := poolFeeNetIn(amountIn, s.feePoolBps)
+	newReserveIn := new(uint256.Int).Add(realIn, netAmountIn)
+	newReserveOut := new(uint256.Int).Sub(realOut, amountOut)
+	isVrInUpdated := effIn.Cmp(realIn) != 0
+	isVrOutUpdated := effOut.Cmp(realOut) != 0
+	if err := s.validateSpreads(
+		isToken0Out, newReserveIn, newReserveOut,
+		isVrInUpdated, isVrOutUpdated,
+		netAmountIn, amountOut,
+		vr0In, vr0Out, vr1In, vr1Out,
+	); err != nil {
+		return nil, err
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: s.Info.Tokens[indexOut], Amount: amountOut.ToBig()},
+		Fee:            &pool.TokenAmount{Token: s.Info.Tokens[indexIn], Amount: big.NewInt(0)},
+		Gas:            s.gas,
+	}, nil
+}
+
+// poolFeeNetIn returns amountIn * (BPS - feePoolBps) / BPS, mirroring the on-chain
+// `netAmountIn = amountIn - poolFeeAmount` computation.
+func poolFeeNetIn(amountIn, feePoolBps *uint256.Int) *uint256.Int {
+	one := new(uint256.Int).Sub(bpsDivisorU, feePoolBps)
+	out := new(uint256.Int).Mul(amountIn, one)
+	out.Div(out, bpsDivisorU)
+	return out
+}
+
+// CalcAmountIn is the exact-out counterpart of CalcAmountOut: given a desired
+// amountOut, compute the minimum amountIn required. Port of UniPoolPairSwap's
+// `getAmountIn` (UniPoolPairSwap.sol:339-350) which rounds the division UP so
+// the user always supplies at least enough input on-chain.
+func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
+	tokenAmountOut, tokenIn := params.TokenAmountOut, params.TokenIn
+	indexIn, indexOut := s.GetTokenIndex(tokenIn), s.GetTokenIndex(tokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 {
+		return nil, ErrInvalidToken
+	}
+
+	amountOut, overflow := uint256.FromBig(tokenAmountOut.Amount)
+	if overflow || amountOut.Sign() <= 0 {
+		return nil, ErrInvalidAmountOut
+	}
+
+	totalFee := new(uint256.Int).Add(s.feeLpBps, s.feePoolBps)
+	if totalFee.Cmp(bpsDivisorU) >= 0 {
+		return nil, ErrFeeExceedsMax
+	}
+
+	now := uint64(time.Now().Unix())
+	vr0In, vr0Out, vr1In, vr1Out := s.projectVirtualReserves(now)
+
+	isToken0Out := indexOut == 0
+	var effIn, effOut, realOut, totalBorrowedOut *uint256.Int
+	if isToken0Out {
+		realOut = s.reserve0
+		effIn = max256(vr1In, s.reserve1)
+		effOut = min256(vr0Out, s.reserve0)
+		totalBorrowedOut = s.totalBorrowed0
+	} else {
+		realOut = s.reserve1
+		effIn = max256(vr0In, s.reserve0)
+		effOut = min256(vr1Out, s.reserve1)
+		totalBorrowedOut = s.totalBorrowed1
+	}
+
+	// Both bounds apply in exact-out: cannot consume more than the effective
+	// curve allows AND cannot transfer out more than reserve - borrowed.
+	if amountOut.Cmp(effOut) >= 0 {
+		return nil, ErrInsufficientSwapLiquidity
+	}
+	if realOut.Cmp(totalBorrowedOut) <= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+	cap := new(uint256.Int).Sub(realOut, totalBorrowedOut)
+	if amountOut.Cmp(cap) >= 0 {
+		return nil, ErrInsufficientSwapLiquidity
+	}
+
+	amountIn := getAmountInRoundUp(amountOut, effIn, effOut, totalFee)
+	if amountIn.Sign() <= 0 {
+		return nil, ErrInvalidAmountIn
+	}
+
+	return &pool.CalcAmountInResult{
+		TokenAmountIn: &pool.TokenAmount{Token: s.Info.Tokens[indexIn], Amount: amountIn.ToBig()},
+		Fee:           &pool.TokenAmount{Token: s.Info.Tokens[indexIn], Amount: big.NewInt(0)},
+		Gas:           s.gas,
+	}, nil
+}
+
+// getAmountInRoundUp ports UniPoolPairSwap.getAmountIn (fullMulDivUpChecked):
+//
+//	amountIn = ⌈(reserveIn * amountOut * BPS) / ((reserveOut - amountOut) * (BPS - totalFee))⌉
+//
+// On-chain reserves and amountOut are uint128, so reserveIn * amountOut fits in
+// uint256 (2 * 128 bits). Multiplying by BPS (~14 bits) can push the
+// intermediate above 2^256 in adversarial inputs. We do the rounded-up
+// 3-factor multiplication in math/big to stay precision-correct in all cases;
+// the cost is negligible since this runs once per CalcAmountIn call.
+func getAmountInRoundUp(amountOut, reserveIn, reserveOut, totalFee *uint256.Int) *uint256.Int {
+	if reserveOut.Cmp(amountOut) <= 0 {
+		// amountOut >= reserveOut: undefined output, return 0 (caller rejects).
+		return new(uint256.Int)
+	}
+
+	rIn := reserveIn.ToBig()
+	aOut := amountOut.ToBig()
+	rOut := reserveOut.ToBig()
+	fee := totalFee.ToBig()
+	bps := big.NewInt(int64(bpsDivisor))
+
+	numerator := new(big.Int).Mul(rIn, aOut)
+	numerator.Mul(numerator, bps)
+
+	denominator := new(big.Int).Sub(rOut, aOut)
+	denominator.Mul(denominator, new(big.Int).Sub(bps, fee))
+	if denominator.Sign() == 0 {
+		return new(uint256.Int)
+	}
+
+	// ceil(num / den) = (num + den - 1) / den
+	tmp := new(big.Int).Sub(denominator, big.NewInt(1))
+	tmp.Add(tmp, numerator)
+	tmp.Quo(tmp, denominator)
+
+	out, overflow := uint256.FromBig(tmp)
+	if overflow {
+		// amountIn that overflows uint256 is unreachable on-chain anyway
+		// (the contract caps amounts to uint128). Return 0 so the caller's
+		// `Sign() <= 0` guard kicks in and rejects the request.
+		return new(uint256.Int)
+	}
+	return out
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.reserve0 = new(uint256.Int).Set(s.reserve0)
+	cloned.reserve1 = new(uint256.Int).Set(s.reserve1)
+	cloned.vr0In = new(uint256.Int).Set(s.vr0In)
+	cloned.vr0Out = new(uint256.Int).Set(s.vr0Out)
+	cloned.vr1In = new(uint256.Int).Set(s.vr1In)
+	cloned.vr1Out = new(uint256.Int).Set(s.vr1Out)
+	cloned.totalBorrowed0 = new(uint256.Int).Set(s.totalBorrowed0)
+	cloned.totalBorrowed1 = new(uint256.Int).Set(s.totalBorrowed1)
+
+	// Deep-copy the embedded pool.Pool.Info.Reserves slice — `cloned := *s`
+	// only shallow-copies the slice header, so the backing array would
+	// otherwise be shared and UpdateBalance on the clone would mutate the
+	// original.
+	if s.Info.Reserves != nil {
+		clonedReserves := make([]*big.Int, len(s.Info.Reserves))
+		for i, r := range s.Info.Reserves {
+			if r != nil {
+				clonedReserves[i] = new(big.Int).Set(r)
+			}
+		}
+		cloned.Info.Reserves = clonedReserves
+	}
+	return &cloned
+}
+
+// UpdateBalance applies a swap to local state so subsequent CalcAmountOut calls
+// on the same simulator see the post-swap reserves.
+//
+// We mirror the on-chain UniPoolPairSwap.swap finalization (lines ~221-231):
+//   - real reserves: in += netAmountIn (= amountIn * (BPS - feePoolBps)/BPS), out -= amountOut
+//   - virtualReserveIn  of input token  set to effectiveIn + netAmountIn  (if it was clamped up)
+//   - virtualReserveOut of output token set to effectiveOut - amountOut   (if it was clamped down)
+//
+// The "other" two VRs (in-side of output token, out-side of input token) are not
+// touched by the swap; they continue to decay normally.
+//
+// We also reset lastUpdateTimestamp to the wall clock so subsequent calls use
+// elapsed=0, matching the contract's State.updateState() behavior.
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	indexIn := s.GetTokenIndex(params.TokenAmountIn.Token)
+	indexOut := s.GetTokenIndex(params.TokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 {
+		return
+	}
+
+	amtIn, _ := uint256.FromBig(params.TokenAmountIn.Amount)
+	amtOut, _ := uint256.FromBig(params.TokenAmountOut.Amount)
+	if amtIn == nil || amtOut == nil {
+		return
+	}
+
+	netAmountIn := poolFeeNetIn(amtIn, s.feePoolBps)
+
+	now := uint64(time.Now().Unix())
+	vr0In, vr0Out, vr1In, vr1Out := s.projectVirtualReserves(now)
+
+	var reserveIn, reserveOut, effIn, effOut, newReserveIn, newReserveOut *uint256.Int
+	if indexOut == 0 {
+		reserveIn, reserveOut = s.reserve1, s.reserve0
+		effIn = max256(vr1In, reserveIn)
+		effOut = min256(vr0Out, reserveOut)
+	} else {
+		reserveIn, reserveOut = s.reserve0, s.reserve1
+		effIn = max256(vr0In, reserveIn)
+		effOut = min256(vr1Out, reserveOut)
+	}
+	newReserveIn = new(uint256.Int).Add(reserveIn, netAmountIn)
+	newReserveOut = new(uint256.Int).Sub(reserveOut, amtOut)
+
+	// Write back real reserves.
+	if indexOut == 0 {
+		s.reserve1.Set(newReserveIn)
+		s.reserve0.Set(newReserveOut)
+	} else {
+		s.reserve0.Set(newReserveIn)
+		s.reserve1.Set(newReserveOut)
+	}
+
+	// Update VR_in of input token if MEV protection was active on the in side.
+	if effIn.Cmp(reserveIn) != 0 {
+		newVRIn := new(uint256.Int).Add(effIn, netAmountIn)
+		if indexOut == 0 {
+			s.vr1In.Set(newVRIn)
+		} else {
+			s.vr0In.Set(newVRIn)
+		}
+	}
+	// Update VR_out of output token if MEV protection was active on the out side.
+	if effOut.Cmp(reserveOut) != 0 {
+		newVROut := new(uint256.Int).Sub(effOut, amtOut)
+		if indexOut == 0 {
+			s.vr0Out.Set(newVROut)
+		} else {
+			s.vr1Out.Set(newVROut)
+		}
+	}
+
+	// On-chain, every state-changing call refreshes lastUpdateTimestamp to
+	// block.timestamp. Mirror that so the next projection uses elapsed=0.
+	s.lastUpdateTimestamp = now
+
+	// Update the parent reserves slice used by some router code paths.
+	s.Info.Reserves[0] = s.reserve0.ToBig()
+	s.Info.Reserves[1] = s.reserve1.ToBig()
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any { return nil }
+
+// projectVirtualReserves replays UniPoolPairGetters.previewVirtualReservesElapsed:
+//
+//	if elapsed >= decay : VR  = reserve
+//	else                : VR  = (VR_stored*(decay-elapsed) + reserve*elapsed) / decay
+//
+// We use *uint256.Int to stay within the contract's domain (uint128 reserves,
+// uint128 VRs, decay <= a few minutes — no overflow risk in the multiplications).
+func (s *PoolSimulator) projectVirtualReserves(now uint64) (vr0In, vr0Out, vr1In, vr1Out *uint256.Int) {
+	// Match the contract's three-way split in previewVirtualReservesElapsed:
+	//   elapsed == 0          -> stored VRs (no time passed)
+	//   elapsed >= priceDecay -> VR == reserve (fully converged; covers decay==0)
+	//   else                  -> linear interpolation
+	if now <= s.lastUpdateTimestamp {
+		return new(uint256.Int).Set(s.vr0In), new(uint256.Int).Set(s.vr0Out),
+			new(uint256.Int).Set(s.vr1In), new(uint256.Int).Set(s.vr1Out)
+	}
+	elapsed := now - s.lastUpdateTimestamp
+	if s.priceDecay == 0 || elapsed >= s.priceDecay {
+		return new(uint256.Int).Set(s.reserve0), new(uint256.Int).Set(s.reserve0),
+			new(uint256.Int).Set(s.reserve1), new(uint256.Int).Set(s.reserve1)
+	}
+
+	decay := uint256.NewInt(s.priceDecay)
+	elapsedU := uint256.NewInt(elapsed)
+	diffU := new(uint256.Int).Sub(decay, elapsedU)
+
+	r0Elapsed := new(uint256.Int).Mul(elapsedU, s.reserve0)
+	r1Elapsed := new(uint256.Int).Mul(elapsedU, s.reserve1)
+
+	vr0In = interpolate(s.vr0In, diffU, r0Elapsed, decay)
+	vr0Out = interpolate(s.vr0Out, diffU, r0Elapsed, decay)
+	vr1In = interpolate(s.vr1In, diffU, r1Elapsed, decay)
+	vr1Out = interpolate(s.vr1Out, diffU, r1Elapsed, decay)
+	return
+}
+
+func interpolate(vrStored, diff, reserveElapsed, decay *uint256.Int) *uint256.Int {
+	tmp := new(uint256.Int).Mul(vrStored, diff)
+	tmp.Add(tmp, reserveElapsed)
+	return tmp.Div(tmp, decay)
+}
+
+// getAmountOut is the port of UniPoolPairSwap.getAmountOut (CPMM with bps fees):
+//
+//	amountInWithFee = amountIn * (BPS - totalFee)
+//	amountOut       = (reserveOut * amountInWithFee) / (reserveIn * BPS + amountInWithFee)
+func getAmountOut(amountIn, reserveIn, reserveOut, totalFee *uint256.Int) *uint256.Int {
+	amountInWithFee := new(uint256.Int).Sub(bpsDivisorU, totalFee)
+	amountInWithFee.Mul(amountIn, amountInWithFee)
+
+	denominator := new(uint256.Int).Mul(reserveIn, bpsDivisorU)
+	denominator.Add(denominator, amountInWithFee)
+	if denominator.Sign() == 0 {
+		return new(uint256.Int)
+	}
+
+	numerator := new(uint256.Int).Mul(reserveOut, amountInWithFee)
+	return numerator.Div(numerator, denominator)
+}
+
+func max256(a, b *uint256.Int) *uint256.Int {
+	if a.Cmp(b) >= 0 {
+		return a
+	}
+	return b
+}
+
+func min256(a, b *uint256.Int) *uint256.Int {
+	if a.Cmp(b) <= 0 {
+		return a
+	}
+	return b
+}
+
+// validateSpreads is the port of UniPoolPairSwap._validateSpreads.
+//
+// It bounds the spread between the AMM mid-price and the buy/sell prices induced
+// by the swap. The contract reverts with UniPoolPairExcessiveSpread if any of the
+// two |Δprice| / midprice ratios exceeds swapPriceToleranceBps.
+//
+// We compute in math/big to avoid uint256 overflow on the `abs * BPS` and
+// `tolerance * comp` products (worst case ~2^286).
+func (s *PoolSimulator) validateSpreads(
+	isToken0Out bool,
+	newReserveIn, newReserveOut *uint256.Int,
+	isVrInUpdated, isVrOutUpdated bool,
+	netAmountIn, amountOut *uint256.Int,
+	vr0In, vr0Out, vr1In, vr1Out *uint256.Int,
+) error {
+	if s.swapPriceToleranceBps == swapPriceToleranceDisabled {
+		return nil
+	}
+
+	toBI := func(u *uint256.Int) *big.Int { return u.ToBig() }
+	bigMax := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) >= 0 {
+			return a
+		}
+		return b
+	}
+	bigMin := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) <= 0 {
+			return a
+		}
+		return b
+	}
+
+	rIn := toBI(newReserveIn)
+	rOut := toBI(newReserveOut)
+	nAmtIn := toBI(netAmountIn)
+	aOut := toBI(amountOut)
+	v0InB, v0OutB := toBI(vr0In), toBI(vr0Out)
+	v1InB, v1OutB := toBI(vr1In), toBI(vr1Out)
+	bpsBI := big.NewInt(bpsDivisor)
+	tolBI := big.NewInt(int64(s.swapPriceToleranceBps))
+
+	// check enforces:  |rL*maxVal - rR*minVal| * BPS  <=  tolerance * min(rR*minVal, rL*maxVal)
+	check := func(maxVal, minVal, rL, rR *big.Int) error {
+		rLmax := new(big.Int).Mul(rL, maxVal)
+		rRmin := new(big.Int).Mul(rR, minVal)
+		abs := new(big.Int).Sub(rLmax, rRmin)
+		abs.Abs(abs)
+		comp := bigMin(rRmin, rLmax)
+		lhs := new(big.Int).Mul(abs, bpsBI)
+		rhs := new(big.Int).Mul(tolBI, comp)
+		if lhs.Cmp(rhs) > 0 {
+			return ErrExcessiveSpread
+		}
+		return nil
+	}
+
+	if isToken0Out {
+		// Check 1: buy-side, uses POST-update virtual reserves on the touched sides.
+		var inVR *big.Int
+		if isVrInUpdated {
+			inVR = new(big.Int).Add(v1InB, nAmtIn)
+		} else {
+			inVR = v1InB
+		}
+		var outVR *big.Int
+		if isVrOutUpdated {
+			outVR = new(big.Int).Sub(v0OutB, aOut)
+		} else {
+			outVR = v0OutB
+		}
+		if err := check(bigMax(rIn, inVR), bigMin(rOut, outVR), rOut, rIn); err != nil {
+			return err
+		}
+		// Check 2: sell-side, uses pre-swap (projected) virtual reserves untouched.
+		if err := check(bigMax(rOut, v0InB), bigMin(rIn, v1OutB), rIn, rOut); err != nil {
+			return err
+		}
+	} else {
+		// Check 1: sell-side, pre-swap VRs.
+		if err := check(bigMax(rOut, v1InB), bigMin(rIn, v0OutB), rIn, rOut); err != nil {
+			return err
+		}
+		// Check 2: buy-side, post-update VRs.
+		var inVR *big.Int
+		if isVrInUpdated {
+			inVR = new(big.Int).Add(v0InB, nAmtIn)
+		} else {
+			inVR = v0InB
+		}
+		var outVR *big.Int
+		if isVrOutUpdated {
+			outVR = new(big.Int).Sub(v1OutB, aOut)
+		} else {
+			outVR = v1OutB
+		}
+		if err := check(bigMax(rIn, inVR), bigMin(rOut, outVR), rOut, rIn); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/liquidity-source/unipool/pool_simulator_test.go
+++ b/pkg/liquidity-source/unipool/pool_simulator_test.go
@@ -810,7 +810,7 @@ func TestNewPoolSimulator_H1c_NullBigIntsTolerated(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// I. Token mapping symetry
+// I. Token mapping symmetry
 // ---------------------------------------------------------------------------
 
 func TestTokenMapping_I1_LexicoOrder(t *testing.T) {

--- a/pkg/liquidity-source/unipool/pool_simulator_test.go
+++ b/pkg/liquidity-source/unipool/pool_simulator_test.go
@@ -1,0 +1,1037 @@
+package unipool
+
+import (
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers / fixtures
+// ---------------------------------------------------------------------------
+
+const (
+	tokenA = "0x000000000000000000000000000000000000000a"
+	tokenB = "0x000000000000000000000000000000000000000b"
+
+	// "non lexico" pair (token0 > token1) to verify we don't assume ordering.
+	tokenC = "0x00000000000000000000000000000000000000ff"
+	tokenD = "0x0000000000000000000000000000000000000011"
+)
+
+// makeExtra builds a default Extra (all VRs == reserves, no fees, no spread
+// guard, no borrowed). Tests override fields as needed.
+func makeExtra(reserve0, reserve1 *big.Int) Extra {
+	return Extra{
+		Reserve0:              new(big.Int).Set(reserve0),
+		Reserve1:              new(big.Int).Set(reserve1),
+		VirtualReserve0In:     new(big.Int).Set(reserve0),
+		VirtualReserve0Out:    new(big.Int).Set(reserve0),
+		VirtualReserve1In:     new(big.Int).Set(reserve1),
+		VirtualReserve1Out:    new(big.Int).Set(reserve1),
+		LastUpdateTimestamp:   uint64(time.Now().Unix()),
+		PriceDecay:            300,
+		FeeLpBps:              0,
+		FeePoolBps:            0,
+		TotalBorrowed0:        big.NewInt(0),
+		TotalBorrowed1:        big.NewInt(0),
+		SwapPriceToleranceBps: math.MaxUint16, // disabled
+	}
+}
+
+// makePool wraps the entity.Pool boilerplate and instantiates a simulator.
+func makePool(t *testing.T, token0, token1 string, extra Extra) *PoolSimulator {
+	t.Helper()
+	extraBytes, err := json.Marshal(extra)
+	require.NoError(t, err)
+	ep := entity.Pool{
+		Address:  "0xpool",
+		Exchange: "unipool",
+		Type:     DexType,
+		Tokens: []*entity.PoolToken{
+			{Address: token0, Swappable: true},
+			{Address: token1, Swappable: true},
+		},
+		Extra: string(extraBytes),
+	}
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+	return sim
+}
+
+// solidityAmountOut ports UniPoolPairSwap.getAmountOut for cross-checking.
+//
+//	amountInWithFee = amountIn * (BPS - totalFee)
+//	amountOut       = (reserveOut * amountInWithFee) / (reserveIn * BPS + amountInWithFee)
+func solidityAmountOut(amountIn, reserveIn, reserveOut *big.Int, totalFeeBps uint64) *big.Int {
+	bps := big.NewInt(int64(bpsDivisor))
+	netBps := new(big.Int).Sub(bps, new(big.Int).SetUint64(totalFeeBps))
+	amountInWithFee := new(big.Int).Mul(amountIn, netBps)
+	denominator := new(big.Int).Add(new(big.Int).Mul(reserveIn, bps), amountInWithFee)
+	if denominator.Sign() == 0 {
+		return big.NewInt(0)
+	}
+	numerator := new(big.Int).Mul(reserveOut, amountInWithFee)
+	return new(big.Int).Quo(numerator, denominator)
+}
+
+// pow10 returns 10**n as a *big.Int.
+func pow10(n int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(n)), nil)
+}
+
+// ---------------------------------------------------------------------------
+// A. CalcAmountOut basique
+// ---------------------------------------------------------------------------
+
+func TestCalcAmountOut_A1_Token0ToToken1_EqualReserves(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// add a small fee so amountOut < amountIn even at equal reserves
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16) // 0.01e18
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.TokenAmountOut)
+
+	out := res.TokenAmountOut.Amount
+	assert.Equal(t, 1, out.Sign(), "amountOut must be > 0")
+	assert.True(t, out.Cmp(amountIn) < 0, "amountOut must be < amountIn (fees)")
+
+	// Cross-check against the Solidity formula.
+	want := solidityAmountOut(amountIn, r, r, 30)
+	assert.Equal(t, 0, out.Cmp(want), "want %s got %s", want, out)
+
+	// Fee is reported as zero (port note: pool only tracks Fee at zero today).
+	assert.Equal(t, 0, res.Fee.Amount.Sign())
+	assert.Equal(t, tokenB, res.TokenAmountOut.Token)
+	assert.Equal(t, int64(defaultGas), res.Gas)
+}
+
+func TestCalcAmountOut_A2_Token1ToToken0_Symmetry(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+
+	res01, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+
+	// Fresh sim because UpdateBalance is not called between calls — but reserves
+	// are symmetric so the two directions must yield the exact same amountOut.
+	sim2 := makePool(t, tokenA, tokenB, extra)
+	res10, err := sim2.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenB, Amount: amountIn},
+		TokenOut:      tokenA,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, res01.TokenAmountOut.Amount.Cmp(res10.TokenAmountOut.Amount),
+		"symmetric reserves must give the same out: 0->1=%s 1->0=%s",
+		res01.TokenAmountOut.Amount, res10.TokenAmountOut.Amount)
+}
+
+func TestCalcAmountOut_A3_DustAmountIn(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := big.NewInt(1)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+
+	// With reserve = 1e18 and amountIn = 1, the numerator after the fee bps mul
+	// is 9970 while the denominator is ~1e22 -> integer division rounds to 0.
+	// The simulator should return ErrInsufficientOutputAmount in that case.
+	if err == nil {
+		assert.NotNil(t, res)
+		assert.Equal(t, 1, res.TokenAmountOut.Amount.Sign())
+	} else {
+		assert.ErrorIs(t, err, ErrInsufficientOutputAmount)
+	}
+}
+
+func TestCalcAmountOut_A4_HugeAmountIn(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	// amountIn = 10x reserve — well below uint256 overflow but huge for the curve.
+	amountIn := new(big.Int).Mul(r, big.NewInt(10))
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	out := res.TokenAmountOut.Amount
+	// amountOut must be strictly less than the (effective) reserveOut.
+	assert.True(t, out.Cmp(r) < 0, "amountOut (%s) must stay below reserveOut (%s)", out, r)
+	// And clearly close to reserveOut: at 10x reserveIn we expect well over 50%.
+	half := new(big.Int).Rsh(r, 1)
+	assert.True(t, out.Cmp(half) > 0, "amountOut should be most of reserveOut, got %s", out)
+}
+
+// ---------------------------------------------------------------------------
+// B. Erreurs attendues
+// ---------------------------------------------------------------------------
+
+func TestCalcAmountOut_B1_UnknownTokenIn(t *testing.T) {
+	t.Parallel()
+	sim := makePool(t, tokenA, tokenB, makeExtra(pow10(18), pow10(18)))
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: "0xdeadbeef", Amount: big.NewInt(1)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestCalcAmountOut_B2_UnknownTokenOut(t *testing.T) {
+	t.Parallel()
+	sim := makePool(t, tokenA, tokenB, makeExtra(pow10(18), pow10(18)))
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: big.NewInt(1)},
+		TokenOut:      "0xdeadbeef",
+	})
+	assert.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestCalcAmountOut_B3_ZeroAmountIn(t *testing.T) {
+	t.Parallel()
+	sim := makePool(t, tokenA, tokenB, makeExtra(pow10(18), pow10(18)))
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: big.NewInt(0)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrInvalidAmountIn)
+}
+
+func TestCalcAmountOut_B3b_NegativeAmountIn(t *testing.T) {
+	t.Parallel()
+	sim := makePool(t, tokenA, tokenB, makeExtra(pow10(18), pow10(18)))
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: big.NewInt(-1)},
+		TokenOut:      tokenB,
+	})
+	// uint256.FromBig either flags overflow or the Sign() <= 0 branch trips.
+	assert.ErrorIs(t, err, ErrInvalidAmountIn)
+}
+
+func TestCalcAmountOut_B4_AmountInAboveReserve_GetsCaught(t *testing.T) {
+	t.Parallel()
+	// amountIn > reserveIn AND most of the output is borrowed. The combination
+	// pushes the curve output above the available real cap and must be caught.
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.TotalBorrowed1 = new(big.Int).Sub(r, big.NewInt(1)) // cap = 1 wei
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := new(big.Int).Mul(r, big.NewInt(10)) // 10x reserveIn
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.Error(t, err)
+	// Either of the two swap-liquidity error paths is acceptable; both express
+	// "trade can't physically settle".
+	assert.True(t,
+		err == ErrInsufficientSwapLiquidity || err == ErrInsufficientLiquidity,
+		"want swap or liquidity error, got %v", err)
+}
+
+func TestCalcAmountOut_B5_FeeAtOrAboveBPS(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 6000
+	extra.FeePoolBps = 4000 // sum == 10_000 == BPS
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrFeeExceedsMax)
+}
+
+func TestCalcAmountOut_B5b_FeeWayAboveBPS(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 9000
+	extra.FeePoolBps = 9000 // sum > 10_000
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrFeeExceedsMax)
+}
+
+// ---------------------------------------------------------------------------
+// C. Virtual reserve decay (projectVirtualReserves)
+// ---------------------------------------------------------------------------
+
+func TestProjectVR_C1_ElapsedZero_ReturnsStored(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	extra := makeExtra(r0, r1)
+	// stored VRs different from reserves so we can tell them apart
+	extra.VirtualReserve0In = pow10(20)
+	extra.VirtualReserve0Out = pow10(19)
+	extra.VirtualReserve1In = pow10(17)
+	extra.VirtualReserve1Out = pow10(16)
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000 // in the future
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	v0In, v0Out, v1In, v1Out := sim.projectVirtualReserves(uint64(time.Now().Unix()))
+	assert.Equal(t, 0, v0In.ToBig().Cmp(pow10(20)))
+	assert.Equal(t, 0, v0Out.ToBig().Cmp(pow10(19)))
+	assert.Equal(t, 0, v1In.ToBig().Cmp(pow10(17)))
+	assert.Equal(t, 0, v1Out.ToBig().Cmp(pow10(16)))
+}
+
+func TestProjectVR_C2_ElapsedExceedsDecay_EqualsReserves(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), new(big.Int).Mul(pow10(18), big.NewInt(2))
+	extra := makeExtra(r0, r1)
+	extra.VirtualReserve0In = pow10(20)
+	extra.VirtualReserve0Out = pow10(19)
+	extra.VirtualReserve1In = pow10(17)
+	extra.VirtualReserve1Out = pow10(16)
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) - 10_000 // far in the past
+	extra.PriceDecay = 300
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	v0In, v0Out, v1In, v1Out := sim.projectVirtualReserves(uint64(time.Now().Unix()))
+	assert.Equal(t, 0, v0In.ToBig().Cmp(r0))
+	assert.Equal(t, 0, v0Out.ToBig().Cmp(r0))
+	assert.Equal(t, 0, v1In.ToBig().Cmp(r1))
+	assert.Equal(t, 0, v1Out.ToBig().Cmp(r1))
+}
+
+func TestProjectVR_C3_PartialInterpolation(t *testing.T) {
+	t.Parallel()
+	r0 := big.NewInt(1_000_000)
+	r1 := big.NewInt(4_000_000)
+	extra := makeExtra(r0, r1)
+	extra.VirtualReserve0In = big.NewInt(2_000_000)
+	extra.VirtualReserve0Out = big.NewInt(500_000)
+	extra.VirtualReserve1In = big.NewInt(8_000_000)
+	extra.VirtualReserve1Out = big.NewInt(1_000_000)
+	extra.PriceDecay = 200
+	// Set lastUpdate so that elapsed == 100 at "now".
+	now := uint64(time.Now().Unix())
+	extra.LastUpdateTimestamp = now - 100
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	v0In, v0Out, v1In, v1Out := sim.projectVirtualReserves(now)
+
+	// formula: VR = (stored * (decay-elapsed) + reserve * elapsed) / decay
+	// elapsed=100, decay=200, diff=100
+	// vr0In = (2_000_000*100 + 1_000_000*100) / 200 = 300_000_000/200 = 1_500_000
+	assert.Equal(t, "1500000", v0In.ToBig().String())
+	// vr0Out = (500_000*100 + 1_000_000*100)/200 = 150_000_000/200 = 750_000
+	assert.Equal(t, "750000", v0Out.ToBig().String())
+	// vr1In = (8_000_000*100 + 4_000_000*100)/200 = 1_200_000_000/200 = 6_000_000
+	assert.Equal(t, "6000000", v1In.ToBig().String())
+	// vr1Out = (1_000_000*100 + 4_000_000*100)/200 = 500_000_000/200 = 2_500_000
+	assert.Equal(t, "2500000", v1Out.ToBig().String())
+}
+
+// priceDecay == 0 with positive elapsed mirrors the contract's `elapsed >= decay`
+// branch: virtual reserves snap to the real reserves immediately.
+func TestProjectVR_C4_DecayZero_Elapsed_SnapsToReal(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	extra := makeExtra(r0, r1)
+	extra.VirtualReserve0In = pow10(20)
+	extra.VirtualReserve0Out = pow10(19)
+	extra.VirtualReserve1In = pow10(17)
+	extra.VirtualReserve1Out = pow10(16)
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) - 5_000
+	extra.PriceDecay = 0
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	v0In, v0Out, v1In, v1Out := sim.projectVirtualReserves(uint64(time.Now().Unix()))
+	assert.Equal(t, 0, v0In.ToBig().Cmp(r0))
+	assert.Equal(t, 0, v0Out.ToBig().Cmp(r0))
+	assert.Equal(t, 0, v1In.ToBig().Cmp(r1))
+	assert.Equal(t, 0, v1Out.ToBig().Cmp(r1))
+}
+
+// priceDecay == 0 AND elapsed == 0: contract's early-return path takes precedence.
+func TestProjectVR_C4b_DecayZero_NoElapsed_KeepsStored(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	extra := makeExtra(r0, r1)
+	extra.VirtualReserve0In = pow10(20)
+	extra.VirtualReserve0Out = pow10(19)
+	extra.VirtualReserve1In = pow10(17)
+	extra.VirtualReserve1Out = pow10(16)
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000 // now <= lastUpdate
+	extra.PriceDecay = 0
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	v0In, v0Out, v1In, v1Out := sim.projectVirtualReserves(uint64(time.Now().Unix()))
+	assert.Equal(t, 0, v0In.ToBig().Cmp(pow10(20)))
+	assert.Equal(t, 0, v0Out.ToBig().Cmp(pow10(19)))
+	assert.Equal(t, 0, v1In.ToBig().Cmp(pow10(17)))
+	assert.Equal(t, 0, v1Out.ToBig().Cmp(pow10(16)))
+}
+
+// ---------------------------------------------------------------------------
+// D. Effective reserves (MEV protection)
+// ---------------------------------------------------------------------------
+
+func TestEffectiveReserves_D1_VRInAboveReserveIn(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// Make VR0In strictly larger than reserve0 -> effIn = VR0In (token0 in).
+	extra.VirtualReserve0In = new(big.Int).Mul(r, big.NewInt(2))
+	// VRs frozen for the test (elapsed=0).
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+
+	// Curve uses effIn = 2e18 instead of 1e18, so amountOut must match.
+	want := solidityAmountOut(amountIn, new(big.Int).Mul(r, big.NewInt(2)), r, 0)
+	assert.Equal(t, 0, res.TokenAmountOut.Amount.Cmp(want),
+		"want %s got %s", want, res.TokenAmountOut.Amount)
+
+	// And clearly smaller than a swap done on plain reserves.
+	wantPlain := solidityAmountOut(amountIn, r, r, 0)
+	assert.True(t, res.TokenAmountOut.Amount.Cmp(wantPlain) < 0)
+}
+
+func TestEffectiveReserves_D2_VROutBelowReserveOut(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// Token0 in, Token1 out: effOut = min(VR1Out, reserve1). Make VR1Out half.
+	extra.VirtualReserve1Out = new(big.Int).Rsh(r, 1)
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000 // freeze VRs
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+
+	half := new(big.Int).Rsh(r, 1)
+	want := solidityAmountOut(amountIn, r, half, 0)
+	assert.Equal(t, 0, res.TokenAmountOut.Amount.Cmp(want),
+		"want %s got %s", want, res.TokenAmountOut.Amount)
+}
+
+func TestEffectiveReserves_D3_VREqualsReserve_NoMEVImpact(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r) // all VRs == reserves
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+
+	want := solidityAmountOut(amountIn, r, r, 30)
+	assert.Equal(t, 0, res.TokenAmountOut.Amount.Cmp(want))
+}
+
+// ---------------------------------------------------------------------------
+// E. Borrowed cap
+// ---------------------------------------------------------------------------
+
+func TestBorrowedCap_E1_AmountOutBelowAvailable_OK(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// Borrow some of token1: 10% of reserve1.
+	extra.TotalBorrowed1 = new(big.Int).Div(r, big.NewInt(10))
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.TokenAmountOut.Amount.Sign() > 0)
+}
+
+func TestBorrowedCap_E2_AmountOutExceedsCap_Errors(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// Borrow 99.9999...% of token1 reserve. Any positive output trips the cap.
+	extra.TotalBorrowed1 = new(big.Int).Sub(r, big.NewInt(1))
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrInsufficientSwapLiquidity)
+}
+
+func TestBorrowedCap_E3_BorrowedEqualsReserve_Errors(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.TotalBorrowed1 = new(big.Int).Set(r) // borrowed == reserve
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
+}
+
+func TestBorrowedCap_E3b_BorrowedAboveReserve_Errors(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.TotalBorrowed1 = new(big.Int).Add(r, big.NewInt(1))
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
+}
+
+// ---------------------------------------------------------------------------
+// F. validateSpreads
+// ---------------------------------------------------------------------------
+
+func TestSpread_F1_DisabledSentinel_NeverErrors(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// VRs absurdly far from reserves: would normally trip spreads.
+	extra.VirtualReserve0In = new(big.Int).Mul(r, big.NewInt(1000))
+	extra.VirtualReserve1Out = new(big.Int).Div(r, big.NewInt(1000))
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000 // freeze
+	extra.SwapPriceToleranceBps = math.MaxUint16                   // disabled
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.NoError(t, err)
+}
+
+func TestSpread_F2_VRsAlignedWithReserves_NoError(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r) // VR_*=reserves
+	extra.SwapPriceToleranceBps = 100
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(15)},
+		TokenOut:      tokenB,
+	})
+	assert.NoError(t, err)
+}
+
+func TestSpread_F3_VRsFarFromReserves_TripsSpread(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	// Token0 in -> effIn = max(VR0In, r0). Inflate VR0In by 10x to force a huge
+	// gap between post-update reserveIn and the spread reference.
+	extra.VirtualReserve0In = new(big.Int).Mul(r, big.NewInt(10))
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000 // freeze
+	extra.SwapPriceToleranceBps = 100                              // 1%
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrExcessiveSpread)
+}
+
+func TestSpread_F4_ToleranceZero_RevertsOnAnySwap(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r) // perfectly aligned reserves & VRs
+	extra.SwapPriceToleranceBps = 0
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	// Any non-trivial swap makes new reserves drift from the (unchanged) VRs.
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenOut:      tokenB,
+	})
+	assert.ErrorIs(t, err, ErrExcessiveSpread)
+}
+
+// ---------------------------------------------------------------------------
+// G. CloneState + UpdateBalance
+// ---------------------------------------------------------------------------
+
+func TestCloneState_G1_IndependentReserves(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	cloned := sim.CloneState().(*PoolSimulator)
+
+	// Mutate clone via UpdateBalance.
+	cloned.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenA, Amount: pow10(16)},
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: pow10(15)},
+	})
+
+	// Original must be untouched.
+	assert.Equal(t, 0, sim.reserve0.ToBig().Cmp(r),
+		"original reserve0 mutated: got %s", sim.reserve0.ToBig())
+	assert.Equal(t, 0, sim.reserve1.ToBig().Cmp(r),
+		"original reserve1 mutated: got %s", sim.reserve1.ToBig())
+	// And the parent slice too.
+	assert.Equal(t, 0, sim.Info.Reserves[0].Cmp(r))
+	assert.Equal(t, 0, sim.Info.Reserves[1].Cmp(r))
+
+	// Clone must have moved.
+	assert.NotEqual(t, 0, cloned.reserve0.ToBig().Cmp(r))
+	assert.NotEqual(t, 0, cloned.reserve1.ToBig().Cmp(r))
+}
+
+func TestUpdateBalance_G2_PostUpdateAffectsNextCalc(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	res1, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: res1.TokenAmountOut.Amount},
+	})
+
+	// After the swap reserve0 grew and reserve1 shrank.
+	assert.True(t, sim.reserve0.ToBig().Cmp(r) > 0)
+	assert.True(t, sim.reserve1.ToBig().Cmp(r) < 0)
+	// Info.Reserves mirror must follow.
+	assert.Equal(t, 0, sim.Info.Reserves[0].Cmp(sim.reserve0.ToBig()))
+	assert.Equal(t, 0, sim.Info.Reserves[1].Cmp(sim.reserve1.ToBig()))
+
+	// Second swap of same amount yields strictly less because reserveIn went up
+	// and reserveOut went down.
+	res2, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+	assert.True(t, res2.TokenAmountOut.Amount.Cmp(res1.TokenAmountOut.Amount) < 0,
+		"second swap should yield less: r1=%s r2=%s",
+		res1.TokenAmountOut.Amount, res2.TokenAmountOut.Amount)
+}
+
+func TestUpdateBalance_G2b_UnknownTokenSilentlyIgnored(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	sim := makePool(t, tokenA, tokenB, makeExtra(r, r))
+	before0, before1 := new(big.Int).Set(sim.reserve0.ToBig()), new(big.Int).Set(sim.reserve1.ToBig())
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: "0xdeadbeef", Amount: big.NewInt(1)},
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: big.NewInt(1)},
+	})
+
+	assert.Equal(t, 0, sim.reserve0.ToBig().Cmp(before0))
+	assert.Equal(t, 0, sim.reserve1.ToBig().Cmp(before1))
+}
+
+// ---------------------------------------------------------------------------
+// H. JSON round-trip via NewPoolSimulator
+// ---------------------------------------------------------------------------
+
+func TestNewPoolSimulator_H1_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	r0 := pow10(18)
+	r1 := new(big.Int).Mul(pow10(18), big.NewInt(3))
+	extra := Extra{
+		Reserve0:              r0,
+		Reserve1:              r1,
+		VirtualReserve0In:     pow10(20),
+		VirtualReserve0Out:    pow10(19),
+		VirtualReserve1In:     pow10(17),
+		VirtualReserve1Out:    pow10(16),
+		LastUpdateTimestamp:   1_700_000_000,
+		PriceDecay:            299,
+		FeeLpBps:              30,
+		FeePoolBps:            5,
+		TotalBorrowed0:        pow10(10),
+		TotalBorrowed1:        pow10(11),
+		SwapPriceToleranceBps: 250,
+	}
+	extraBytes, err := json.Marshal(extra)
+	require.NoError(t, err)
+
+	ep := entity.Pool{
+		Address:  "0xabc",
+		Exchange: "unipool",
+		Type:     DexType,
+		Tokens: []*entity.PoolToken{
+			{Address: tokenA, Swappable: true},
+			{Address: tokenB, Swappable: true},
+		},
+		BlockNumber: 42,
+		Extra:       string(extraBytes),
+	}
+
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	assert.Equal(t, "0xabc", sim.Info.Address)
+	assert.Equal(t, "unipool", sim.Info.Exchange)
+	assert.Equal(t, DexType, sim.Info.Type)
+	assert.Equal(t, uint64(42), sim.Info.BlockNumber)
+	require.Len(t, sim.Info.Tokens, 2)
+	assert.Equal(t, tokenA, sim.Info.Tokens[0])
+	assert.Equal(t, tokenB, sim.Info.Tokens[1])
+
+	assert.Equal(t, 0, sim.reserve0.ToBig().Cmp(r0))
+	assert.Equal(t, 0, sim.reserve1.ToBig().Cmp(r1))
+	assert.Equal(t, 0, sim.vr0In.ToBig().Cmp(pow10(20)))
+	assert.Equal(t, 0, sim.vr0Out.ToBig().Cmp(pow10(19)))
+	assert.Equal(t, 0, sim.vr1In.ToBig().Cmp(pow10(17)))
+	assert.Equal(t, 0, sim.vr1Out.ToBig().Cmp(pow10(16)))
+	assert.Equal(t, uint64(1_700_000_000), sim.lastUpdateTimestamp)
+	assert.Equal(t, uint64(299), sim.priceDecay)
+	assert.Equal(t, uint64(30), sim.feeLpBps.Uint64())
+	assert.Equal(t, uint64(5), sim.feePoolBps.Uint64())
+	assert.Equal(t, 0, sim.totalBorrowed0.ToBig().Cmp(pow10(10)))
+	assert.Equal(t, 0, sim.totalBorrowed1.ToBig().Cmp(pow10(11)))
+	assert.Equal(t, uint16(250), sim.swapPriceToleranceBps)
+	assert.Equal(t, int64(defaultGas), sim.gas)
+
+	// Info.Reserves slice mirrors the typed reserves.
+	require.Len(t, sim.Info.Reserves, 2)
+	assert.Equal(t, 0, sim.Info.Reserves[0].Cmp(r0))
+	assert.Equal(t, 0, sim.Info.Reserves[1].Cmp(r1))
+}
+
+func TestNewPoolSimulator_H1b_InvalidJSON_Errors(t *testing.T) {
+	t.Parallel()
+	_, err := NewPoolSimulator(entity.Pool{
+		Tokens: []*entity.PoolToken{{Address: tokenA}, {Address: tokenB}},
+		Extra:  "not-json",
+	})
+	assert.Error(t, err)
+}
+
+func TestNewPoolSimulator_H1c_NullBigIntsTolerated(t *testing.T) {
+	t.Parallel()
+	// fromBig() treats nil as zero. Hand-craft a JSON blob where every big.Int
+	// field is JSON `null` to verify NewPoolSimulator accepts that.
+	extraJSON := `{
+		"reserve0": null,
+		"reserve1": null,
+		"vr0In": null,
+		"vr0Out": null,
+		"vr1In": null,
+		"vr1Out": null,
+		"lastUpdateTs": 1700000000,
+		"priceDecay": 299,
+		"feeLpBps": 0,
+		"feePoolBps": 0,
+		"totalBorrowed0": null,
+		"totalBorrowed1": null,
+		"swapPriceToleranceBps": 65535
+	}`
+	sim, err := NewPoolSimulator(entity.Pool{
+		Tokens: []*entity.PoolToken{{Address: tokenA}, {Address: tokenB}},
+		Type:   DexType,
+		Extra:  extraJSON,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), sim.reserve0.Uint64())
+	assert.Equal(t, uint64(0), sim.reserve1.Uint64())
+	assert.Equal(t, uint64(0), sim.totalBorrowed0.Uint64())
+	assert.Equal(t, uint64(0), sim.totalBorrowed1.Uint64())
+}
+
+// ---------------------------------------------------------------------------
+// I. Token mapping symetry
+// ---------------------------------------------------------------------------
+
+func TestTokenMapping_I1_LexicoOrder(t *testing.T) {
+	t.Parallel()
+	// token0 < token1 (tokenA < tokenB lexically by hex).
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+	out01 := res.TokenAmountOut.Amount
+	want01 := solidityAmountOut(amountIn, r, r, 30)
+	assert.Equal(t, 0, out01.Cmp(want01))
+}
+
+func TestTokenMapping_I1b_ReverseOrder(t *testing.T) {
+	t.Parallel()
+	// token0 > token1 (tokenC = 0x..ff > tokenD = 0x..11).
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.FeeLpBps = 30
+	sim := makePool(t, tokenC, tokenD, extra)
+
+	amountIn := pow10(16)
+
+	// Swap "token0" (tokenC) -> "token1" (tokenD): indexIn=0, indexOut=1.
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenC, Amount: amountIn},
+		TokenOut:      tokenD,
+	})
+	require.NoError(t, err)
+	want := solidityAmountOut(amountIn, r, r, 30)
+	assert.Equal(t, 0, res.TokenAmountOut.Amount.Cmp(want),
+		"out != want despite reversed lexico order")
+
+	// And the reverse direction must produce the same number too (symmetric reserves).
+	sim2 := makePool(t, tokenC, tokenD, extra)
+	res2, err := sim2.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenD, Amount: amountIn},
+		TokenOut:      tokenC,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.TokenAmountOut.Amount.Cmp(res2.TokenAmountOut.Amount))
+
+	// Verify the simulator maps indices the way the entity ordered them
+	// (no implicit sort).
+	assert.Equal(t, 0, sim.GetTokenIndex(tokenC), "tokenC must remain at index 0")
+	assert.Equal(t, 1, sim.GetTokenIndex(tokenD), "tokenD must remain at index 1")
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers exercised by the simulator
+// ---------------------------------------------------------------------------
+
+func TestHelpers_MaxMin256(t *testing.T) {
+	t.Parallel()
+	a := uint256.NewInt(10)
+	b := uint256.NewInt(20)
+	assert.Equal(t, b, max256(a, b))
+	assert.Equal(t, b, max256(b, a))
+	assert.Equal(t, a, min256(a, b))
+	assert.Equal(t, a, min256(b, a))
+	// Equal case: max picks `a` (>=), min picks `a` (<=).
+	c := uint256.NewInt(10)
+	assert.Equal(t, a, max256(a, c))
+	assert.Equal(t, a, min256(a, c))
+}
+
+func TestHelpers_PoolFeeNetIn(t *testing.T) {
+	t.Parallel()
+	// 1_000 in @ 5 bps fee -> 1_000 * (10_000-5) / 10_000 = 999 (floor).
+	got := poolFeeNetIn(uint256.NewInt(1000), uint256.NewInt(5))
+	assert.Equal(t, uint64(999), got.Uint64())
+	// Zero pool fee is a no-op.
+	got = poolFeeNetIn(uint256.NewInt(1000), uint256.NewInt(0))
+	assert.Equal(t, uint64(1000), got.Uint64())
+}
+
+func TestHelpers_GetAmountOut_MatchesSolidity(t *testing.T) {
+	t.Parallel()
+	in := uint256.NewInt(125_224_746)
+	rIn := uint256.MustFromDecimal("10089138480746")
+	rOut := uint256.MustFromDecimal("10066716097576")
+	totalFee := uint256.NewInt(30) // 0.3%
+
+	got := getAmountOut(in, rIn, rOut, totalFee)
+	want := solidityAmountOut(in.ToBig(), rIn.ToBig(), rOut.ToBig(), 30)
+	assert.Equal(t, 0, got.ToBig().Cmp(want),
+		"port mismatch: want %s got %s", want, got.ToBig())
+}
+
+// ---------------------------------------------------------------------------
+// J. CalcAmountIn (exact-out routing)
+// ---------------------------------------------------------------------------
+
+// solidityAmountIn mirrors UniPoolPairSwap.getAmountIn:
+//
+//	amountIn = ⌈(reserveIn * amountOut * BPS) / ((reserveOut - amountOut) * (BPS - totalFee))⌉
+func solidityAmountIn(amountOut, reserveIn, reserveOut *big.Int, totalFeeBps uint64) *big.Int {
+	bps := big.NewInt(int64(bpsDivisor))
+	num := new(big.Int).Mul(reserveIn, amountOut)
+	num.Mul(num, bps)
+	den := new(big.Int).Sub(reserveOut, amountOut)
+	den.Mul(den, new(big.Int).Sub(bps, new(big.Int).SetUint64(totalFeeBps)))
+	if den.Sign() == 0 {
+		return big.NewInt(0)
+	}
+	// ceil division
+	one := big.NewInt(1)
+	tmp := new(big.Int).Sub(den, one)
+	tmp.Add(tmp, num)
+	return tmp.Quo(tmp, den)
+}
+
+func TestCalcAmountIn_J1_Basic(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	extra := makeExtra(r0, r1)
+	extra.FeeLpBps = 25
+	extra.FeePoolBps = 5
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountOut := pow10(16) // 0.01 of reserve1
+	res, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: amountOut},
+		TokenIn:        tokenA,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Cross-check against the Solidity formula port.
+	expected := solidityAmountIn(amountOut, r0, r1, 30)
+	assert.Equal(t, 0, res.TokenAmountIn.Amount.Cmp(expected),
+		"want %s got %s", expected, res.TokenAmountIn.Amount)
+}
+
+// J2: round-trip — feed CalcAmountOut's result back into CalcAmountIn and
+// verify we recover the original amountIn (modulo the +1 wei ceil overhead).
+func TestCalcAmountIn_J2_RoundTrip(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	extra := makeExtra(r0, r1)
+	extra.FeeLpBps = 25
+	extra.FeePoolBps = 5
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	amountIn := pow10(16)
+	out, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: amountIn},
+		TokenOut:      tokenB,
+	})
+	require.NoError(t, err)
+
+	back, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: out.TokenAmountOut.Amount},
+		TokenIn:        tokenA,
+	})
+	require.NoError(t, err)
+
+	// Round-trip property: amountOut = floor(f(X)) loses fractional output, so
+	// the minimum input ceil(g(amountOut)) needed to PRODUCE that floored
+	// output is ≤ the original X. (If amountOut were the exact non-floored
+	// value, back would equal X. With floor, back can be at most X, and at
+	// least X minus a small wei budget.)
+	diff := new(big.Int).Sub(amountIn, back.TokenAmountIn.Amount)
+	assert.True(t, diff.Sign() >= 0,
+		"back must not exceed amountIn (rounding makes it ≤): diff=%s", diff)
+	assert.True(t, diff.Cmp(big.NewInt(2)) <= 0,
+		"rounding slack must be tiny: diff=%s", diff)
+}
+
+func TestCalcAmountIn_J3_InvalidToken(t *testing.T) {
+	t.Parallel()
+	sim := makePool(t, tokenA, tokenB, makeExtra(pow10(18), pow10(18)))
+	_, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: "0xdeadbeef", Amount: pow10(15)},
+		TokenIn:        tokenA,
+	})
+	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestCalcAmountIn_J4_AmountOutNonPositive(t *testing.T) {
+	t.Parallel()
+	sim := makePool(t, tokenA, tokenB, makeExtra(pow10(18), pow10(18)))
+	_, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: big.NewInt(0)},
+		TokenIn:        tokenA,
+	})
+	require.ErrorIs(t, err, ErrInvalidAmountOut)
+}
+
+func TestCalcAmountIn_J5_AmountOutAboveEffOut(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	sim := makePool(t, tokenA, tokenB, makeExtra(r0, r1))
+	// Request the entire reserveOut: must reject (curve asymptotes here).
+	_, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: r1},
+		TokenIn:        tokenA,
+	})
+	require.ErrorIs(t, err, ErrInsufficientSwapLiquidity)
+}
+
+func TestCalcAmountIn_J6_BorrowedCap(t *testing.T) {
+	t.Parallel()
+	r0, r1 := pow10(18), pow10(18)
+	extra := makeExtra(r0, r1)
+	// 99% of token1 is locked in loans.
+	extra.TotalBorrowed1 = new(big.Int).Sub(r1, big.NewInt(100))
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	// Trying to pull out 1000 wei of token1 -> only 100 wei are spendable.
+	_, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: tokenB, Amount: big.NewInt(1000)},
+		TokenIn:        tokenA,
+	})
+	require.ErrorIs(t, err, ErrInsufficientSwapLiquidity)
+}

--- a/pkg/liquidity-source/unipool/pool_tracker.go
+++ b/pkg/liquidity-source/unipool/pool_tracker.go
@@ -1,0 +1,145 @@
+package unipool
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE(DexType, NewPoolTracker)
+
+func NewPoolTracker(config *Config, ethrpcClient *ethrpc.Client) (*PoolTracker, error) {
+	return &PoolTracker{config: config, ethrpcClient: ethrpcClient}, nil
+}
+
+// rpcState bundles the per-pool storage values we need from the pair.
+//
+// Why these and not previewReserves: we store the raw (un-interpolated) snapshot at
+// lastUpdateTimestamp so the off-chain simulator can replay the virtual-reserve
+// decay in Go at quote time, matching previewVirtualReservesElapsed.
+type rpcState struct {
+	reserves              reservesABI
+	virtualReserves       virtualReservesABI
+	lastUpdateTimestamp   *big.Int
+	priceDecay            *big.Int
+	fees                  feesBpsABI
+	totalBorrowed0        *big.Int
+	totalBorrowed1        *big.Int
+	swapPriceToleranceBps uint16
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	start := time.Now()
+	logger.WithFields(logger.Fields{"pool_id": p.Address}).Info("Started getting new pool state")
+
+	state, blockNumber, err := t.fetchState(ctx, p.Address)
+	if err != nil {
+		return p, err
+	}
+	if p.BlockNumber > blockNumber {
+		logger.WithFields(logger.Fields{
+			"pool_id":           p.Address,
+			"pool_block_number": p.BlockNumber,
+			"data_block_number": blockNumber,
+		}).Info("skip update: data block number is less than current pool block number")
+		return p, nil
+	}
+
+	extra := Extra{
+		Reserve0:              state.reserves.Reserve0,
+		Reserve1:              state.reserves.Reserve1,
+		VirtualReserve0In:     state.virtualReserves.VirtualReserve0In,
+		VirtualReserve0Out:    state.virtualReserves.VirtualReserve0Out,
+		VirtualReserve1In:     state.virtualReserves.VirtualReserve1In,
+		VirtualReserve1Out:    state.virtualReserves.VirtualReserve1Out,
+		LastUpdateTimestamp:   state.lastUpdateTimestamp.Uint64(),
+		PriceDecay:            state.priceDecay.Uint64(),
+		FeeLpBps:              state.fees.FeeLpBps,
+		FeePoolBps:            state.fees.FeePoolBps,
+		TotalBorrowed0:        state.totalBorrowed0,
+		TotalBorrowed1:        state.totalBorrowed1,
+		SwapPriceToleranceBps: state.swapPriceToleranceBps,
+	}
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return p, err
+	}
+
+	p.Reserves = entity.PoolReserves{
+		state.reserves.Reserve0.String(),
+		state.reserves.Reserve1.String(),
+	}
+	p.Extra = string(extraBytes)
+	p.BlockNumber = blockNumber
+	p.Timestamp = time.Now().Unix()
+
+	logger.WithFields(logger.Fields{
+		"pool_id":     p.Address,
+		"block":       blockNumber,
+		"duration_ms": time.Since(start).Milliseconds(),
+	}).Info("Finished getting new pool state")
+
+	return p, nil
+}
+
+func (t *PoolTracker) fetchState(ctx context.Context, pairAddress string) (*rpcState, uint64, error) {
+	state := &rpcState{
+		reserves:            reservesABI{Reserve0: new(big.Int), Reserve1: new(big.Int)},
+		virtualReserves:     virtualReservesABI{},
+		lastUpdateTimestamp: new(big.Int),
+		priceDecay:          new(big.Int),
+		totalBorrowed0:      new(big.Int),
+		totalBorrowed1:      new(big.Int),
+	}
+
+	// getVirtualReserves returns a single tuple. go-ethereum's abi.copyAtomic
+	// (accounts/abi/argument.go:131-138) takes `dst.Field(0)` when the receiver
+	// is a struct, so the tuple destination must be wrapped in a parent struct
+	// with one field of the target type. Without this wrapper, the unpacker
+	// silently fails with "cannot unmarshal struct in to *big.Int" and the VR
+	// fields stay nil.
+	var vrRecv struct{ Reserves virtualReservesABI }
+
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetReserves},
+		[]any{&state.reserves})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetVirtualReserves},
+		[]any{&vrRecv})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetLastUpdateTimestamp},
+		[]any{&state.lastUpdateTimestamp})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetPriceDecay},
+		[]any{&state.priceDecay})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetFeesBps},
+		[]any{&state.fees})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetTotalBorrowed0},
+		[]any{&state.totalBorrowed0})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetTotalBorrowed1},
+		[]any{&state.totalBorrowed1})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pairAddress, Method: pairMethodGetSwapPriceToleranceBps},
+		[]any{&state.swapPriceToleranceBps})
+
+	resp, err := req.TryBlockAndAggregate()
+	if err != nil {
+		return nil, 0, err
+	}
+	state.virtualReserves = vrRecv.Reserves
+	return state, resp.BlockNumber.Uint64(), nil
+}

--- a/pkg/liquidity-source/unipool/pool_tracker_test.go
+++ b/pkg/liquidity-source/unipool/pool_tracker_test.go
@@ -1,0 +1,119 @@
+package unipool
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+// NOTE: The tracker's main path (fetchState) hits an RPC node, so a full
+// integration test requires a deployed UniPool instance. These tests cover the
+// pieces that DON'T require network: instantiation and the Extra ↔ JSON ↔
+// simulator round-trip the tracker is expected to produce.
+//
+// Live integration coverage will be added under //go:build integration once
+// UniPool is deployed (cf. nabla / integral patterns in this repo).
+
+func TestNewPoolTracker_Smoke(t *testing.T) {
+	t.Parallel()
+	tracker, err := NewPoolTracker(&Config{
+		DexID:          "unipool",
+		FactoryAddress: "0x1234567890123456789012345678901234567890",
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tracker)
+	assert.NotNil(t, tracker.config)
+}
+
+// TestTrackerProducedExtra_IsConsumedBySimulator verifies the contract between
+// what the tracker serialises into entity.Pool.Extra and what NewPoolSimulator
+// expects to read. The Extra struct is the only handover surface; if its
+// shape ever drifts, this test will catch it.
+func TestTrackerProducedExtra_IsConsumedBySimulator(t *testing.T) {
+	t.Parallel()
+
+	// Build the exact same Extra struct the tracker would serialise after a
+	// successful fetchState (see pool_tracker.go GetNewPoolState).
+	extra := Extra{
+		Reserve0:              new(big.Int).SetUint64(1_000_000),
+		Reserve1:              new(big.Int).SetUint64(2_000_000),
+		VirtualReserve0In:     new(big.Int).SetUint64(1_100_000),
+		VirtualReserve0Out:    new(big.Int).SetUint64(900_000),
+		VirtualReserve1In:     new(big.Int).SetUint64(2_100_000),
+		VirtualReserve1Out:    new(big.Int).SetUint64(1_900_000),
+		LastUpdateTimestamp:   uint64(time.Now().Unix()),
+		PriceDecay:            300,
+		FeeLpBps:              25,
+		FeePoolBps:            5,
+		TotalBorrowed0:        new(big.Int).SetUint64(50_000),
+		TotalBorrowed1:        new(big.Int).SetUint64(100_000),
+		SwapPriceToleranceBps: 500,
+	}
+	extraBytes, err := json.Marshal(extra)
+	require.NoError(t, err)
+
+	entityPool := entity.Pool{
+		Address:  "0xcccccccccccccccccccccccccccccccccccccccc",
+		Exchange: "unipool",
+		Type:     DexType,
+		Reserves: entity.PoolReserves{"1000000", "2000000"},
+		Tokens: []*entity.PoolToken{
+			{Address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Swappable: true},
+			{Address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Swappable: true},
+		},
+		Extra:       string(extraBytes),
+		StaticExtra: `{"factoryAddress":"0x1234567890123456789012345678901234567890"}`,
+		BlockNumber: 12345,
+	}
+
+	sim, err := NewPoolSimulator(entityPool)
+	require.NoError(t, err)
+	require.NotNil(t, sim)
+
+	// Spot-check that all dynamic fields landed in the simulator.
+	assert.Equal(t, "1000000", sim.reserve0.Dec())
+	assert.Equal(t, "2000000", sim.reserve1.Dec())
+	assert.Equal(t, "1100000", sim.vr0In.Dec())
+	assert.Equal(t, "900000", sim.vr0Out.Dec())
+	assert.Equal(t, "2100000", sim.vr1In.Dec())
+	assert.Equal(t, "1900000", sim.vr1Out.Dec())
+	assert.Equal(t, extra.LastUpdateTimestamp, sim.lastUpdateTimestamp)
+	assert.Equal(t, uint64(300), sim.priceDecay)
+	assert.Equal(t, "25", sim.feeLpBps.Dec())
+	assert.Equal(t, "5", sim.feePoolBps.Dec())
+	assert.Equal(t, "50000", sim.totalBorrowed0.Dec())
+	assert.Equal(t, "100000", sim.totalBorrowed1.Dec())
+	assert.Equal(t, uint16(500), sim.swapPriceToleranceBps)
+}
+
+// zeroExtra (used by both factory and list-updater at discovery time) must
+// also be consumable by the simulator without crashing — even though it
+// represents a not-yet-tracked pool with all-zero state.
+func TestZeroExtra_IsConsumedBySimulator(t *testing.T) {
+	t.Parallel()
+	extra := zeroExtra()
+	extraBytes, err := json.Marshal(extra)
+	require.NoError(t, err)
+
+	entityPool := entity.Pool{
+		Address: "0xc0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ff",
+		Type:    DexType,
+		Tokens: []*entity.PoolToken{
+			{Address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			{Address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		},
+		Reserves: entity.PoolReserves{"0", "0"},
+		Extra:    string(extraBytes),
+	}
+	sim, err := NewPoolSimulator(entityPool)
+	require.NoError(t, err)
+	require.NotNil(t, sim)
+	assert.Equal(t, "0", sim.reserve0.Dec())
+	assert.Equal(t, "0", sim.reserve1.Dec())
+}

--- a/pkg/liquidity-source/unipool/pool_tracker_test.go
+++ b/pkg/liquidity-source/unipool/pool_tracker_test.go
@@ -12,13 +12,9 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 )
 
-// NOTE: The tracker's main path (fetchState) hits an RPC node, so a full
-// integration test requires a deployed UniPool instance. These tests cover the
-// pieces that DON'T require network: instantiation and the Extra ↔ JSON ↔
-// simulator round-trip the tracker is expected to produce.
-//
-// Live integration coverage will be added under //go:build integration once
-// UniPool is deployed (cf. nabla / integral patterns in this repo).
+// NOTE: The tracker's main path (fetchState) hits an RPC node, so these tests
+// focus on the pieces that DON'T require network: instantiation and the
+// Extra ↔ JSON ↔ simulator round-trip the tracker is expected to produce.
 
 func TestNewPoolTracker_Smoke(t *testing.T) {
 	t.Parallel()

--- a/pkg/liquidity-source/unipool/pools_list_updater.go
+++ b/pkg/liquidity-source/unipool/pools_list_updater.go
@@ -1,0 +1,195 @@
+package unipool
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type (
+	PoolsListUpdater struct {
+		config       *Config
+		ethrpcClient *ethrpc.Client
+	}
+
+	PoolsListUpdaterMetadata struct {
+		Offset int `json:"offset"`
+	}
+)
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: cfg, ethrpcClient: ethrpcClient}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	startTime := time.Now()
+	dexID := u.config.DexID
+
+	logger.WithFields(logger.Fields{"dex_id": dexID}).Info("Started getting new pools")
+
+	allPairsLength, err := u.getAllPairsLength(ctx)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Error("getAllPairsLength failed")
+		return nil, metadataBytes, err
+	}
+
+	offset, err := u.getOffset(metadataBytes)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Warn("getOffset failed")
+	}
+
+	batchSize := u.getBatchSize(allPairsLength, u.config.NewPoolLimit, offset)
+
+	pairAddresses, err := u.listPairAddresses(ctx, offset, batchSize)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Error("listPairAddresses failed")
+		return nil, metadataBytes, err
+	}
+
+	pools, err := u.initPools(ctx, pairAddresses)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Error("initPools failed")
+		return nil, metadataBytes, err
+	}
+
+	newMetadataBytes, err := u.newMetadata(offset + batchSize)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Error("newMetadata failed")
+		return nil, metadataBytes, err
+	}
+
+	logger.WithFields(logger.Fields{
+		"dex_id":      dexID,
+		"pools_len":   len(pools),
+		"offset":      offset,
+		"duration_ms": time.Since(startTime).Milliseconds(),
+	}).Info("Finished getting new pools")
+
+	return pools, newMetadataBytes, nil
+}
+
+func (u *PoolsListUpdater) getAllPairsLength(ctx context.Context) (int, error) {
+	var allPairsLength *big.Int
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{
+		ABI:    uniPoolFactoryABI,
+		Target: u.config.FactoryAddress,
+		Method: factoryMethodGetAllPairsLength,
+	}, []any{&allPairsLength})
+
+	if _, err := req.Call(); err != nil {
+		return 0, err
+	}
+	return int(allPairsLength.Int64()), nil
+}
+
+func (u *PoolsListUpdater) getOffset(metadataBytes []byte) (int, error) {
+	if len(metadataBytes) == 0 {
+		return 0, nil
+	}
+	var m PoolsListUpdaterMetadata
+	if err := json.Unmarshal(metadataBytes, &m); err != nil {
+		return 0, err
+	}
+	return m.Offset, nil
+}
+
+func (u *PoolsListUpdater) listPairAddresses(ctx context.Context, offset, batchSize int) ([]common.Address, error) {
+	results := make([]common.Address, batchSize)
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i := 0; i < batchSize; i++ {
+		req.AddCall(&ethrpc.Call{
+			ABI:    uniPoolFactoryABI,
+			Target: u.config.FactoryAddress,
+			Method: factoryMethodGetPairAtIndex,
+			Params: []any{big.NewInt(int64(offset + i))},
+		}, []any{&results[i]})
+	}
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+
+	pairs := make([]common.Address, 0, batchSize)
+	for i, ok := range resp.Result {
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, results[i])
+	}
+	return pairs, nil
+}
+
+func (u *PoolsListUpdater) initPools(ctx context.Context, pairAddresses []common.Address) ([]entity.Pool, error) {
+	if len(pairAddresses) == 0 {
+		return nil, nil
+	}
+
+	tokenResults := make([]tokensABI, len(pairAddresses))
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i, addr := range pairAddresses {
+		req.AddCall(&ethrpc.Call{
+			ABI:    uniPoolPairABI,
+			Target: addr.Hex(),
+			Method: pairMethodGetTokens,
+		}, []any{&tokenResults[i]})
+	}
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+
+	staticExtra := StaticExtra{FactoryAddress: u.config.FactoryAddress}
+	staticExtraBytes, err := json.Marshal(staticExtra)
+	if err != nil {
+		return nil, err
+	}
+
+	extra := zeroExtra()
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return nil, err
+	}
+
+	pools := make([]entity.Pool, 0, len(pairAddresses))
+	for i, pairAddr := range pairAddresses {
+		pools = append(pools, entity.Pool{
+			Address:   hexutil.Encode(pairAddr[:]),
+			Exchange:  u.config.DexID,
+			Type:      DexType,
+			Timestamp: time.Now().Unix(),
+			Reserves:  entity.PoolReserves{"0", "0"},
+			Tokens: []*entity.PoolToken{
+				{Address: hexutil.Encode(tokenResults[i].Token0[:]), Swappable: true},
+				{Address: hexutil.Encode(tokenResults[i].Token1[:]), Swappable: true},
+			},
+			Extra:       string(extraBytes),
+			StaticExtra: string(staticExtraBytes),
+		})
+	}
+	return pools, nil
+}
+
+func (u *PoolsListUpdater) newMetadata(newOffset int) ([]byte, error) {
+	return json.Marshal(PoolsListUpdaterMetadata{Offset: newOffset})
+}
+
+func (u *PoolsListUpdater) getBatchSize(length, limit, offset int) int {
+	if offset >= length {
+		return 0
+	}
+	if offset+limit >= length {
+		return length - offset
+	}
+	return limit
+}

--- a/pkg/liquidity-source/unipool/types.go
+++ b/pkg/liquidity-source/unipool/types.go
@@ -1,0 +1,87 @@
+package unipool
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Extra is the dynamic per-pool state serialized into entity.Pool.Extra.
+//
+// All values are raw storage snapshots from the pair (not projected to current time):
+// the simulator interpolates the virtual reserves forward at quote time using
+// LastUpdateTimestamp + PriceDecay, mirroring the on-chain previewVirtualReservesElapsed.
+type Extra struct {
+	Reserve0 *big.Int `json:"reserve0"`
+	Reserve1 *big.Int `json:"reserve1"`
+
+	VirtualReserve0In  *big.Int `json:"vr0In"`
+	VirtualReserve0Out *big.Int `json:"vr0Out"`
+	VirtualReserve1In  *big.Int `json:"vr1In"`
+	VirtualReserve1Out *big.Int `json:"vr1Out"`
+
+	LastUpdateTimestamp uint64 `json:"lastUpdateTs"`
+	PriceDecay          uint64 `json:"priceDecay"`
+
+	FeeLpBps   uint16 `json:"feeLpBps"`
+	FeePoolBps uint16 `json:"feePoolBps"`
+
+	TotalBorrowed0 *big.Int `json:"totalBorrowed0"`
+	TotalBorrowed1 *big.Int `json:"totalBorrowed1"`
+
+	// SwapPriceToleranceBps caps the spread between the AMM mid-price and the
+	// buy/sell prices implied by the swap. Disabled if equal to math.MaxUint16.
+	SwapPriceToleranceBps uint16 `json:"swapPriceToleranceBps"`
+}
+
+// StaticExtra is the immutable per-pool data serialized into entity.Pool.StaticExtra.
+type StaticExtra struct {
+	FactoryAddress string `json:"factoryAddress"`
+}
+
+// zeroExtra returns an Extra with all big.Int fields freshly allocated to 0.
+// Used at pool discovery time (factory event or list updater) when the real
+// state hasn't been tracked yet.
+func zeroExtra() Extra {
+	return Extra{
+		Reserve0:           big.NewInt(0),
+		Reserve1:           big.NewInt(0),
+		VirtualReserve0In:  big.NewInt(0),
+		VirtualReserve0Out: big.NewInt(0),
+		VirtualReserve1In:  big.NewInt(0),
+		VirtualReserve1Out: big.NewInt(0),
+		TotalBorrowed0:     big.NewInt(0),
+		TotalBorrowed1:     big.NewInt(0),
+	}
+}
+
+// --- ABI receiver structs ---------------------------------------------------
+
+// virtualReservesABI mirrors the Solidity `VirtualReserves` struct returned by
+// pair.getVirtualReserves(). Field names match the tuple component names so the
+// go-ethereum ABI unpacker can map them by PascalCase.
+type virtualReservesABI struct {
+	VirtualReserve0In  *big.Int
+	VirtualReserve0Out *big.Int
+	VirtualReserve1In  *big.Int
+	VirtualReserve1Out *big.Int
+}
+
+// reservesABI receives pair.getReserves() => (uint256 reserve0, uint256 reserve1).
+type reservesABI struct {
+	Reserve0 *big.Int
+	Reserve1 *big.Int
+}
+
+// feesBpsABI receives pair.getFeesBps() => (uint16 feeLpBps, uint16 feePoolBps, uint16 burnFeeBps).
+type feesBpsABI struct {
+	FeeLpBps   uint16
+	FeePoolBps uint16
+	BurnFeeBps uint16
+}
+
+// tokensABI receives pair.getTokens() => (address token0, address token1).
+type tokensABI struct {
+	Token0 common.Address
+	Token1 common.Address
+}

--- a/pkg/pooltypes/factory_test.go
+++ b/pkg/pooltypes/factory_test.go
@@ -48,8 +48,8 @@ func TestCanCalcAmountIn(t *testing.T) {
 		"curve-stable-plain", "curve-tricrypto-ng", "curve-twocrypto-ng", "deltaswap-v1", "dodo-classical", "ekubo",
 		"ekubo-v3", "euler-swap", "fluid-dex-t1", "iziswap", "limit-order", "liquiditybook-v21", "baseline",
 		"maverick-v1", "muteswitch", "pancake-v3", "ringswap", "sky-psm", "slipstream", "solidly-v2", "solidly-v3",
-		"swap-x-v2", "syncswap-classic", "syncswap-stable", "syncswapv2-classic", "syncswapv2-stable", "uniswap-v1",
-		"uniswap-v2", "uniswap-v4", "uniswapv3", "velodrome", "velodrome-v2", "virtual-fun"}
+		"swap-x-v2", "syncswap-classic", "syncswap-stable", "syncswapv2-classic", "syncswapv2-stable", "unipool",
+		"uniswap-v1", "uniswap-v2", "uniswap-v4", "uniswapv3", "velodrome", "velodrome-v2", "virtual-fun"}
 	for _, tt := range dexes {
 		t.Run(tt, func(t *testing.T) {
 			assert.Contains(t, pool.CanCalcAmountIn, tt)
@@ -88,7 +88,7 @@ func TestPoolListerFactory(t *testing.T) {
 		"sfrxeth-convertor", "etherfi-vampire", "algebra-integral", "virtual-fun", "beets-ss", "swap-x-v2",
 		"etherfi-ebtc", "uniswap-v4", "sky-psm", "honey", "curve-llamma", "curve-lending", "balancer-v3-eclp", "ekubo",
 		"ekubo-v3", "erc4626", "hyeth", "brownfi", "midas", "arbera-den", "cusd", "arbera-zap", "kelp-rseth-l2",
-		"valantis-stex", "nabla", "lunarbase"}
+		"unipool", "valantis-stex", "nabla", "lunarbase"}
 
 	for _, poolLister := range poolListers {
 		t.Run(poolLister, func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestPoolTrackerFactory(t *testing.T) {
 		"ringswap", "generic-simple-rate", "primeeth", "staderethx", "meth", "ondo-usdy", "deltaswap-v1", "sfrxeth",
 		"sfrxeth-convertor", "etherfi-vampire", "algebra-integral", "virtual-fun", "beets-ss", "swap-x-v2",
 		"etherfi-ebtc", "uniswap-v4", "sky-psm", "honey", "curve-llamma", "curve-lending", "balancer-v3-eclp", "ekubo",
-		"ekubo-v3", "erc4626", "hyeth", "brownfi", "cusd", "kelp-rseth-l2", "valantis-stex", "nabla", "lunarbase"}
+		"ekubo-v3", "erc4626", "hyeth", "brownfi", "cusd", "kelp-rseth-l2", "unipool", "valantis-stex", "nabla", "lunarbase"}
 	t.Logf("%#v", poolTrackers)
 
 	for _, poolTracker := range poolTrackers {

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -130,6 +130,7 @@ import (
 	syncswapv2classic "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/classic"
 	syncswapv2stable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/stable"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tessera"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/unipool"
 	uniswaplo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/lo"
 	uniswapv1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v1"
 	uniswapv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v2"
@@ -269,6 +270,7 @@ type Types struct {
 	Smardex                    string
 	Integral                   string
 	Fxdx                       string
+	UniPool                    string
 	UniswapV1                  string
 	UniswapV2                  string
 	QuickPerps                 string
@@ -484,6 +486,7 @@ var (
 		Smardex:                    smardex.DexTypeSmardex,
 		Integral:                   integral.DexTypeIntegral,
 		Fxdx:                       fxdx.DexTypeFxdx,
+		UniPool:                    unipool.DexType,
 		UniswapV1:                  uniswapv1.DexType,
 		UniswapV2:                  uniswapv2.DexType,
 		QuickPerps:                 quickperps.DexTypeQuickperps,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -246,6 +246,7 @@ const (
 	ExchangeSynthetix                  = "synthetix"
 	ExchangeTessera                    = "tessera"
 	ExchangeThenaFusionV3              = "thena-fusion-v3"
+	ExchangeUniPool                    = "unipool"
 	ExchangeUniSwap                    = "uniswap"
 	ExchangeUniswapLO                  = "uniswap-lo"
 	ExchangeUniSwapV1                  = "uniswap-v1"


### PR DESCRIPTION
## Why did we need it?
Adds support for UniPool, a UniswapV2-style CPMM with virtual reserves (linear time decay for MEV protection) and on-pool lending.
Integrates the standard 3-component pipeline (`PoolsListUpdater`, `PoolTracker`, `PoolSimulator`) plus the `PairCreated` factory event decoder.

## Related Issue
N/A

## Release Note
- New `DexType = "unipool"` / `ExchangeUniPool = "unipool"`
- Pending-liquidation simulation is skipped in V1 (quote drift bounded by `totalBorrowed / reserve`)

## How Has This Been Tested?
- 59 unit tests (simulator math, ABI decoding, JSON round-trip, error paths)
- Live integration suite on Arbitrum (gated by `test.SkipCI`) — factory pagination, tracker on WETH/USDT + EV/USDT, end-to-end list→track→simulate
- Cross-check against on-chain `UniPoolQuoter` (`0xc264944e9e7073f8f98fef7338cda973914fca44`): exact match across 4 input sizes / both directions
- `go test -race` clean / `staticcheck` 0 warning

## Screenshots (if appropriate):
N/A