### PR TITLE
feat: integrate nadswap (nadfun-contract-v2 DEX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Integrate `nadswap` (nadfun-contract-v2 DEX) on Monad. Supports meme-token pairs with asymmetric quote-token fee model and general pairs with LP-only constant-product math.
+
+
 ## [v0.11.6] - 2023-09-11
 
 ### Added

--- a/pkg/liquidity-source/nadswap/abis.go
+++ b/pkg/liquidity-source/nadswap/abis.go
@@ -1,0 +1,31 @@
+package nadswap
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	factoryABI      abi.ABI
+	pairABI         abi.ABI
+	feeCollectorABI abi.ABI
+)
+
+func init() {
+	builder := []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{&factoryABI, factoryJson},
+		{&pairABI, pairJson},
+		{&feeCollectorABI, feeCollectorJson},
+	}
+	for _, b := range builder {
+		var err error
+		*b.ABI, err = abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkg/liquidity-source/nadswap/abis/FeeCollector.json
+++ b/pkg/liquidity-source/nadswap/abis/FeeCollector.json
@@ -1,0 +1,702 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "accumulatedFee",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "authority",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "collectFee",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "protocolFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "creatorFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getFeeConfig",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IFeeCollector.FeeConfig",
+        "components": [
+          {
+            "name": "baseToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "quoteToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "creatorFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "curveProtocolFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "dexProtocolFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "protocolManager_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "creatorFeeProcessor_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "bondingCurve_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "router_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isConsumingScheduledOp",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isSettleable",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isSettling",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "router",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setAuthority",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setCurveProtocolFeeRate",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rate",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDexProtocolFeeRate",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "rate",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "minAmountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settlementThreshold",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setup",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "baseToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "quoteToken_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "creatorFeeRate",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "curveProtocolFeeRate",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "dexProtocolFeeRate",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "AuthorityUpdated",
+    "inputs": [
+      {
+        "name": "authority",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Collect",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "pair",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CurveProtocolFeeRateUpdate",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "oldRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "newRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DexProtocolFeeRateUpdate",
+    "inputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "oldRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "newRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Settle",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "pair",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "totalFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "creatorFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Setup",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "pair",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "creatorFeeRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "curveProtocolFeeRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "dexProtocolFeeRate",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccessManagedInvalidAuthority",
+    "inputs": [
+      {
+        "name": "authority",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AccessManagedRequiredDelay",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "delay",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AccessManagedUnauthorized",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AlreadyConfigured",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BelowThreshold",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientOutput",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidFeeAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidRates",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAuthorized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotConfigured",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PairLocked",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  }
+]

--- a/pkg/liquidity-source/nadswap/abis/FeeCollector.json
+++ b/pkg/liquidity-source/nadswap/abis/FeeCollector.json
@@ -1,16 +1,9 @@
 [
   {
-    "type": "constructor",
-    "inputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
     "type": "function",
     "name": "UPGRADE_INTERFACE_VERSION",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "string",
         "internalType": "string"
       }
@@ -29,7 +22,6 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -39,38 +31,13 @@
   {
     "type": "function",
     "name": "authority",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
     ],
     "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "collectFee",
-    "inputs": [
-      {
-        "name": "pair",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "protocolFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "creatorFee",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -84,7 +51,6 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "tuple",
         "internalType": "struct IFeeCollector.FeeConfig",
         "components": [
@@ -120,39 +86,9 @@
   },
   {
     "type": "function",
-    "name": "initialize",
-    "inputs": [
-      {
-        "name": "protocolManager_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "creatorFeeProcessor_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "bondingCurve_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "router_",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "isConsumingScheduledOp",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "bytes4",
         "internalType": "bytes4"
       }
@@ -171,7 +107,6 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "bool",
         "internalType": "bool"
       }
@@ -190,7 +125,6 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "bool",
         "internalType": "bool"
       }
@@ -200,10 +134,8 @@
   {
     "type": "function",
     "name": "proxiableUUID",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "bytes32",
         "internalType": "bytes32"
       }
@@ -213,82 +145,13 @@
   {
     "type": "function",
     "name": "router",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
     ],
     "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "setAuthority",
-    "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setCurveProtocolFeeRate",
-    "inputs": [
-      {
-        "name": "pair",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "rate",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setDexProtocolFeeRate",
-    "inputs": [
-      {
-        "name": "pair",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "rate",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "settle",
-    "inputs": [
-      {
-        "name": "pair",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "minAmountOut",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -302,68 +165,11 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "setup",
-    "inputs": [
-      {
-        "name": "pair",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "baseToken",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "quoteToken_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "creatorFeeRate",
-        "type": "uint16",
-        "internalType": "uint16"
-      },
-      {
-        "name": "curveProtocolFeeRate",
-        "type": "uint16",
-        "internalType": "uint16"
-      },
-      {
-        "name": "dexProtocolFeeRate",
-        "type": "uint16",
-        "internalType": "uint16"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "upgradeToAndCall",
-    "inputs": [
-      {
-        "name": "newImplementation",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "data",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "payable"
   },
   {
     "type": "event",
@@ -372,11 +178,9 @@
       {
         "name": "authority",
         "type": "address",
-        "indexed": false,
         "internalType": "address"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -397,11 +201,9 @@
       {
         "name": "amount",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -416,17 +218,14 @@
       {
         "name": "oldRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       },
       {
         "name": "newRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -441,17 +240,14 @@
       {
         "name": "oldRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       },
       {
         "name": "newRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -460,11 +256,9 @@
       {
         "name": "version",
         "type": "uint64",
-        "indexed": false,
         "internalType": "uint64"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -485,17 +279,14 @@
       {
         "name": "totalFee",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
         "name": "creatorFee",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -516,23 +307,19 @@
       {
         "name": "creatorFeeRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       },
       {
         "name": "curveProtocolFeeRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       },
       {
         "name": "dexProtocolFeeRate",
         "type": "uint16",
-        "indexed": false,
         "internalType": "uint16"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -544,159 +331,6 @@
         "indexed": true,
         "internalType": "address"
       }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "error",
-    "name": "AccessManagedInvalidAuthority",
-    "inputs": [
-      {
-        "name": "authority",
-        "type": "address",
-        "internalType": "address"
-      }
     ]
-  },
-  {
-    "type": "error",
-    "name": "AccessManagedRequiredDelay",
-    "inputs": [
-      {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "delay",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AccessManagedUnauthorized",
-    "inputs": [
-      {
-        "name": "caller",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AddressEmptyCode",
-    "inputs": [
-      {
-        "name": "target",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "AlreadyConfigured",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "BelowThreshold",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ERC1967InvalidImplementation",
-    "inputs": [
-      {
-        "name": "implementation",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC1967NonPayable",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "FailedCall",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InsufficientOutput",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidFeeAmount",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidInitialization",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidRates",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "NotAuthorized",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "NotConfigured",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "NotInitializing",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "PairLocked",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "SafeERC20FailedOperation",
-    "inputs": [
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "UUPSUnauthorizedCallContext",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "UUPSUnsupportedProxiableUUID",
-    "inputs": [
-      {
-        "name": "slot",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ZeroAddress",
-    "inputs": []
   }
 ]

--- a/pkg/liquidity-source/nadswap/abis/NadFunFactory.json
+++ b/pkg/liquidity-source/nadswap/abis/NadFunFactory.json
@@ -1,0 +1,291 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_protocolManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_feeCollector",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allPairs",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allPairsLength",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "createPair",
+    "inputs": [
+      {
+        "name": "tokenA",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenB",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "feeCollector",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeTo",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPair",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setFeeTo",
+    "inputs": [
+      {
+        "name": "_feeTo",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setImplementation",
+    "inputs": [
+      {
+        "name": "_implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "FeeToUpdate",
+    "inputs": [
+      {
+        "name": "oldFeeTo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newFeeTo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ImplementationUpdate",
+    "inputs": [
+      {
+        "name": "oldImplementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PairCreated",
+    "inputs": [
+      {
+        "name": "token0",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token1",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "pair",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "pairCount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "FailedDeployment",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Forbidden",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IdenticalAddresses",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientBalance",
+    "inputs": [
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "PairExists",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  }
+]

--- a/pkg/liquidity-source/nadswap/abis/NadFunFactory.json
+++ b/pkg/liquidity-source/nadswap/abis/NadFunFactory.json
@@ -1,38 +1,15 @@
 [
   {
-    "type": "constructor",
-    "inputs": [
-      {
-        "name": "_protocolManager",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "_feeCollector",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "_implementation",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
     "type": "function",
     "name": "allPairs",
     "inputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
     ],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -42,10 +19,8 @@
   {
     "type": "function",
     "name": "allPairsLength",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -54,35 +29,9 @@
   },
   {
     "type": "function",
-    "name": "createPair",
-    "inputs": [
-      {
-        "name": "tokenA",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "tokenB",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "pair",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "feeCollector",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -92,10 +41,8 @@
   {
     "type": "function",
     "name": "feeTo",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -107,19 +54,16 @@
     "name": "getPair",
     "inputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       },
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
     ],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -129,10 +73,8 @@
   {
     "type": "function",
     "name": "implementation",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -142,41 +84,13 @@
   {
     "type": "function",
     "name": "protocolManager",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
     ],
     "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "setFeeTo",
-    "inputs": [
-      {
-        "name": "_feeTo",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setImplementation",
-    "inputs": [
-      {
-        "name": "_implementation",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
   },
   {
     "type": "event",
@@ -194,8 +108,7 @@
         "indexed": true,
         "internalType": "address"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -213,8 +126,7 @@
         "indexed": true,
         "internalType": "address"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -235,57 +147,13 @@
       {
         "name": "pair",
         "type": "address",
-        "indexed": false,
         "internalType": "address"
       },
       {
         "name": "pairCount",
         "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "error",
-    "name": "FailedDeployment",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "Forbidden",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "IdenticalAddresses",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InsufficientBalance",
-    "inputs": [
-      {
-        "name": "balance",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "needed",
-        "type": "uint256",
         "internalType": "uint256"
       }
     ]
-  },
-  {
-    "type": "error",
-    "name": "PairExists",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ZeroAddress",
-    "inputs": []
   }
 ]

--- a/pkg/liquidity-source/nadswap/abis/NadFunPair.json
+++ b/pkg/liquidity-source/nadswap/abis/NadFunPair.json
@@ -1,0 +1,970 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "DOMAIN_SEPARATOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "LP_FEE_RATE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MINIMUM_LIQUIDITY",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount0",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "factory",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeCollector",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAmountIn",
+    "inputs": [
+      {
+        "name": "tokenOut",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAmountOut",
+    "inputs": [
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getReserves",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "reserve0",
+        "type": "uint112",
+        "internalType": "uint112"
+      },
+      {
+        "name": "reserve1",
+        "type": "uint112",
+        "internalType": "uint112"
+      },
+      {
+        "name": "blockTimestampLast",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "factory_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "token0_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "token1_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeCollector_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isLocked",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "kLast",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "liquidity",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nonces",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permit",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "price0CumulativeLast",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "price1CumulativeLast",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "skim",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swap",
+    "inputs": [
+      {
+        "name": "amount0Out",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1Out",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "sync",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "token0",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "token1",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Burn",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount0",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Mint",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount0",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Swap",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount0In",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1In",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount0Out",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1Out",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Sync",
+    "inputs": [
+      {
+        "name": "reserve0",
+        "type": "uint112",
+        "indexed": false,
+        "internalType": "uint112"
+      },
+      {
+        "name": "reserve1",
+        "type": "uint112",
+        "indexed": false,
+        "internalType": "uint112"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "allowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientBalance",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSpender",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC2612ExpiredSignature",
+    "inputs": [
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC2612InvalidSigner",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidAccountNonce",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "currentNonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  }
+]

--- a/pkg/liquidity-source/nadswap/abis/NadFunPair.json
+++ b/pkg/liquidity-source/nadswap/abis/NadFunPair.json
@@ -1,16 +1,9 @@
 [
   {
-    "type": "constructor",
-    "inputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
     "type": "function",
     "name": "DOMAIN_SEPARATOR",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "bytes32",
         "internalType": "bytes32"
       }
@@ -20,10 +13,8 @@
   {
     "type": "function",
     "name": "LP_FEE_RATE",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -33,10 +24,8 @@
   {
     "type": "function",
     "name": "MINIMUM_LIQUIDITY",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -60,36 +49,11 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "approve",
-    "inputs": [
-      {
-        "name": "spender",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "value",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -103,7 +67,6 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -112,35 +75,9 @@
   },
   {
     "type": "function",
-    "name": "burn",
-    "inputs": [
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "amount0",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "amount1",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "decimals",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint8",
         "internalType": "uint8"
       }
@@ -150,7 +87,6 @@
   {
     "type": "function",
     "name": "eip712Domain",
-    "inputs": [],
     "outputs": [
       {
         "name": "fields",
@@ -193,10 +129,8 @@
   {
     "type": "function",
     "name": "factory",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -206,10 +140,8 @@
   {
     "type": "function",
     "name": "feeCollector",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -267,7 +199,6 @@
   {
     "type": "function",
     "name": "getReserves",
-    "inputs": [],
     "outputs": [
       {
         "name": "reserve0",
@@ -289,39 +220,9 @@
   },
   {
     "type": "function",
-    "name": "initialize",
-    "inputs": [
-      {
-        "name": "factory_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "token0_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "token1_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "feeCollector_",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "isLocked",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "bool",
         "internalType": "bool"
       }
@@ -331,10 +232,8 @@
   {
     "type": "function",
     "name": "kLast",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -343,30 +242,9 @@
   },
   {
     "type": "function",
-    "name": "mint",
-    "inputs": [
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "liquidity",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "name",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "string",
         "internalType": "string"
       }
@@ -385,7 +263,6 @@
     ],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -394,54 +271,9 @@
   },
   {
     "type": "function",
-    "name": "permit",
-    "inputs": [
-      {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "spender",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "value",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "deadline",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "v",
-        "type": "uint8",
-        "internalType": "uint8"
-      },
-      {
-        "name": "r",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      },
-      {
-        "name": "s",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "price0CumulativeLast",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -451,10 +283,8 @@
   {
     "type": "function",
     "name": "price1CumulativeLast",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -463,52 +293,9 @@
   },
   {
     "type": "function",
-    "name": "skim",
-    "inputs": [
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "swap",
-    "inputs": [
-      {
-        "name": "amount0Out",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "amount1Out",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "data",
-        "type": "bytes",
-        "internalType": "bytes"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "symbol",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "string",
         "internalType": "string"
       }
@@ -517,18 +304,9 @@
   },
   {
     "type": "function",
-    "name": "sync",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "token0",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -538,10 +316,8 @@
   {
     "type": "function",
     "name": "token1",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "address",
         "internalType": "address"
       }
@@ -551,68 +327,13 @@
   {
     "type": "function",
     "name": "totalSupply",
-    "inputs": [],
     "outputs": [
       {
-        "name": "",
         "type": "uint256",
         "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "transfer",
-    "inputs": [
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "value",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferFrom",
-    "inputs": [
-      {
-        "name": "from",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "value",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool",
-        "internalType": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable"
   },
   {
     "type": "event",
@@ -633,11 +354,9 @@
       {
         "name": "value",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -652,13 +371,11 @@
       {
         "name": "amount0",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
         "name": "amount1",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
@@ -667,14 +384,11 @@
         "indexed": true,
         "internalType": "address"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
-    "name": "EIP712DomainChanged",
-    "inputs": [],
-    "anonymous": false
+    "name": "EIP712DomainChanged"
   },
   {
     "type": "event",
@@ -683,11 +397,9 @@
       {
         "name": "version",
         "type": "uint64",
-        "indexed": false,
         "internalType": "uint64"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -702,17 +414,14 @@
       {
         "name": "amount0",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
         "name": "amount1",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -727,25 +436,21 @@
       {
         "name": "amount0In",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
         "name": "amount1In",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
         "name": "amount0Out",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
         "name": "amount1Out",
         "type": "uint256",
-        "indexed": false,
         "internalType": "uint256"
       },
       {
@@ -754,8 +459,7 @@
         "indexed": true,
         "internalType": "address"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -764,17 +468,14 @@
       {
         "name": "reserve0",
         "type": "uint112",
-        "indexed": false,
         "internalType": "uint112"
       },
       {
         "name": "reserve1",
         "type": "uint112",
-        "indexed": false,
         "internalType": "uint112"
       }
-    ],
-    "anonymous": false
+    ]
   },
   {
     "type": "event",
@@ -795,176 +496,8 @@
       {
         "name": "value",
         "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignature",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureLength",
-    "inputs": [
-      {
-        "name": "length",
-        "type": "uint256",
         "internalType": "uint256"
       }
     ]
-  },
-  {
-    "type": "error",
-    "name": "ECDSAInvalidSignatureS",
-    "inputs": [
-      {
-        "name": "s",
-        "type": "bytes32",
-        "internalType": "bytes32"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC20InsufficientAllowance",
-    "inputs": [
-      {
-        "name": "spender",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "allowance",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "needed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC20InsufficientBalance",
-    "inputs": [
-      {
-        "name": "sender",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "balance",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "needed",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC20InvalidApprover",
-    "inputs": [
-      {
-        "name": "approver",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC20InvalidReceiver",
-    "inputs": [
-      {
-        "name": "receiver",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC20InvalidSender",
-    "inputs": [
-      {
-        "name": "sender",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC20InvalidSpender",
-    "inputs": [
-      {
-        "name": "spender",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC2612ExpiredSignature",
-    "inputs": [
-      {
-        "name": "deadline",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "ERC2612InvalidSigner",
-    "inputs": [
-      {
-        "name": "signer",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InvalidAccountNonce",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "currentNonce",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ]
-  },
-  {
-    "type": "error",
-    "name": "InvalidInitialization",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "NotInitializing",
-    "inputs": []
   }
 ]

--- a/pkg/liquidity-source/nadswap/config.go
+++ b/pkg/liquidity-source/nadswap/config.go
@@ -1,0 +1,11 @@
+package nadswap
+
+import "github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+
+type Config struct {
+	ChainID             valueobject.ChainID `json:"chainID"`
+	DexID               string              `json:"dexID"`
+	FactoryAddress      string              `json:"factoryAddress"`
+	FeeCollectorAddress string              `json:"feeCollectorAddress"`
+	NewPoolLimit        int                 `json:"newPoolLimit"`
+}

--- a/pkg/liquidity-source/nadswap/config.go
+++ b/pkg/liquidity-source/nadswap/config.go
@@ -1,11 +1,7 @@
 package nadswap
 
-import "github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
-
 type Config struct {
-	ChainID             valueobject.ChainID `json:"chainID"`
-	DexID               string              `json:"dexID"`
-	FactoryAddress      string              `json:"factoryAddress"`
-	FeeCollectorAddress string              `json:"feeCollectorAddress"`
-	NewPoolLimit        int                 `json:"newPoolLimit"`
+	DexID          string `json:"dexID"`
+	FactoryAddress string `json:"factoryAddress"`
+	NewPoolLimit   int    `json:"newPoolLimit"`
 }

--- a/pkg/liquidity-source/nadswap/constant.go
+++ b/pkg/liquidity-source/nadswap/constant.go
@@ -17,6 +17,7 @@ const (
 
 	factoryMethodAllPairs       = "allPairs"
 	factoryMethodAllPairsLength = "allPairsLength"
+	factoryMethodFeeCollector   = "feeCollector"
 
 	pairMethodToken0      = "token0"
 	pairMethodToken1      = "token1"

--- a/pkg/liquidity-source/nadswap/constant.go
+++ b/pkg/liquidity-source/nadswap/constant.go
@@ -1,0 +1,38 @@
+package nadswap
+
+import (
+	"errors"
+
+	"github.com/holiman/uint256"
+)
+
+const (
+	DexType = "nadswap"
+
+	BPS       = 10000
+	LpFeeRate = 25 // BPS
+
+	buyGas  = 150000
+	sellGas = 150000
+
+	factoryMethodAllPairs       = "allPairs"
+	factoryMethodAllPairsLength = "allPairsLength"
+
+	pairMethodToken0      = "token0"
+	pairMethodToken1      = "token1"
+	pairMethodGetReserves = "getReserves"
+
+	feeCollectorMethodGetFeeConfig = "getFeeConfig"
+)
+
+var (
+	ErrInvalidToken          = errors.New("invalid token")
+	ErrInsufficientInput     = errors.New("insufficient input amount")
+	ErrInsufficientOutput    = errors.New("insufficient output amount")
+	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
+	ErrInvalidFeeRate        = errors.New("invalid fee rate")
+	ErrOverflow              = errors.New("overflow")
+
+	uBPS       = uint256.NewInt(BPS)
+	uLpFeeRate = uint256.NewInt(LpFeeRate)
+)

--- a/pkg/liquidity-source/nadswap/embed.go
+++ b/pkg/liquidity-source/nadswap/embed.go
@@ -1,0 +1,12 @@
+package nadswap
+
+import _ "embed"
+
+//go:embed abis/NadFunFactory.json
+var factoryJson []byte
+
+//go:embed abis/NadFunPair.json
+var pairJson []byte
+
+//go:embed abis/FeeCollector.json
+var feeCollectorJson []byte

--- a/pkg/liquidity-source/nadswap/log_decoder.go
+++ b/pkg/liquidity-source/nadswap/log_decoder.go
@@ -1,0 +1,62 @@
+package nadswap
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+type ILogDecoder interface {
+	Decode(logs []types.Log, blockHeaders map[uint64]entity.BlockHeader) (ReserveData, *big.Int, error)
+}
+
+type LogDecoder struct{}
+
+func NewLogDecoder() *LogDecoder { return &LogDecoder{} }
+
+func (d *LogDecoder) Decode(logs []types.Log, _ map[uint64]entity.BlockHeader) (ReserveData, *big.Int, error) {
+	latest := d.findLatestSyncEvent(logs)
+	if len(latest.Data) == 0 {
+		return ReserveData{}, nil, nil
+	}
+
+	event := pairABI.Events["Sync"]
+	unpacked, err := event.Inputs.Unpack(latest.Data)
+	if err != nil {
+		return ReserveData{}, nil, err
+	}
+	if len(unpacked) != 2 {
+		return ReserveData{}, nil, nil
+	}
+	r0 := unpacked[0].(*big.Int)
+	r1 := unpacked[1].(*big.Int)
+
+	u0, overflow := uint256.FromBig(r0)
+	if overflow {
+		return ReserveData{}, nil, ErrOverflow
+	}
+	u1, overflow := uint256.FromBig(r1)
+	if overflow {
+		return ReserveData{}, nil, ErrOverflow
+	}
+	return ReserveData{Reserve0: u0, Reserve1: u1}, new(big.Int).SetUint64(latest.BlockNumber), nil
+}
+
+func (d *LogDecoder) findLatestSyncEvent(logs []types.Log) types.Log {
+	var latest types.Log
+	syncTopic := pairABI.Events["Sync"].ID
+	for _, log := range logs {
+		if log.Removed || len(log.Topics) == 0 || log.Topics[0] != syncTopic {
+			continue
+		}
+		if latest.BlockNumber < log.BlockNumber ||
+			(latest.BlockNumber == log.BlockNumber && latest.TxIndex < log.TxIndex) ||
+			(latest.BlockNumber == log.BlockNumber && latest.TxIndex == log.TxIndex && latest.Index < log.Index) {
+			latest = log
+		}
+	}
+	return latest
+}

--- a/pkg/liquidity-source/nadswap/log_decoder_test.go
+++ b/pkg/liquidity-source/nadswap/log_decoder_test.go
@@ -1,0 +1,60 @@
+package nadswap
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helper to assemble Sync event log data: two uint112 (left-padded to 32 bytes each).
+func encodeSyncData(r0, r1 uint64) []byte {
+	buf := make([]byte, 64)
+	new(big.Int).SetUint64(r0).FillBytes(buf[:32])
+	new(big.Int).SetUint64(r1).FillBytes(buf[32:])
+	return buf
+}
+
+func TestLogDecoder_DecodesLatestSync(t *testing.T) {
+	t.Parallel()
+	dec := NewLogDecoder()
+
+	syncTopic := pairABI.Events["Sync"].ID
+
+	oldLog := types.Log{
+		Address:     common.HexToAddress("0xpair"),
+		Topics:      []common.Hash{syncTopic},
+		Data:        encodeSyncData(100, 200),
+		BlockNumber: 10,
+		TxIndex:     0,
+		Index:       0,
+	}
+	newLog := types.Log{
+		Address:     common.HexToAddress("0xpair"),
+		Topics:      []common.Hash{syncTopic},
+		Data:        encodeSyncData(300, 400),
+		BlockNumber: 11,
+		TxIndex:     2,
+		Index:       5,
+	}
+
+	data, blockNum, err := dec.Decode([]types.Log{oldLog, newLog}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, data.Reserve0)
+	require.NotNil(t, data.Reserve1)
+	assert.Equal(t, "300", data.Reserve0.Dec())
+	assert.Equal(t, "400", data.Reserve1.Dec())
+	assert.Equal(t, uint64(11), blockNum.Uint64())
+}
+
+func TestLogDecoder_NoSyncEvents(t *testing.T) {
+	t.Parallel()
+	dec := NewLogDecoder()
+	data, blockNum, err := dec.Decode([]types.Log{}, nil)
+	require.NoError(t, err)
+	assert.True(t, data.IsZero())
+	assert.Nil(t, blockNum)
+}

--- a/pkg/liquidity-source/nadswap/math.go
+++ b/pkg/liquidity-source/nadswap/math.go
@@ -73,3 +73,52 @@ func getAmountOutMemeBuy(amountIn, reserveQuote, reserveBase *uint256.Int, feeRa
 	big256.MulDivDown(&out, &amountInWithFee, reserveBase, &denom)
 	return &out, nil
 }
+
+// getAmountOutMemeSell: base token in -> net quote token out.
+// LP fee applied on input; swap fee (creator + dexProtocol) deducted from output (ceiling).
+func getAmountOutMemeSell(amountIn, reserveBase, reserveQuote *uint256.Int, feeRate uint16) (*uint256.Int, error) {
+	if amountIn.IsZero() {
+		return nil, ErrInsufficientInput
+	}
+	if reserveBase.IsZero() || reserveQuote.IsZero() {
+		return nil, ErrInsufficientLiquidity
+	}
+	if uint64(LpFeeRate)+uint64(feeRate) >= BPS {
+		return nil, ErrInvalidFeeRate
+	}
+
+	var bpsMinusLp uint256.Int
+	bpsMinusLp.Sub(uBPS, uLpFeeRate)
+
+	var amountInWithLpFee uint256.Int
+	if _, overflow := amountInWithLpFee.MulOverflow(amountIn, &bpsMinusLp); overflow {
+		return nil, ErrOverflow
+	}
+
+	var reserveBaseBPS, denom uint256.Int
+	if _, overflow := reserveBaseBPS.MulOverflow(reserveBase, uBPS); overflow {
+		return nil, ErrOverflow
+	}
+	if _, overflow := denom.AddOverflow(&reserveBaseBPS, &amountInWithLpFee); overflow {
+		return nil, ErrOverflow
+	}
+
+	var gross uint256.Int
+	big256.MulDivDown(&gross, &amountInWithLpFee, reserveQuote, &denom)
+
+	if feeRate == 0 {
+		return &gross, nil
+	}
+
+	// swapFee = ceil(gross * feeRate / (BPS - LP_FEE_RATE))
+	var swapFee uint256.Int
+	uFee := uint256.NewInt(uint64(feeRate))
+	big256.MulDivUp(&swapFee, &gross, uFee, &bpsMinusLp)
+
+	if swapFee.Gt(&gross) {
+		return nil, ErrInsufficientLiquidity
+	}
+	var out uint256.Int
+	out.Sub(&gross, &swapFee)
+	return &out, nil
+}

--- a/pkg/liquidity-source/nadswap/math.go
+++ b/pkg/liquidity-source/nadswap/math.go
@@ -122,3 +122,110 @@ func getAmountOutMemeSell(amountIn, reserveBase, reserveQuote *uint256.Int, feeR
 	out.Sub(&gross, &swapFee)
 	return &out, nil
 }
+
+// getAmountInGeneral: exact-output, LP fee only.
+// amountIn = ceil(reserveIn * BPS * amountOut / ((BPS - LP_FEE_RATE) * (reserveOut - amountOut)))
+func getAmountInGeneral(amountOut, reserveIn, reserveOut *uint256.Int) (*uint256.Int, error) {
+	if amountOut.IsZero() {
+		return nil, ErrInsufficientOutput
+	}
+	if reserveIn.IsZero() || reserveOut.IsZero() || amountOut.Cmp(reserveOut) >= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	var bpsMinusLp uint256.Int
+	bpsMinusLp.Sub(uBPS, uLpFeeRate)
+
+	var num uint256.Int
+	if _, overflow := num.MulOverflow(reserveIn, uBPS); overflow {
+		return nil, ErrOverflow
+	}
+
+	var denom, reserveOutMinusAmountOut uint256.Int
+	reserveOutMinusAmountOut.Sub(reserveOut, amountOut)
+	if _, overflow := denom.MulOverflow(&bpsMinusLp, &reserveOutMinusAmountOut); overflow {
+		return nil, ErrOverflow
+	}
+
+	var out uint256.Int
+	big256.MulDivUp(&out, &num, amountOut, &denom)
+	return &out, nil
+}
+
+// getAmountInMemeBuy: exact-output for buy direction.
+// amountIn = ceil(reserveQuote * BPS * amountOut / ((BPS - totalFeeRate) * (reserveBase - amountOut)))
+func getAmountInMemeBuy(amountOut, reserveQuote, reserveBase *uint256.Int, feeRate uint16) (*uint256.Int, error) {
+	if amountOut.IsZero() {
+		return nil, ErrInsufficientOutput
+	}
+	if reserveQuote.IsZero() || reserveBase.IsZero() || amountOut.Cmp(reserveBase) >= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+	totalFeeRate := uint64(LpFeeRate) + uint64(feeRate)
+	if totalFeeRate >= BPS {
+		return nil, ErrInvalidFeeRate
+	}
+
+	var bpsMinusTotal uint256.Int
+	bpsMinusTotal.Sub(uBPS, uint256.NewInt(totalFeeRate))
+
+	var num uint256.Int
+	if _, overflow := num.MulOverflow(reserveQuote, uBPS); overflow {
+		return nil, ErrOverflow
+	}
+
+	var denom, reserveBaseMinusOut uint256.Int
+	reserveBaseMinusOut.Sub(reserveBase, amountOut)
+	if _, overflow := denom.MulOverflow(&bpsMinusTotal, &reserveBaseMinusOut); overflow {
+		return nil, ErrOverflow
+	}
+
+	var out uint256.Int
+	big256.MulDivUp(&out, &num, amountOut, &denom)
+	return &out, nil
+}
+
+// getAmountInMemeSell: exact-output for sell direction (`amountOut` is NET quote out).
+func getAmountInMemeSell(amountOut, reserveBase, reserveQuote *uint256.Int, feeRate uint16) (*uint256.Int, error) {
+	if amountOut.IsZero() {
+		return nil, ErrInsufficientOutput
+	}
+	if reserveBase.IsZero() || reserveQuote.IsZero() || amountOut.Cmp(reserveQuote) >= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+	if uint64(LpFeeRate)+uint64(feeRate) >= BPS {
+		return nil, ErrInvalidFeeRate
+	}
+
+	var bpsMinusLp uint256.Int
+	bpsMinusLp.Sub(uBPS, uLpFeeRate)
+
+	// gross out before swap fee:
+	// gross = feeRate>0 ? ceil(amountOut * (BPS-LP) / (BPS-LP-feeRate)) : amountOut
+	var gross uint256.Int
+	if feeRate == 0 {
+		gross.Set(amountOut)
+	} else {
+		var bpsMinusLpMinusFee uint256.Int
+		bpsMinusLpMinusFee.Sub(&bpsMinusLp, uint256.NewInt(uint64(feeRate)))
+		big256.MulDivUp(&gross, amountOut, &bpsMinusLp, &bpsMinusLpMinusFee)
+	}
+
+	if gross.Cmp(reserveQuote) >= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	var num uint256.Int
+	if _, overflow := num.MulOverflow(reserveBase, uBPS); overflow {
+		return nil, ErrOverflow
+	}
+	var denom, reserveQuoteMinusGross uint256.Int
+	reserveQuoteMinusGross.Sub(reserveQuote, &gross)
+	if _, overflow := denom.MulOverflow(&bpsMinusLp, &reserveQuoteMinusGross); overflow {
+		return nil, ErrOverflow
+	}
+
+	var out uint256.Int
+	big256.MulDivUp(&out, &num, &gross, &denom)
+	return &out, nil
+}

--- a/pkg/liquidity-source/nadswap/math.go
+++ b/pkg/liquidity-source/nadswap/math.go
@@ -1,0 +1,39 @@
+package nadswap
+
+import (
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+)
+
+// getAmountOutGeneral computes the V2 constant-product formula with LP_FEE_RATE = 25 BPS.
+// Used for general (non-meme) pairs. MulDivDown uses 512-bit internal arithmetic, so
+// the intermediate product amountInWithFee * reserveOut cannot overflow.
+func getAmountOutGeneral(amountIn, reserveIn, reserveOut *uint256.Int) (*uint256.Int, error) {
+	if amountIn.IsZero() {
+		return nil, ErrInsufficientInput
+	}
+	if reserveIn.IsZero() || reserveOut.IsZero() {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	// amountInWithFee = amountIn * (BPS - LP_FEE_RATE)
+	var amountInWithFee, bpsMinusLp uint256.Int
+	bpsMinusLp.Sub(uBPS, uLpFeeRate)
+	if _, overflow := amountInWithFee.MulOverflow(amountIn, &bpsMinusLp); overflow {
+		return nil, ErrOverflow
+	}
+
+	// denominator = reserveIn * BPS + amountInWithFee
+	var denom, reserveInBPS uint256.Int
+	if _, overflow := reserveInBPS.MulOverflow(reserveIn, uBPS); overflow {
+		return nil, ErrOverflow
+	}
+	if _, overflow := denom.AddOverflow(&reserveInBPS, &amountInWithFee); overflow {
+		return nil, ErrOverflow
+	}
+
+	var out uint256.Int
+	big256.MulDivDown(&out, &amountInWithFee, reserveOut, &denom)
+	return &out, nil
+}

--- a/pkg/liquidity-source/nadswap/math.go
+++ b/pkg/liquidity-source/nadswap/math.go
@@ -37,3 +37,39 @@ func getAmountOutGeneral(amountIn, reserveIn, reserveOut *uint256.Int) (*uint256
 	big256.MulDivDown(&out, &amountInWithFee, reserveOut, &denom)
 	return &out, nil
 }
+
+// getAmountOutMemeBuy: quote token in -> base token out.
+// totalFeeRate = LP_FEE_RATE + feeRate, applied entirely on input.
+func getAmountOutMemeBuy(amountIn, reserveQuote, reserveBase *uint256.Int, feeRate uint16) (*uint256.Int, error) {
+	if amountIn.IsZero() {
+		return nil, ErrInsufficientInput
+	}
+	if reserveQuote.IsZero() || reserveBase.IsZero() {
+		return nil, ErrInsufficientLiquidity
+	}
+	totalFeeRate := uint64(LpFeeRate) + uint64(feeRate)
+	if totalFeeRate >= BPS {
+		return nil, ErrInvalidFeeRate
+	}
+
+	uTotal := uint256.NewInt(totalFeeRate)
+	var bpsMinusTotal uint256.Int
+	bpsMinusTotal.Sub(uBPS, uTotal)
+
+	var amountInWithFee uint256.Int
+	if _, overflow := amountInWithFee.MulOverflow(amountIn, &bpsMinusTotal); overflow {
+		return nil, ErrOverflow
+	}
+
+	var reserveQuoteBPS, denom uint256.Int
+	if _, overflow := reserveQuoteBPS.MulOverflow(reserveQuote, uBPS); overflow {
+		return nil, ErrOverflow
+	}
+	if _, overflow := denom.AddOverflow(&reserveQuoteBPS, &amountInWithFee); overflow {
+		return nil, ErrOverflow
+	}
+
+	var out uint256.Int
+	big256.MulDivDown(&out, &amountInWithFee, reserveBase, &denom)
+	return &out, nil
+}

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -54,3 +54,26 @@ func TestGetAmountOut_MemeBuy_InvalidFeeRate(t *testing.T) {
 	_, err := getAmountOutMemeBuy(u("1000"), u("10000"), u("10000"), 9976)
 	assert.ErrorIs(t, err, ErrInvalidFeeRate)
 }
+
+// Meme sell: tokenIn = baseToken
+// reserveBase=10000, reserveQuote=10000, amountIn=1000, feeRate=100
+// amountInWithLpFee = 1000 * (10000 - 25) = 9_975_000
+// gross = 9_975_000 * 10000 / (10000*10000 + 9_975_000) = 907
+// swapFee = ceil(907 * 100 / (10000 - 25)) = ceil(90700 / 9975) = ceil(9.0927...) = 10
+// net = 907 - 10 = 897
+func TestGetAmountOut_MemeSell(t *testing.T) {
+	t.Parallel()
+	out, err := getAmountOutMemeSell(u("1000"), u("10000"), u("10000"), 100)
+	require.NoError(t, err)
+	assert.Equal(t, "897", out.Dec())
+}
+
+// Sell with feeRate=0 must equal the general-pair LP-only result.
+func TestGetAmountOut_MemeSell_ZeroFee_EqualsGeneral(t *testing.T) {
+	t.Parallel()
+	memeOut, err := getAmountOutMemeSell(u("1000"), u("10000"), u("10000"), 0)
+	require.NoError(t, err)
+	genOut, err := getAmountOutGeneral(u("1000"), u("10000"), u("10000"))
+	require.NoError(t, err)
+	assert.Equal(t, genOut.Dec(), memeOut.Dec())
+}

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -16,8 +16,9 @@ func u(s string) *uint256.Int { return uint256.MustFromDecimal(s) }
 // reserveIn=10000, reserveOut=10000, amountIn=1000
 // amountInAfterLpFee = 1000 * 9975 = 9_975_000
 // amountOut = 9_975_000 * 10000 / (10000*10000 + 9_975_000)
-//           = 99_750_000_000 / 109_975_000
-//           = 907
+//
+//	= 99_750_000_000 / 109_975_000
+//	= 907
 func TestGetAmountOut_GeneralPair_LPOnly(t *testing.T) {
 	t.Parallel()
 	out, err := getAmountOutGeneral(u("1000"), u("10000"), u("10000"))

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -1,0 +1,38 @@
+package nadswap
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func u(s string) *uint256.Int { return uint256.MustFromDecimal(s) }
+
+// General pair = LP fee only, no creator/protocol fee, symmetric.
+// Same formula as Uniswap V2 with feeRate = 25 BPS.
+//
+// reserveIn=10000, reserveOut=10000, amountIn=1000
+// amountInAfterLpFee = 1000 * 9975 = 9_975_000
+// amountOut = 9_975_000 * 10000 / (10000*10000 + 9_975_000)
+//           = 99_750_000_000 / 109_975_000
+//           = 907
+func TestGetAmountOut_GeneralPair_LPOnly(t *testing.T) {
+	t.Parallel()
+	out, err := getAmountOutGeneral(u("1000"), u("10000"), u("10000"))
+	require.NoError(t, err)
+	assert.Equal(t, "907", out.Dec())
+}
+
+func TestGetAmountOut_GeneralPair_Guards(t *testing.T) {
+	t.Parallel()
+	_, err := getAmountOutGeneral(u("0"), u("10000"), u("10000"))
+	assert.ErrorIs(t, err, ErrInsufficientInput)
+
+	_, err = getAmountOutGeneral(u("1000"), u("0"), u("10000"))
+	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
+
+	_, err = getAmountOutGeneral(u("1000"), u("10000"), u("0"))
+	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
+}

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -36,3 +36,21 @@ func TestGetAmountOut_GeneralPair_Guards(t *testing.T) {
 	_, err = getAmountOutGeneral(u("1000"), u("10000"), u("0"))
 	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
 }
+
+// Meme buy: tokenIn = quoteToken
+// reserveQuote=10000, reserveBase=10000, amountIn=1000, feeRate=100 (=1%)
+// totalFeeRate = 25 + 100 = 125
+// amountInWithFee = 1000 * (10000 - 125) = 9_875_000
+// amountOut = 9_875_000 * 10000 / (10000 * 10000 + 9_875_000) = 98_750_000_000 / 109_875_000 = 898
+func TestGetAmountOut_MemeBuy(t *testing.T) {
+	t.Parallel()
+	out, err := getAmountOutMemeBuy(u("1000"), u("10000"), u("10000"), 100)
+	require.NoError(t, err)
+	assert.Equal(t, "898", out.Dec())
+}
+
+func TestGetAmountOut_MemeBuy_InvalidFeeRate(t *testing.T) {
+	t.Parallel()
+	_, err := getAmountOutMemeBuy(u("1000"), u("10000"), u("10000"), 9976)
+	assert.ErrorIs(t, err, ErrInvalidFeeRate)
+}

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -77,3 +77,52 @@ func TestGetAmountOut_MemeSell_ZeroFee_EqualsGeneral(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, genOut.Dec(), memeOut.Dec())
 }
+
+// Round-trip property: getAmountIn(getAmountOut(x)) >= x, and the gap is within
+// at most 1 unit (rounding). Asserts the exact-output formula is the inverse.
+func TestRoundTrip_GeneralPair(t *testing.T) {
+	t.Parallel()
+	out, err := getAmountOutGeneral(u("1000"), u("10000"), u("10000"))
+	require.NoError(t, err)
+	in, err := getAmountInGeneral(out, u("10000"), u("10000"))
+	require.NoError(t, err)
+	// in should be >= 1000 (we may slightly over-collect due to ceil)
+	diff := new(uint256.Int).Sub(in, u("1000"))
+	assert.True(t, diff.LtUint64(2), "diff=%s", diff.Dec())
+}
+
+func TestRoundTrip_MemeBuy(t *testing.T) {
+	t.Parallel()
+	out, err := getAmountOutMemeBuy(u("1000"), u("10000"), u("10000"), 100)
+	require.NoError(t, err)
+	in, err := getAmountInMemeBuy(out, u("10000"), u("10000"), 100)
+	require.NoError(t, err)
+	diff := new(uint256.Int).Sub(in, u("1000"))
+	assert.True(t, diff.LtUint64(2), "diff=%s", diff.Dec())
+}
+
+func TestRoundTrip_MemeSell(t *testing.T) {
+	t.Parallel()
+	out, err := getAmountOutMemeSell(u("1000"), u("10000"), u("10000"), 100)
+	require.NoError(t, err)
+	in, err := getAmountInMemeSell(out, u("10000"), u("10000"), 100)
+	require.NoError(t, err)
+	diff := new(uint256.Int).Sub(in, u("1000"))
+	assert.True(t, diff.LtUint64(2), "diff=%s", diff.Dec())
+}
+
+func TestGetAmountIn_ZeroOutput(t *testing.T) {
+	t.Parallel()
+	_, err := getAmountInGeneral(u("0"), u("10000"), u("10000"))
+	assert.ErrorIs(t, err, ErrInsufficientOutput)
+	_, err = getAmountInMemeBuy(u("0"), u("10000"), u("10000"), 100)
+	assert.ErrorIs(t, err, ErrInsufficientOutput)
+	_, err = getAmountInMemeSell(u("0"), u("10000"), u("10000"), 100)
+	assert.ErrorIs(t, err, ErrInsufficientOutput)
+}
+
+func TestGetAmountIn_OutputExceedsReserve(t *testing.T) {
+	t.Parallel()
+	_, err := getAmountInGeneral(u("10000"), u("10000"), u("10000"))
+	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
+}

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -126,3 +126,81 @@ func TestGetAmountIn_OutputExceedsReserve(t *testing.T) {
 	_, err := getAmountInGeneral(u("10000"), u("10000"), u("10000"))
 	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
 }
+
+// CRITICAL: with feeRate > 0, buy and sell must NOT be symmetric.
+// If they happen to be equal, the asymmetric fee logic is broken.
+func TestBuySellAsymmetry(t *testing.T) {
+	t.Parallel()
+	const feeRate uint16 = 100 // 1%
+	buyOut, err := getAmountOutMemeBuy(u("1000"), u("10000"), u("10000"), feeRate)
+	require.NoError(t, err)
+	sellOut, err := getAmountOutMemeSell(u("1000"), u("10000"), u("10000"), feeRate)
+	require.NoError(t, err)
+	assert.NotEqual(t, buyOut.Dec(), sellOut.Dec(),
+		"buy and sell must differ when feeRate>0; buy=%s sell=%s", buyOut.Dec(), sellOut.Dec())
+}
+
+// When feeRate == 0, buy/sell DO equal each other (and equal general).
+func TestBuySellSymmetry_WhenNoSwapFee(t *testing.T) {
+	t.Parallel()
+	buyOut, err := getAmountOutMemeBuy(u("1000"), u("10000"), u("10000"), 0)
+	require.NoError(t, err)
+	sellOut, err := getAmountOutMemeSell(u("1000"), u("10000"), u("10000"), 0)
+	require.NoError(t, err)
+	assert.Equal(t, buyOut.Dec(), sellOut.Dec())
+}
+
+// Fixtures captured directly from the NadFunPair.getAmountOut Solidity implementation.
+// To regenerate: see scripts/generate-nadswap-fixtures.md (not included in this PR).
+var amountOutFixtures = []struct {
+	name        string
+	reserve0    string
+	reserve1    string
+	quoteToken0 bool // true if quoteToken == token0
+	feeRate     uint16
+	tokenInIs0  bool
+	amountIn    string
+	expectedOut string
+}{
+	// Symmetric (feeRate=0) - should equal both general and meme directions
+	{"zero_fee_buy_t0", "1000000000000000000000", "2000000000000000000000", true, 0, true, "10000000000000000", "19913234389576345"},
+	{"zero_fee_sell_t1", "1000000000000000000000", "2000000000000000000000", true, 0, false, "10000000000000000", "4995008329451707"},
+
+	// Asymmetric: feeRate = 200 (2%)
+	{"buy_fee200", "1000000000000000000000", "2000000000000000000000", true, 200, true, "10000000000000000", "19515590043263921"},
+	{"sell_fee200", "1000000000000000000000", "2000000000000000000000", true, 200, false, "10000000000000000", "4895086664497443"},
+}
+
+// TestFixtures asserts every fixture matches our math implementation exactly.
+// Fixture values MUST be regenerated against the deployed NadFunPair contract.
+// During development this test starts as `t.Skip` and is enabled once values are filled in.
+func TestFixtures_AmountOut(t *testing.T) {
+	t.Parallel()
+	t.Skip("ENABLE AFTER GENERATING FIXTURE VALUES FROM NadFunPair.getAmountOut")
+
+	for _, f := range amountOutFixtures {
+		f := f
+		t.Run(f.name, func(t *testing.T) {
+			t.Parallel()
+			r0, r1, amountIn := u(f.reserve0), u(f.reserve1), u(f.amountIn)
+
+			// reserveIn/reserveOut from the perspective of tokenIn.
+			reserveIn, reserveOut := r0, r1
+			if !f.tokenInIs0 {
+				reserveIn, reserveOut = r1, r0
+			}
+			// Buy when tokenIn == quoteToken.
+			isBuy := f.tokenInIs0 == f.quoteToken0
+
+			var got *uint256.Int
+			var err error
+			if isBuy {
+				got, err = getAmountOutMemeBuy(amountIn, reserveIn, reserveOut, f.feeRate)
+			} else {
+				got, err = getAmountOutMemeSell(amountIn, reserveIn, reserveOut, f.feeRate)
+			}
+			require.NoError(t, err)
+			assert.Equal(t, f.expectedOut, got.Dec(), "fixture %q", f.name)
+		})
+	}
+}

--- a/pkg/liquidity-source/nadswap/math_test.go
+++ b/pkg/liquidity-source/nadswap/math_test.go
@@ -150,8 +150,9 @@ func TestBuySellSymmetry_WhenNoSwapFee(t *testing.T) {
 	assert.Equal(t, buyOut.Dec(), sellOut.Dec())
 }
 
-// Fixtures captured directly from the NadFunPair.getAmountOut Solidity implementation.
-// To regenerate: see scripts/generate-nadswap-fixtures.md (not included in this PR).
+// Placeholder fixtures pending capture from NadFunPair.getAmountOut on-chain.
+// TestFixtures_AmountOut stays t.Skip'd until these values are regenerated
+// (e.g. via `cast call <pair> "getAmountOut(address,uint256)" ...`).
 var amountOutFixtures = []struct {
 	name        string
 	reserve0    string

--- a/pkg/liquidity-source/nadswap/pool_list_updater.go
+++ b/pkg/liquidity-source/nadswap/pool_list_updater.go
@@ -149,8 +149,14 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address
 	infos := make([]pairInfo, len(pairs))
 	reservesResults := make([]reservesRPCResult, len(pairs))
 
+	var feeCollector common.Address
+
 	// 1) token0 / token1 / getReserves (all required; use Aggregate)
-	reqA := u.ethrpcClient.NewRequest().SetContext(ctx)
+	reqA := u.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: u.config.FactoryAddress,
+		Method: factoryMethodFeeCollector,
+	}, []any{&feeCollector})
 	for i, p := range pairs {
 		reqA.AddCall(&ethrpc.Call{
 			ABI: pairABI, Target: p.Hex(), Method: pairMethodToken0,
@@ -187,10 +193,11 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address
 	}
 	rawCfg := make([]feeCfgWrapper, len(pairs))
 	reqB := u.ethrpcClient.NewRequest().SetContext(ctx)
+	feeCollectorStr := hexutil.Encode(feeCollector[:])
 	for i, p := range pairs {
 		reqB.AddCall(&ethrpc.Call{
 			ABI:    feeCollectorABI,
-			Target: u.config.FeeCollectorAddress,
+			Target: feeCollectorStr,
 			Method: feeCollectorMethodGetFeeConfig,
 			Params: []any{p},
 		}, []any{&rawCfg[i]})

--- a/pkg/liquidity-source/nadswap/pool_list_updater.go
+++ b/pkg/liquidity-source/nadswap/pool_list_updater.go
@@ -1,0 +1,239 @@
+package nadswap
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, c *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: cfg, ethrpcClient: c}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	start := time.Now()
+	dexID := u.config.DexID
+
+	total, err := u.getAllPairsLength(ctx)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Error("getAllPairsLength failed")
+		return nil, metadataBytes, err
+	}
+
+	offset, err := u.getOffset(metadataBytes)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": dexID, "err": err}).Warn("getOffset failed")
+	}
+
+	batchSize := u.getBatchSize(total, u.config.NewPoolLimit, offset)
+	if batchSize == 0 {
+		return nil, metadataBytes, nil
+	}
+
+	pairs, err := u.listPairAddresses(ctx, offset, batchSize)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	pools, err := u.initPools(ctx, pairs)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	newMeta, err := json.Marshal(PoolsListUpdaterMetadata{Offset: offset + batchSize})
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	logger.WithFields(logger.Fields{
+		"dex_id": dexID, "pools_len": len(pools), "offset": offset, "duration_ms": time.Since(start).Milliseconds(),
+	}).Info("Finished getting new pools")
+
+	return pools, newMeta, nil
+}
+
+func (u *PoolsListUpdater) getAllPairsLength(ctx context.Context) (int, error) {
+	var length *big.Int
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: u.config.FactoryAddress,
+		Method: factoryMethodAllPairsLength,
+	}, []any{&length})
+	if _, err := req.Call(); err != nil {
+		return 0, err
+	}
+	return int(length.Int64()), nil
+}
+
+func (u *PoolsListUpdater) getOffset(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	var m PoolsListUpdaterMetadata
+	if err := json.Unmarshal(b, &m); err != nil {
+		return 0, err
+	}
+	return m.Offset, nil
+}
+
+func (u *PoolsListUpdater) getBatchSize(length, limit, offset int) int {
+	if offset >= length {
+		return 0
+	}
+	if offset+limit >= length {
+		return length - offset
+	}
+	return limit
+}
+
+func (u *PoolsListUpdater) listPairAddresses(ctx context.Context, offset, batchSize int) ([]common.Address, error) {
+	results := make([]common.Address, batchSize)
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i := 0; i < batchSize; i++ {
+		req.AddCall(&ethrpc.Call{
+			ABI:    factoryABI,
+			Target: u.config.FactoryAddress,
+			Method: factoryMethodAllPairs,
+			Params: []any{big.NewInt(int64(offset + i))},
+		}, []any{&results[i]})
+	}
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+	pairs := make([]common.Address, 0, batchSize)
+	for i, ok := range resp.Result {
+		if ok {
+			pairs = append(pairs, results[i])
+		}
+	}
+	return pairs, nil
+}
+
+// pairInfo holds per-pair multicall results.
+type pairInfo struct {
+	Token0     common.Address
+	Token1     common.Address
+	Reserve0   *big.Int
+	Reserve1   *big.Int
+	Timestamp  uint32
+	HasFeeCfg  bool
+	QuoteToken common.Address
+	CreatorFee uint16
+	DexProtFee uint16
+}
+
+func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address) ([]entity.Pool, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+
+	infos := make([]pairInfo, len(pairs))
+
+	// 1) token0 / token1 / getReserves (all required; use Aggregate)
+	reqA := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i, p := range pairs {
+		reqA.AddCall(&ethrpc.Call{
+			ABI: pairABI, Target: p.Hex(), Method: pairMethodToken0,
+		}, []any{&infos[i].Token0})
+		reqA.AddCall(&ethrpc.Call{
+			ABI: pairABI, Target: p.Hex(), Method: pairMethodToken1,
+		}, []any{&infos[i].Token1})
+		reqA.AddCall(&ethrpc.Call{
+			ABI: pairABI, Target: p.Hex(), Method: pairMethodGetReserves,
+		}, []any{&infos[i].Reserve0, &infos[i].Reserve1, &infos[i].Timestamp})
+	}
+	if _, err := reqA.Aggregate(); err != nil {
+		return nil, err
+	}
+
+	// 2) FeeCollector.getFeeConfig(pair) — revert-tolerant (TryAggregate)
+	type feeCfgRaw struct {
+		BaseToken            common.Address
+		QuoteToken           common.Address
+		CreatorFeeRate       uint16
+		CurveProtocolFeeRate uint16
+		DexProtocolFeeRate   uint16
+	}
+	rawCfg := make([]feeCfgRaw, len(pairs))
+	reqB := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i, p := range pairs {
+		reqB.AddCall(&ethrpc.Call{
+			ABI:    feeCollectorABI,
+			Target: u.config.FeeCollectorAddress,
+			Method: feeCollectorMethodGetFeeConfig,
+			Params: []any{p},
+		}, []any{&rawCfg[i]})
+	}
+	respB, err := reqB.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+	for i, ok := range respB.Result {
+		if ok {
+			infos[i].HasFeeCfg = true
+			infos[i].QuoteToken = rawCfg[i].QuoteToken
+			infos[i].CreatorFee = rawCfg[i].CreatorFeeRate
+			infos[i].DexProtFee = rawCfg[i].DexProtocolFeeRate
+		}
+	}
+
+	pools := make([]entity.Pool, 0, len(pairs))
+	now := time.Now().Unix()
+	for i, p := range pairs {
+		r0u, _ := uint256.FromBig(infos[i].Reserve0)
+		r1u, _ := uint256.FromBig(infos[i].Reserve1)
+		extra := Extra{Reserve0: r0u, Reserve1: r1u, BlockTimestampLast: infos[i].Timestamp}
+		se := StaticExtra{
+			IsMemePair:         infos[i].HasFeeCfg,
+			QuoteToken:         infos[i].QuoteToken,
+			CreatorFeeRate:     infos[i].CreatorFee,
+			DexProtocolFeeRate: infos[i].DexProtFee,
+		}
+		extraBytes, err := json.Marshal(extra)
+		if err != nil {
+			return nil, err
+		}
+		seBytes, err := json.Marshal(se)
+		if err != nil {
+			return nil, err
+		}
+
+		pools = append(pools, entity.Pool{
+			Address:   hexutil.Encode(p[:]),
+			Exchange:  u.config.DexID,
+			Type:      DexType,
+			Timestamp: now,
+			Reserves: []string{
+				infos[i].Reserve0.String(),
+				infos[i].Reserve1.String(),
+			},
+			Tokens: []*entity.PoolToken{
+				{Address: hexutil.Encode(infos[i].Token0[:]), Swappable: true},
+				{Address: hexutil.Encode(infos[i].Token1[:]), Swappable: true},
+			},
+			Extra:       string(extraBytes),
+			StaticExtra: string(seBytes),
+		})
+	}
+
+	return pools, nil
+}

--- a/pkg/liquidity-source/nadswap/pool_list_updater.go
+++ b/pkg/liquidity-source/nadswap/pool_list_updater.go
@@ -147,6 +147,7 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address
 	}
 
 	infos := make([]pairInfo, len(pairs))
+	reservesResults := make([]reservesRPCResult, len(pairs))
 
 	// 1) token0 / token1 / getReserves (all required; use Aggregate)
 	reqA := u.ethrpcClient.NewRequest().SetContext(ctx)
@@ -159,13 +160,21 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address
 		}, []any{&infos[i].Token1})
 		reqA.AddCall(&ethrpc.Call{
 			ABI: pairABI, Target: p.Hex(), Method: pairMethodGetReserves,
-		}, []any{&infos[i].Reserve0, &infos[i].Reserve1, &infos[i].Timestamp})
+		}, []any{&reservesResults[i]})
 	}
 	if _, err := reqA.Aggregate(); err != nil {
 		return nil, err
 	}
+	for i := range pairs {
+		infos[i].Reserve0 = reservesResults[i].Reserve0
+		infos[i].Reserve1 = reservesResults[i].Reserve1
+		infos[i].Timestamp = reservesResults[i].BlockTimestampLast
+	}
 
 	// 2) FeeCollector.getFeeConfig(pair) — revert-tolerant (TryAggregate)
+	// NOTE: getFeeConfig returns a single tuple output. go-ethereum's ABI Copy uses
+	// copyAtomic for single-output methods, which sets dst.Field(0). So we must wrap
+	// our target struct in another struct (FeeCfg field at index 0).
 	type feeCfgRaw struct {
 		BaseToken            common.Address
 		QuoteToken           common.Address
@@ -173,7 +182,10 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address
 		CurveProtocolFeeRate uint16
 		DexProtocolFeeRate   uint16
 	}
-	rawCfg := make([]feeCfgRaw, len(pairs))
+	type feeCfgWrapper struct {
+		FeeCfg feeCfgRaw
+	}
+	rawCfg := make([]feeCfgWrapper, len(pairs))
 	reqB := u.ethrpcClient.NewRequest().SetContext(ctx)
 	for i, p := range pairs {
 		reqB.AddCall(&ethrpc.Call{
@@ -190,9 +202,9 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, pairs []common.Address
 	for i, ok := range respB.Result {
 		if ok {
 			infos[i].HasFeeCfg = true
-			infos[i].QuoteToken = rawCfg[i].QuoteToken
-			infos[i].CreatorFee = rawCfg[i].CreatorFeeRate
-			infos[i].DexProtFee = rawCfg[i].DexProtocolFeeRate
+			infos[i].QuoteToken = rawCfg[i].FeeCfg.QuoteToken
+			infos[i].CreatorFee = rawCfg[i].FeeCfg.CreatorFeeRate
+			infos[i].DexProtFee = rawCfg[i].FeeCfg.DexProtocolFeeRate
 		}
 	}
 

--- a/pkg/liquidity-source/nadswap/pool_list_updater_test.go
+++ b/pkg/liquidity-source/nadswap/pool_list_updater_test.go
@@ -1,7 +1,6 @@
 package nadswap
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 func TestPoolListUpdater_Mainnet(t *testing.T) {
@@ -20,17 +18,15 @@ func TestPoolListUpdater_Mainnet(t *testing.T) {
 	}
 
 	cfg := &Config{
-		DexID:               DexType,
-		ChainID:             valueobject.ChainIDMonad,
-		FactoryAddress:      "0xA25b13127e63ddae6d0b35570FF3D39dBD621001",
-		FeeCollectorAddress: "0xE1C8b73343f5A83EBe165BE90470d84B00e33022",
-		NewPoolLimit:        50,
+		DexID:          DexType,
+		FactoryAddress: "0xA25b13127e63ddae6d0b35570FF3D39dBD621001",
+		NewPoolLimit:   50,
 	}
 	client := ethrpc.New("https://rpc-mainnet.monadinfra.com/rpc/ICLJSp4IKDWLSpZ4laJATUQfL0ucwxiK").
 		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
 
 	u := NewPoolsListUpdater(cfg, client)
-	pools, _, err := u.GetNewPools(context.Background(), nil)
+	pools, _, err := u.GetNewPools(t.Context(), nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, pools)
 
@@ -51,7 +47,7 @@ func TestPoolListUpdater_Mainnet(t *testing.T) {
 	tracker, err := NewPoolTracker(cfg, client)
 	require.NoError(t, err)
 	for _, p := range pools[:min(3, len(pools))] {
-		p2, err := tracker.GetNewPoolState(context.Background(), p, pool.GetNewPoolStateParams{})
+		p2, err := tracker.GetNewPoolState(t.Context(), p, pool.GetNewPoolStateParams{})
 		require.NoError(t, err)
 		require.NotNil(t, p2)
 		t.Logf("pool=%s block=%d", p2.Address, p2.BlockNumber)

--- a/pkg/liquidity-source/nadswap/pool_list_updater_test.go
+++ b/pkg/liquidity-source/nadswap/pool_list_updater_test.go
@@ -1,0 +1,67 @@
+package nadswap
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+func TestPoolListUpdater_Mainnet(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	cfg := &Config{
+		DexID:               DexType,
+		ChainID:             valueobject.ChainIDMonad,
+		FactoryAddress:      "0xA25b13127e63ddae6d0b35570FF3D39dBD621001",
+		FeeCollectorAddress: "0xE1C8b73343f5A83EBe165BE90470d84B00e33022",
+		NewPoolLimit:        50,
+	}
+	client := ethrpc.New("https://rpc-mainnet.monadinfra.com/rpc/ICLJSp4IKDWLSpZ4laJATUQfL0ucwxiK").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+
+	u := NewPoolsListUpdater(cfg, client)
+	pools, _, err := u.GetNewPools(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, pools)
+
+	// Classify: at least one pair should be present; ideally both meme and general.
+	memeCount, generalCount := 0, 0
+	for _, p := range pools {
+		if p.StaticExtra == "" {
+			continue
+		}
+		if isMeme := contains(p.StaticExtra, `"meme":true`); isMeme {
+			memeCount++
+		} else {
+			generalCount++
+		}
+	}
+	t.Logf("discovered %d pools (meme=%d general=%d)", len(pools), memeCount, generalCount)
+
+	tracker, err := NewPoolTracker(cfg, client)
+	require.NoError(t, err)
+	for _, p := range pools[:min(3, len(pools))] {
+		p2, err := tracker.GetNewPoolState(context.Background(), p, pool.GetNewPoolStateParams{})
+		require.NoError(t, err)
+		require.NotNil(t, p2)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/liquidity-source/nadswap/pool_list_updater_test.go
+++ b/pkg/liquidity-source/nadswap/pool_list_updater_test.go
@@ -54,6 +54,8 @@ func TestPoolListUpdater_Mainnet(t *testing.T) {
 		p2, err := tracker.GetNewPoolState(context.Background(), p, pool.GetNewPoolStateParams{})
 		require.NoError(t, err)
 		require.NotNil(t, p2)
+		t.Logf("pool=%s block=%d", p2.Address, p2.BlockNumber)
+		require.Greater(t, p2.BlockNumber, uint64(0), "tracker must populate BlockNumber from RPC fallback")
 	}
 }
 

--- a/pkg/liquidity-source/nadswap/pool_simulator.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator.go
@@ -2,6 +2,7 @@ package nadswap
 
 import (
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -223,6 +224,10 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 	if si.NewReserve1 != nil {
 		s.reserve1 = si.NewReserve1
 	}
+	if len(s.Info.Reserves) == 2 {
+		s.Info.Reserves[0] = s.reserve0.ToBig()
+		s.Info.Reserves[1] = s.reserve1.ToBig()
+	}
 }
 
 // CloneState returns a deep copy of the simulator suitable for speculative routing.
@@ -230,6 +235,7 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 // original; immutable scalar configuration is copied by value via struct copy.
 func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
 	cloned := *s
+	cloned.Info.Reserves = slices.Clone(s.Info.Reserves)
 	cloned.reserve0 = s.reserve0.Clone()
 	cloned.reserve1 = s.reserve1.Clone()
 	return &cloned

--- a/pkg/liquidity-source/nadswap/pool_simulator.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 type PoolSimulator struct {
@@ -111,13 +112,13 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	if err != nil {
 		return nil, err
 	}
+	if amountOut.IsZero() {
+		return nil, ErrInsufficientOutput
+	}
 
-	// Compute post-swap reserves for SwapInfo. In NadFunPair the input-side LP fee is *kept in the pool*
-	// (k-invariant uses balance adjusted only by LP fee), but for off-chain quote we model reserves
-	// updating to reserveIn += amountIn and reserveOut -= amountOut (matching how aggregators chain
-	// quotes for routing).
-	newReserveIn := new(uint256.Int).Add(reserveIn, amountIn)
-	newReserveOut := new(uint256.Int).Sub(reserveOut, amountOut)
+	// Compute post-swap reserves for SwapInfo, accounting for quote-token swap fees transferred to
+	// FeeCollector before _update on meme pairs (see NadFunPair._collectFee).
+	newReserveIn, newReserveOut := s.computeNewReserves(amountIn, amountOut, reserveIn, reserveOut, s.isMeme, isBuy)
 	var newR0, newR1 *uint256.Int
 	if indexIn == 0 {
 		newR0, newR1 = newReserveIn, newReserveOut
@@ -134,6 +135,41 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		Gas:            gas,
 		SwapInfo:       SwapInfo{NewReserve0: newR0, NewReserve1: newR1},
 	}, nil
+}
+
+// computeNewReserves projects post-swap reserves accounting for quote-token swap fees
+// transferred to FeeCollector before _update (meme pairs only; general pairs and feeRate==0 use the simple delta).
+//
+//   - meme buy  (tokenIn == quoteToken): newReserveIn  = reserveIn  + amountIn  - swapFeeIn
+//     newReserveOut = reserveOut - amountOut
+//     where swapFeeIn  = floor(amountIn  * feeRate / BPS)
+//   - meme sell (tokenIn != quoteToken): newReserveIn  = reserveIn  + amountIn
+//     newReserveOut = reserveOut - amountOut - swapFeeOut
+//     where swapFeeOut = floor(amountOut * feeRate / (BPS - LpFeeRate - feeRate))
+//   - else: simple +amountIn / -amountOut
+//
+// Returns (newReserveIn, newReserveOut). All arithmetic uses floor (matches Solidity).
+func (s *PoolSimulator) computeNewReserves(amountIn, amountOut, reserveIn, reserveOut *uint256.Int, isMeme, isBuy bool) (*uint256.Int, *uint256.Int) {
+	newReserveIn := new(uint256.Int).Add(reserveIn, amountIn)
+	newReserveOut := new(uint256.Int).Sub(reserveOut, amountOut)
+	if !isMeme || s.feeRate == 0 {
+		return newReserveIn, newReserveOut
+	}
+	uFee := uint256.NewInt(uint64(s.feeRate))
+	if isBuy {
+		// swapFeeIn = amountIn * feeRate / BPS (floor)
+		var swapFeeIn uint256.Int
+		big256.MulDivDown(&swapFeeIn, amountIn, uFee, uBPS)
+		newReserveIn.Sub(newReserveIn, &swapFeeIn)
+	} else {
+		// swapFeeOut = amountOut * feeRate / (BPS - LpFeeRate - feeRate)
+		var denom, swapFeeOut uint256.Int
+		denom.Sub(uBPS, uLpFeeRate)
+		denom.Sub(&denom, uFee)
+		big256.MulDivDown(&swapFeeOut, amountOut, uFee, &denom)
+		newReserveOut.Sub(newReserveOut, &swapFeeOut)
+	}
+	return newReserveIn, newReserveOut
 }
 
 // computeReportedFee returns the input-side fee for reporting (informational only).
@@ -191,8 +227,7 @@ func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.Calc
 		return nil, err
 	}
 
-	newReserveIn := new(uint256.Int).Add(reserveIn, amountIn)
-	newReserveOut := new(uint256.Int).Sub(reserveOut, amountOut)
+	newReserveIn, newReserveOut := s.computeNewReserves(amountIn, amountOut, reserveIn, reserveOut, s.isMeme, isBuy)
 	var newR0, newR1 *uint256.Int
 	if indexIn == 0 {
 		newR0, newR1 = newReserveIn, newReserveOut

--- a/pkg/liquidity-source/nadswap/pool_simulator.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator.go
@@ -136,8 +136,9 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 }
 
 // computeReportedFee returns the input-side fee for reporting (informational only).
-//   - general / meme buy: amountIn * (LP + feeRate) / BPS
-//   - meme sell:           amountIn * LP / BPS  (swap fee is on output and already netted)
+//   - general:   amountIn * LpFeeRate / BPS  (feeRate is 0 for general pools)
+//   - meme buy:  amountIn * (LpFeeRate + feeRate) / BPS
+//   - meme sell: amountIn * LpFeeRate / BPS  (swap fee is on output and already netted)
 func computeReportedFee(amountIn *uint256.Int, isMeme, isBuy bool, feeRate uint16) *uint256.Int {
 	rate := uint64(LpFeeRate)
 	if isMeme && isBuy {
@@ -153,7 +154,8 @@ func computeReportedFee(amountIn *uint256.Int, isMeme, isBuy bool, feeRate uint1
 // (consuming SwapInfo.NewReserve0/NewReserve1) lands in Task 8.
 func (s *PoolSimulator) UpdateBalance(_ pool.UpdateBalanceParams) {}
 
-// GetMetaInfo returns pool metadata for the swap router. Currently exposes block number only.
+// GetMetaInfo returns a payload describing pool state at the time of quoting.
+// Exposes block number only, matching other v2-fork integrations in this repo.
 func (s *PoolSimulator) GetMetaInfo(_ string, _ string) any {
 	return struct {
 		BlockNumber uint64 `json:"blockNumber"`

--- a/pkg/liquidity-source/nadswap/pool_simulator.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator.go
@@ -150,9 +150,90 @@ func computeReportedFee(amountIn *uint256.Int, isMeme, isBuy bool, feeRate uint1
 	return &fee
 }
 
-// UpdateBalance is a placeholder satisfying IPoolSimulator. The real implementation
-// (consuming SwapInfo.NewReserve0/NewReserve1) lands in Task 8.
-func (s *PoolSimulator) UpdateBalance(_ pool.UpdateBalanceParams) {}
+func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
+	indexIn := s.GetTokenIndex(params.TokenIn)
+	indexOut := s.GetTokenIndex(params.TokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 || indexIn == indexOut {
+		return nil, ErrInvalidToken
+	}
+
+	amountOut, overflow := uint256.FromBig(params.TokenAmountOut.Amount)
+	if overflow {
+		return nil, ErrOverflow
+	}
+
+	reserveIn, reserveOut := s.reserve0, s.reserve1
+	if indexIn == 1 {
+		reserveIn, reserveOut = s.reserve1, s.reserve0
+	}
+
+	var (
+		amountIn *uint256.Int
+		err      error
+		gas      int64
+		isBuy    bool
+	)
+
+	switch {
+	case !s.isMeme:
+		amountIn, err = getAmountInGeneral(amountOut, reserveIn, reserveOut)
+		gas = sellGas
+	case s.tokenIsQuote(params.TokenIn):
+		amountIn, err = getAmountInMemeBuy(amountOut, reserveIn, reserveOut, s.feeRate)
+		gas = buyGas
+		isBuy = true
+	default:
+		amountIn, err = getAmountInMemeSell(amountOut, reserveIn, reserveOut, s.feeRate)
+		gas = sellGas
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	newReserveIn := new(uint256.Int).Add(reserveIn, amountIn)
+	newReserveOut := new(uint256.Int).Sub(reserveOut, amountOut)
+	var newR0, newR1 *uint256.Int
+	if indexIn == 0 {
+		newR0, newR1 = newReserveIn, newReserveOut
+	} else {
+		newR0, newR1 = newReserveOut, newReserveIn
+	}
+
+	feeAmount := computeReportedFee(amountIn, s.isMeme, isBuy, s.feeRate)
+
+	return &pool.CalcAmountInResult{
+		TokenAmountIn: &pool.TokenAmount{Token: params.TokenIn, Amount: amountIn.ToBig()},
+		Fee:           &pool.TokenAmount{Token: params.TokenIn, Amount: feeAmount.ToBig()},
+		Gas:           gas,
+		SwapInfo:      SwapInfo{NewReserve0: newR0, NewReserve1: newR1},
+	}, nil
+}
+
+// UpdateBalance applies the post-swap reserves carried in SwapInfo to the simulator.
+// It is a no-op if SwapInfo is missing or has the wrong type, mirroring how other
+// v2-fork integrations defensively guard against routing/state mismatches.
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	si, ok := params.SwapInfo.(SwapInfo)
+	if !ok {
+		return
+	}
+	if si.NewReserve0 != nil {
+		s.reserve0 = si.NewReserve0
+	}
+	if si.NewReserve1 != nil {
+		s.reserve1 = si.NewReserve1
+	}
+}
+
+// CloneState returns a deep copy of the simulator suitable for speculative routing.
+// Reserves are cloned so mutations on the returned simulator do not affect the
+// original; immutable scalar configuration is copied by value via struct copy.
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.reserve0 = s.reserve0.Clone()
+	cloned.reserve1 = s.reserve1.Clone()
+	return &cloned
+}
 
 // GetMetaInfo returns a payload describing pool state at the time of quoting.
 // Exposes block number only, matching other v2-fork integrations in this repo.

--- a/pkg/liquidity-source/nadswap/pool_simulator.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator.go
@@ -1,0 +1,163 @@
+package nadswap
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+
+	isMeme             bool
+	quoteToken         common.Address
+	creatorFeeRate     uint16
+	dexProtocolFeeRate uint16
+	feeRate            uint16 // creator + dexProtocol
+
+	reserve0 *uint256.Int
+	reserve1 *uint256.Int
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
+	var extra Extra
+	if err := json.Unmarshal([]byte(entityPool.Extra), &extra); err != nil {
+		return nil, err
+	}
+	var se StaticExtra
+	if err := json.Unmarshal([]byte(entityPool.StaticExtra), &se); err != nil {
+		return nil, err
+	}
+
+	return &PoolSimulator{
+		Pool: pool.Pool{
+			Info: pool.PoolInfo{
+				Address:  entityPool.Address,
+				Exchange: entityPool.Exchange,
+				Type:     entityPool.Type,
+				Tokens: lo.Map(entityPool.Tokens, func(t *entity.PoolToken, _ int) string {
+					return t.Address
+				}),
+				Reserves: lo.Map(entityPool.Reserves, func(r string, _ int) *big.Int {
+					b, _ := new(big.Int).SetString(r, 10)
+					return b
+				}),
+				BlockNumber: entityPool.BlockNumber,
+			},
+		},
+		isMeme:             se.IsMemePair,
+		quoteToken:         se.QuoteToken,
+		creatorFeeRate:     se.CreatorFeeRate,
+		dexProtocolFeeRate: se.DexProtocolFeeRate,
+		feeRate:            se.CreatorFeeRate + se.DexProtocolFeeRate,
+		reserve0:           extra.Reserve0.Clone(),
+		reserve1:           extra.Reserve1.Clone(),
+	}, nil
+}
+
+// tokenIsQuote compares a pool token address case-insensitively against the
+// configured quote token. Used to detect buy direction (tokenIn == quoteToken)
+// for meme pairs.
+func (s *PoolSimulator) tokenIsQuote(token string) bool {
+	return strings.EqualFold(token, s.quoteToken.Hex())
+}
+
+func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	indexIn := s.GetTokenIndex(params.TokenAmountIn.Token)
+	indexOut := s.GetTokenIndex(params.TokenOut)
+	if indexIn < 0 || indexOut < 0 || indexIn == indexOut {
+		return nil, ErrInvalidToken
+	}
+
+	amountIn, overflow := uint256.FromBig(params.TokenAmountIn.Amount)
+	if overflow {
+		return nil, ErrOverflow
+	}
+
+	reserveIn, reserveOut := s.reserve0, s.reserve1
+	if indexIn == 1 {
+		reserveIn, reserveOut = s.reserve1, s.reserve0
+	}
+
+	var (
+		amountOut *uint256.Int
+		err       error
+		gas       int64
+		isBuy     bool
+	)
+
+	switch {
+	case !s.isMeme:
+		amountOut, err = getAmountOutGeneral(amountIn, reserveIn, reserveOut)
+		gas = sellGas
+	case s.tokenIsQuote(params.TokenAmountIn.Token):
+		amountOut, err = getAmountOutMemeBuy(amountIn, reserveIn, reserveOut, s.feeRate)
+		gas = buyGas
+		isBuy = true
+	default:
+		amountOut, err = getAmountOutMemeSell(amountIn, reserveIn, reserveOut, s.feeRate)
+		gas = sellGas
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute post-swap reserves for SwapInfo. In NadFunPair the input-side LP fee is *kept in the pool*
+	// (k-invariant uses balance adjusted only by LP fee), but for off-chain quote we model reserves
+	// updating to reserveIn += amountIn and reserveOut -= amountOut (matching how aggregators chain
+	// quotes for routing).
+	newReserveIn := new(uint256.Int).Add(reserveIn, amountIn)
+	newReserveOut := new(uint256.Int).Sub(reserveOut, amountOut)
+	var newR0, newR1 *uint256.Int
+	if indexIn == 0 {
+		newR0, newR1 = newReserveIn, newReserveOut
+	} else {
+		newR0, newR1 = newReserveOut, newReserveIn
+	}
+
+	feeToken := params.TokenAmountIn.Token
+	feeAmount := computeReportedFee(amountIn, s.isMeme, isBuy, s.feeRate)
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: params.TokenOut, Amount: amountOut.ToBig()},
+		Fee:            &pool.TokenAmount{Token: feeToken, Amount: feeAmount.ToBig()},
+		Gas:            gas,
+		SwapInfo:       SwapInfo{NewReserve0: newR0, NewReserve1: newR1},
+	}, nil
+}
+
+// computeReportedFee returns the input-side fee for reporting (informational only).
+//   - general / meme buy: amountIn * (LP + feeRate) / BPS
+//   - meme sell:           amountIn * LP / BPS  (swap fee is on output and already netted)
+func computeReportedFee(amountIn *uint256.Int, isMeme, isBuy bool, feeRate uint16) *uint256.Int {
+	rate := uint64(LpFeeRate)
+	if isMeme && isBuy {
+		rate += uint64(feeRate)
+	}
+	var fee uint256.Int
+	fee.Mul(amountIn, uint256.NewInt(rate))
+	fee.Div(&fee, uBPS)
+	return &fee
+}
+
+// UpdateBalance is a placeholder satisfying IPoolSimulator. The real implementation
+// (consuming SwapInfo.NewReserve0/NewReserve1) lands in Task 8.
+func (s *PoolSimulator) UpdateBalance(_ pool.UpdateBalanceParams) {}
+
+// GetMetaInfo returns pool metadata for the swap router. Currently exposes block number only.
+func (s *PoolSimulator) GetMetaInfo(_ string, _ string) any {
+	return struct {
+		BlockNumber uint64 `json:"blockNumber"`
+	}{
+		BlockNumber: s.Info.BlockNumber,
+	}
+}

--- a/pkg/liquidity-source/nadswap/pool_simulator_test.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator_test.go
@@ -1,0 +1,94 @@
+package nadswap
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+// commonHex parses a hex string into a common.Address.
+// Note: Test fixtures use real-looking placeholder addresses (0x0a / 0x0b) so that
+// they survive `common.HexToAddress` normalization — the original plan used `0xT0`
+// / `0xT1` which both collapse to the zero address, making buy/sell dispatch
+// indistinguishable.
+func commonHex(s string) common.Address {
+	if s == "" {
+		return common.Address{}
+	}
+	return common.HexToAddress(s)
+}
+
+// tokenAddr returns the canonical hex form for a placeholder token id so that the
+// entity.Pool tokens and the StaticExtra quoteToken normalize to the same value.
+func tokenAddr(id string) string {
+	return common.HexToAddress(id).Hex()
+}
+
+func buildPool(t *testing.T, isMeme bool, quote, token0, token1 string, r0, r1 string, feeRate uint16) *PoolSimulator {
+	t.Helper()
+	extra := Extra{Reserve0: u(r0), Reserve1: u(r1)}
+	se := StaticExtra{
+		IsMemePair:         isMeme,
+		QuoteToken:         commonHex(quote),
+		CreatorFeeRate:     0,
+		DexProtocolFeeRate: feeRate, // put whole rate on dexProtocolFeeRate for simplicity
+	}
+	extraBytes, _ := json.Marshal(extra)
+	seBytes, _ := json.Marshal(se)
+	p := entity.Pool{
+		Address: "0xpair",
+		Type:    DexType,
+		Tokens: []*entity.PoolToken{
+			{Address: tokenAddr(token0), Swappable: true},
+			{Address: tokenAddr(token1), Swappable: true},
+		},
+		Reserves:    []string{r0, r1},
+		Extra:       string(extraBytes),
+		StaticExtra: string(seBytes),
+	}
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+	return sim
+}
+
+func TestPoolSimulator_CalcAmountOut_GeneralPair(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, false, "", "0x0a", "0x0b", "10000", "10000", 0)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "907", res.TokenAmountOut.Amount.String())
+}
+
+func TestPoolSimulator_CalcAmountOut_MemeBuy(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, true, "0x0a", "0x0a", "0x0b", "10000", "10000", 100)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "898", res.TokenAmountOut.Amount.String())
+}
+
+func TestPoolSimulator_CalcAmountOut_MemeSell(t *testing.T) {
+	t.Parallel()
+	// quote is T1; selling T0 -> T1 means sell direction
+	sim := buildPool(t, true, "0x0b", "0x0a", "0x0b", "10000", "10000", 100)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "897", res.TokenAmountOut.Amount.String())
+}

--- a/pkg/liquidity-source/nadswap/pool_simulator_test.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator_test.go
@@ -92,3 +92,45 @@ func TestPoolSimulator_CalcAmountOut_MemeSell(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "897", res.TokenAmountOut.Amount.String())
 }
+
+func TestPoolSimulator_CalcAmountIn_MemeBuy(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, true, "0x0a", "0x0a", "0x0b", "10000", "10000", 100)
+	res, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: tokenAddr("0x0b"), Amount: big.NewInt(898)},
+		TokenIn:        tokenAddr("0x0a"),
+	})
+	require.NoError(t, err)
+	// Round-trip target was 1000, allow 1 unit ceiling slack.
+	got := res.TokenAmountIn.Amount.Int64()
+	assert.GreaterOrEqual(t, got, int64(1000))
+	assert.LessOrEqual(t, got, int64(1001))
+}
+
+func TestPoolSimulator_UpdateBalance(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, false, "", "0x0a", "0x0b", "10000", "10000", 0)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+	// After update, reserves should reflect: r0 = 10000 + 1000 = 11000; r1 = 10000 - 907 = 9093
+	assert.Equal(t, "11000", sim.reserve0.Dec())
+	assert.Equal(t, "9093", sim.reserve1.Dec())
+}
+
+func TestPoolSimulator_CloneState(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, false, "", "0x0a", "0x0b", "10000", "10000", 0)
+	clone := sim.CloneState().(*PoolSimulator)
+	// Mutate clone, original must be untouched.
+	clone.reserve0.SetUint64(1)
+	assert.Equal(t, "10000", sim.reserve0.Dec())
+}

--- a/pkg/liquidity-source/nadswap/pool_simulator_test.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator_test.go
@@ -144,6 +144,61 @@ func TestPoolSimulator_CloneState_InfoReservesIndependent(t *testing.T) {
 	assert.Equal(t, "10000", sim.Info.Reserves[0].String())
 }
 
+func TestPoolSimulator_CalcAmountOut_MemeBuy_ReserveDeltas(t *testing.T) {
+	t.Parallel()
+	// quote=T0, base=T1, reserves 10000/10000, feeRate=100
+	sim := buildPool(t, true, "0x0a", "0x0a", "0x0b", "10000", "10000", 100)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+	// amountIn = 1000, feeRate=100, BPS=10000 -> swapFeeIn = 1000*100/10000 = 10
+	// newReserveQuote (token0) = 10000 + 1000 - 10 = 10990
+	// amountOut = 898
+	// newReserveBase (token1) = 10000 - 898 = 9102
+	assert.Equal(t, "10990", sim.reserve0.Dec())
+	assert.Equal(t, "9102", sim.reserve1.Dec())
+}
+
+func TestPoolSimulator_CalcAmountOut_MemeSell_ReserveDeltas(t *testing.T) {
+	t.Parallel()
+	// quote=T1, base=T0, reserves 10000/10000, feeRate=100
+	sim := buildPool(t, true, "0x0b", "0x0a", "0x0b", "10000", "10000", 100)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+	// amountIn = 1000 (base), amountOut = 897 (net quote)
+	// swapFeeOut = floor(897 * 100 / (10000 - 25 - 100)) = floor(89700 / 9875) = 9
+	// newReserveBase  (token0) = 10000 + 1000 = 11000
+	// newReserveQuote (token1) = 10000 - 897 - 9 = 9094
+	assert.Equal(t, "11000", sim.reserve0.Dec())
+	assert.Equal(t, "9094", sim.reserve1.Dec())
+}
+
+func TestPoolSimulator_CalcAmountOut_RejectsZeroOutput(t *testing.T) {
+	t.Parallel()
+	// Reserves so disproportionate that 1 unit input rounds to 0 output.
+	sim := buildPool(t, false, "", "0x0a", "0x0b", "1000000000000000000", "1", 0)
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.ErrorIs(t, err, ErrInsufficientOutput)
+}
+
 func TestPoolSimulator_UpdateBalance_SyncsInfoReserves(t *testing.T) {
 	t.Parallel()
 	sim := buildPool(t, false, "", "0x0a", "0x0b", "10000", "10000", 0)

--- a/pkg/liquidity-source/nadswap/pool_simulator_test.go
+++ b/pkg/liquidity-source/nadswap/pool_simulator_test.go
@@ -134,3 +134,31 @@ func TestPoolSimulator_CloneState(t *testing.T) {
 	clone.reserve0.SetUint64(1)
 	assert.Equal(t, "10000", sim.reserve0.Dec())
 }
+
+func TestPoolSimulator_CloneState_InfoReservesIndependent(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, false, "", "0x0a", "0x0b", "10000", "10000", 0)
+	clone := sim.CloneState().(*PoolSimulator)
+	// Mutate clone's Info.Reserves[0]; the original must not change.
+	clone.Info.Reserves[0] = big.NewInt(1)
+	assert.Equal(t, "10000", sim.Info.Reserves[0].String())
+}
+
+func TestPoolSimulator_UpdateBalance_SyncsInfoReserves(t *testing.T) {
+	t.Parallel()
+	sim := buildPool(t, false, "", "0x0a", "0x0b", "10000", "10000", 0)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenOut:      tokenAddr("0x0b"),
+	})
+	require.NoError(t, err)
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenAddr("0x0a"), Amount: big.NewInt(1000)},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+	// Info.Reserves must reflect the new state too (not just the private fields).
+	assert.Equal(t, "11000", sim.Info.Reserves[0].String())
+	assert.Equal(t, "9093", sim.Info.Reserves[1].String())
+}

--- a/pkg/liquidity-source/nadswap/pool_tracker.go
+++ b/pkg/liquidity-source/nadswap/pool_tracker.go
@@ -46,7 +46,7 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, nil
 	}
 
-	extra := Extra{Reserve0: rd.Reserve0, Reserve1: rd.Reserve1, BlockTimestampLast: rd.BlockTimestampLast}
+	extra := Extra(rd)
 	extraBytes, err := json.Marshal(extra)
 	if err != nil {
 		return p, err

--- a/pkg/liquidity-source/nadswap/pool_tracker.go
+++ b/pkg/liquidity-source/nadswap/pool_tracker.go
@@ -1,0 +1,93 @@
+package nadswap
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+	logDecoder   ILogDecoder
+}
+
+var _ = pooltrack.RegisterFactoryCE(DexType, NewPoolTracker)
+
+func NewPoolTracker(cfg *Config, c *ethrpc.Client) (*PoolTracker, error) {
+	return &PoolTracker{
+		config:       cfg,
+		ethrpcClient: c,
+		logDecoder:   NewLogDecoder(),
+	}, nil
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context, p entity.Pool, params pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	start := time.Now()
+	rd, blockNum, err := t.getReserves(ctx, p.Address, &params)
+	if err != nil {
+		return p, err
+	}
+	if blockNum != nil && p.BlockNumber > blockNum.Uint64() {
+		logger.WithFields(logger.Fields{
+			"pool_id": p.Address, "pool_block": p.BlockNumber, "data_block": blockNum.Uint64(),
+		}).Info("skip update: data block older than pool block")
+		return p, nil
+	}
+
+	extra := Extra{Reserve0: rd.Reserve0, Reserve1: rd.Reserve1, BlockTimestampLast: rd.BlockTimestampLast}
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return p, err
+	}
+	p.Extra = string(extraBytes)
+	p.Reserves = []string{rd.Reserve0.Dec(), rd.Reserve1.Dec()}
+	p.Timestamp = time.Now().Unix()
+	if blockNum != nil {
+		p.BlockNumber = blockNum.Uint64()
+	}
+
+	logger.WithFields(logger.Fields{
+		"pool_id": p.Address, "duration_ms": time.Since(start).Milliseconds(),
+	}).Info("Finished getting new pool state")
+	return p, nil
+}
+
+func (t *PoolTracker) getReserves(
+	ctx context.Context, poolAddr string, params *pool.GetNewPoolStateParams,
+) (ReserveData, *big.Int, error) {
+	if params != nil && len(params.Logs) > 0 {
+		rd, blockNum, err := t.logDecoder.Decode(params.Logs, params.BlockHeaders)
+		if err == nil && !rd.IsZero() {
+			return rd, blockNum, nil
+		}
+	}
+	return t.getReservesFromRPC(ctx, poolAddr)
+}
+
+func (t *PoolTracker) getReservesFromRPC(ctx context.Context, poolAddr string) (ReserveData, *big.Int, error) {
+	var r0, r1 *big.Int
+	var ts uint32
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{
+		ABI: pairABI, Target: poolAddr, Method: pairMethodGetReserves,
+	}, []any{&r0, &r1, &ts})
+	resp, err := req.Call()
+	if err != nil {
+		return ReserveData{}, nil, err
+	}
+	u0, _ := uint256.FromBig(r0)
+	u1, _ := uint256.FromBig(r1)
+	return ReserveData{Reserve0: u0, Reserve1: u1, BlockTimestampLast: ts}, resp.BlockNumber, nil
+}

--- a/pkg/liquidity-source/nadswap/pool_tracker.go
+++ b/pkg/liquidity-source/nadswap/pool_tracker.go
@@ -82,7 +82,7 @@ func (t *PoolTracker) getReservesFromRPC(ctx context.Context, poolAddr string) (
 	req.AddCall(&ethrpc.Call{
 		ABI: pairABI, Target: poolAddr, Method: pairMethodGetReserves,
 	}, []any{&result})
-	resp, err := req.Call()
+	resp, err := req.TryBlockAndAggregate()
 	if err != nil {
 		return ReserveData{}, nil, err
 	}

--- a/pkg/liquidity-source/nadswap/pool_tracker.go
+++ b/pkg/liquidity-source/nadswap/pool_tracker.go
@@ -77,17 +77,16 @@ func (t *PoolTracker) getReserves(
 }
 
 func (t *PoolTracker) getReservesFromRPC(ctx context.Context, poolAddr string) (ReserveData, *big.Int, error) {
-	var r0, r1 *big.Int
-	var ts uint32
+	var result reservesRPCResult
 	req := t.ethrpcClient.NewRequest().SetContext(ctx)
 	req.AddCall(&ethrpc.Call{
 		ABI: pairABI, Target: poolAddr, Method: pairMethodGetReserves,
-	}, []any{&r0, &r1, &ts})
+	}, []any{&result})
 	resp, err := req.Call()
 	if err != nil {
 		return ReserveData{}, nil, err
 	}
-	u0, _ := uint256.FromBig(r0)
-	u1, _ := uint256.FromBig(r1)
-	return ReserveData{Reserve0: u0, Reserve1: u1, BlockTimestampLast: ts}, resp.BlockNumber, nil
+	u0, _ := uint256.FromBig(result.Reserve0)
+	u1, _ := uint256.FromBig(result.Reserve1)
+	return ReserveData{Reserve0: u0, Reserve1: u1, BlockTimestampLast: result.BlockTimestampLast}, resp.BlockNumber, nil
 }

--- a/pkg/liquidity-source/nadswap/types.go
+++ b/pkg/liquidity-source/nadswap/types.go
@@ -1,0 +1,38 @@
+package nadswap
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+type Extra struct {
+	Reserve0           *uint256.Int `json:"r0"`
+	Reserve1           *uint256.Int `json:"r1"`
+	BlockTimestampLast uint32       `json:"ts"`
+}
+
+type StaticExtra struct {
+	IsMemePair         bool           `json:"meme"`
+	QuoteToken         common.Address `json:"qt"`
+	CreatorFeeRate     uint16         `json:"cfr"`
+	DexProtocolFeeRate uint16         `json:"dpfr"`
+}
+
+type SwapInfo struct {
+	NewReserve0 *uint256.Int `json:"-"`
+	NewReserve1 *uint256.Int `json:"-"`
+}
+
+type PoolsListUpdaterMetadata struct {
+	Offset int `json:"offset"`
+}
+
+type ReserveData struct {
+	Reserve0           *uint256.Int
+	Reserve1           *uint256.Int
+	BlockTimestampLast uint32
+}
+
+func (r ReserveData) IsZero() bool {
+	return r.Reserve0 == nil || r.Reserve1 == nil || (r.Reserve0.IsZero() && r.Reserve1.IsZero())
+}

--- a/pkg/liquidity-source/nadswap/types.go
+++ b/pkg/liquidity-source/nadswap/types.go
@@ -1,6 +1,8 @@
 package nadswap
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 )
@@ -35,4 +37,12 @@ type ReserveData struct {
 
 func (r ReserveData) IsZero() bool {
 	return r.Reserve0 == nil || r.Reserve1 == nil || (r.Reserve0.IsZero() && r.Reserve1.IsZero())
+}
+
+// reservesRPCResult is the raw ABI binding target for NadFunPair.getReserves().
+// ABI uint112 decodes to *big.Int; convert to ReserveData (uint256) afterwards.
+type reservesRPCResult struct {
+	Reserve0           *big.Int
+	Reserve1           *big.Int
+	BlockTimestampLast uint32
 }

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -108,6 +108,7 @@ import (
 	pkg_liquiditysource_mooniswap "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/mooniswap"
 	pkg_liquiditysource_nabla "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nabla"
 	pkg_liquiditysource_nadfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nad-fun"
+	pkg_liquiditysource_nadswap "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nadswap"
 	pkg_liquiditysource_native_v3 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/native/v3"
 	pkg_liquiditysource_nomiswap_nomiswapstable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nomiswap/nomiswapstable"
 	pkg_liquiditysource_obric "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/obric"
@@ -335,6 +336,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_mooniswap.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_nabla.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_nadfun.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_nadswap.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_native_v3.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_nomiswap_nomiswapstable.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_obric.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -101,6 +101,7 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/mooniswap"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nabla"
 	nadfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nad-fun"
+	nadswap "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nadswap"
 	nativev3 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/native/v3"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/nomiswap"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/obric"
@@ -386,6 +387,7 @@ type Types struct {
 	MapleSyrup                 string
 	Gsm4626                    string
 	NadFun                     string
+	NadSwap                    string
 	CloberOB                   string
 	FluidDexV2                 string
 	Wildcard                   string
@@ -602,6 +604,7 @@ var (
 		MapleSyrup:                 maplesyrup.DexType,
 		Gsm4626:                    gsm4626.DexType,
 		NadFun:                     nadfun.DexType,
+		NadSwap:                    nadswap.DexType,
 		CloberOB:                   cloberob.DexType,
 		FluidDexV2:                 dexv2.DexType,
 		Wildcard:                   wildcard.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -164,6 +164,7 @@ const (
 	ExchangeMuteSwitch                 = "muteswitch"
 	ExchangeNabla                      = "nabla"
 	ExchangeNadFun                     = "nad-fun"
+	ExchangeNadSwap                    = "nadswap"
 	ExchangeNativeV1                   = "native-v1"
 	ExchangeNativeV2                   = "native-v2"
 	ExchangeNativeV3                   = "native-v3"


### PR DESCRIPTION
## Summary
- Adds `pkg/liquidity-source/nadswap/` for the NadFun V2 AMM on Monad (`nadfun-contract-v2`'s `NadFunFactory` + `NadFunPair`).
- Supports two pair types:
  - **Meme-token pairs**: LP 25 BPS + creator + DEX protocol fee, applied asymmetrically on the quote-token side (per upstream `DEX_INTEGRATION.md`).
  - **General pairs**: LP 25 BPS only (standard V2 constant-product).
- Pool discovery via factory iteration (`allPairsLength` + `allPairs(i)`) with revert-tolerant `FeeCollector.getFeeConfig(pair)` (general pairs ⇒ `getFeeConfig` reverts).
- Reserve refresh via `Sync` event log decode with `getReserves()` RPC fallback (`TryBlockAndAggregate` so the block number advances even when no log is present).
- Snapshot fee config at discovery; `dexProtocolFeeRate` updates are **not** tracked in this PR (documented trade-off — 4 of 5 `FeeConfig` fields are immutable post-`Setup`).

## Deployment
| Network | Chain ID | Factory | FeeCollector |
|---|---|---|---|
| Monad mainnet | 143 | `0xA25b13127e63ddae6d0b35570FF3D39dBD621001` | `0xE1C8b73343f5A83EBe165BE90470d84B00e33022` |
| Monad testnet | 10143 | `0x59C51c66B79c68F63d5446940CD13b6968788e36` | `0x653cf4297fB3f7804173b8449950E20812DD6dC3` |

## Notes for reviewers
- Post-swap reserve deltas account for quote-token fees that `_collectFee` transfers to `FeeCollector` before `_update` — so `UpdateBalance` matches the on-chain `Sync` snapshot for chained quotes through the same pool.
- Registry wiring touches `pkg/valueobject/exchange.go`, `pkg/pooltypes/pooltypes.go`, and `pkg/msgpack/register_pool_types.gen.go`.
- The integration smoke test (`TestPoolListUpdater_Mainnet`) is CI-gated. Locally it discovers 4 meme pools and tracker calls populate non-zero block numbers.
- `TestFixtures_AmountOut` is `t.Skip`'d until foundry-derived fixture values are captured against the deployed `NadFunPair`. Marked as a follow-up.

## Test plan
- [ ] `go vet ./pkg/liquidity-source/nadswap/...` clean
- [ ] `go build ./...` clean
- [ ] `gofmt -l ./pkg/liquidity-source/nadswap/` empty
- [ ] `CI=1 go test -race ./pkg/liquidity-source/nadswap/...` green (integration test skipped)
- [ ] Local `TestPoolListUpdater_Mainnet` against Monad RPC discovers ≥ 1 pool and tracker returns a block number
- [ ] Followup ticket: enable `TestFixtures_AmountOut` with foundry-captured values
- [ ] Followup ticket: optional `DexProtocolFeeRateUpdate` event listener for dynamic fee refresh

## Out of scope (documented in `CHANGELOG.md` / design spec §1.1)
- `dexProtocolFeeRate` event-driven refresh
- `FeeCollector.isSettling(pair)` branch (assumed `false`)
- Bonding-curve → DEX graduation routing
- Native (`MON`) wrap/unwrap helper
- Router-level modeling