### PR TITLE
fix: curve Newton loop denominator underflow and meta pool overquote

### DIFF
--- a/pkg/liquidity-source/curve/lending/pools_list_updater.go
+++ b/pkg/liquidity-source/curve/lending/pools_list_updater.go
@@ -103,7 +103,7 @@ func (u *PoolsListUpdater) getLendingVaults(ctx context.Context) ([]LendingVault
 func (u *PoolsListUpdater) initPools(ctx context.Context, lendingVaults []LendingVault) ([]entity.Pool, error) {
 	calls := u.ethrpcClient.NewRequest().SetContext(ctx)
 	aCoefficients := make([]*big.Int, len(lendingVaults))
-	for i := 0; i < len(lendingVaults); i++ {
+	for i := range lendingVaults {
 		calls.AddCall(&ethrpc.Call{
 			ABI:    llamma.CurveLlammaABI,
 			Target: lendingVaults[i].AmmAddress,

--- a/pkg/liquidity-source/curve/llamma/math.go
+++ b/pkg/liquidity-source/curve/llamma/math.go
@@ -120,7 +120,7 @@ func wadExp(x *int256.Int) (*uint256.Int, error) {
 
 func lnInt(x *uint256.Int) *int256.Int {
 	var res uint256.Int
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		t := new(uint256.Int).Exp(number.Number_2, uint256.NewInt(uint64(7-i)))
 		p := new(uint256.Int).Exp(number.Number_2, t)
 		if x.Cmp(new(uint256.Int).Mul(p, number.Number_1e18)) >= 0 {
@@ -130,7 +130,7 @@ func lnInt(x *uint256.Int) *int256.Int {
 	}
 
 	d := new(uint256.Int).Set(number.Number_1e18)
-	for i := 0; i < 59; i++ {
+	for range 59 {
 		if x.Cmp(new(uint256.Int).Mul(number.Number_2, number.Number_1e18)) >= 0 {
 			res.Add(&res, d)
 			x.Div(x, number.Number_2)

--- a/pkg/liquidity-source/curve/llamma/pool_tracker.go
+++ b/pkg/liquidity-source/curve/llamma/pool_tracker.go
@@ -182,7 +182,7 @@ func (t *PoolTracker) getBands(
 	)
 
 	calls := t.ethrpcClient.NewRequest().SetContext(ctx).SetFrom(shared.AddrDummy)
-	for i := int64(0); i < bandCount; i++ {
+	for i := range bandCount {
 		bandIndex := big.NewInt(i + startBand)
 		calls.AddCall(&ethrpc.Call{
 			ABI:    CurveLlammaABI,
@@ -201,7 +201,7 @@ func (t *PoolTracker) getBands(
 	}
 
 	bands := make([]Band, 0, bandCount)
-	for i := int64(0); i < bandCount; i++ {
+	for i := range bandCount {
 		if bandsX[i].Sign() == 0 && bandsY[i].Sign() == 0 {
 			continue
 		}

--- a/pkg/liquidity-source/curve/llamma/pools_list_updater.go
+++ b/pkg/liquidity-source/curve/llamma/pools_list_updater.go
@@ -86,7 +86,7 @@ func (u *PoolsListUpdater) getPools(ctx context.Context, offset int, batchSize i
 	)
 
 	factoryCalls := u.ethrpcClient.NewRequest().SetContext(ctx)
-	for i := 0; i < batchSize; i++ {
+	for i := range batchSize {
 		idx := big.NewInt(int64(offset + i))
 		factoryCalls.AddCall(&ethrpc.Call{
 			ABI:    CurveControllerFactoryABI,
@@ -105,7 +105,7 @@ func (u *PoolsListUpdater) getPools(ctx context.Context, offset int, batchSize i
 	}
 
 	ammCalls := u.ethrpcClient.NewRequest().SetContext(ctx)
-	for i := 0; i < batchSize; i++ {
+	for i := range batchSize {
 		ammCalls.AddCall(&ethrpc.Call{
 			ABI:    CurveLlammaABI,
 			Target: amms[i].String(),

--- a/pkg/liquidity-source/curve/plain/math.go
+++ b/pkg/liquidity-source/curve/plain/math.go
@@ -64,7 +64,7 @@ func xpMem_inplace(
 	xp []uint256.Int,
 ) int {
 	numTokens := len(rates)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		xp[i].Div(number.Mul(&rates[i], &balances[i]), Precision)
 	}
 	return numTokens
@@ -103,7 +103,7 @@ func (t *PoolSimulator) getD(xp []uint256.Int, a *uint256.Int, D *uint256.Int) e
 
 	numTokensPlus1 := uint256.NewInt(uint64(t.numTokens + 1))
 
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		// D_P: uint256 = D
 		D_P.Set(D)
 
@@ -212,7 +212,7 @@ func (t *PoolSimulator) getY(
 
 	var yPrev uint256.Int
 	y.Set(&d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		// y_prev = y
 		yPrev.Set(y)
 
@@ -410,7 +410,7 @@ func (t *PoolSimulator) getYD(
 	c.Set(d)
 	s.Clear()
 	var nA = number.Mul(a, &t.numTokensU256)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i != tokenIndex {
 			s.Add(&s, &xp[i])
 			c.Div(
@@ -432,7 +432,7 @@ func (t *PoolSimulator) getYD(
 	)
 	var yPrev uint256.Int
 	y.Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		yPrev.Set(y)
 		y.Div(
 			number.Add(
@@ -491,7 +491,7 @@ func (t *PoolSimulator) CalculateWithdrawOneCoinU256(
 	var xpReduced [shared.MaxTokenCount]uint256.Int
 	var nCoinBI = number.SetUint64(uint64(nCoins))
 	var fee = number.Div(number.Mul(t.extra.SwapFee, nCoinBI), number.Mul(uint256.NewInt(4), number.SubUint64(nCoinBI, 1)))
-	for j := 0; j < nCoins; j += 1 {
+	for j := range nCoins {
 		var dxExpected uint256.Int
 		if j == i {
 			dxExpected.Sub(number.Div(number.Mul(&xp[j], D1), &D0), &newY)
@@ -548,7 +548,7 @@ func (t *PoolSimulator) CalculateTokenAmountU256(
 		return err
 	}
 	var balances1 [shared.MaxTokenCount]uint256.Int
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if deposit {
 			balances1[i].Add(&t.reserves[i], &amounts[i])
 		} else {
@@ -612,7 +612,7 @@ func (t *PoolSimulator) AddLiquidityU256(amounts []uint256.Int) (*uint256.Int, e
 	var nCoinsBi = uint256.NewInt(uint64(nCoins))
 	var amp = t._A()
 	var old_balances = make([]uint256.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		old_balances[i].Set(&t.reserves[i])
 	}
 	var D0, D1, D2 uint256.Int
@@ -622,7 +622,7 @@ func (t *PoolSimulator) AddLiquidityU256(amounts []uint256.Int) (*uint256.Int, e
 	}
 	var token_supply = t.LpSupply
 	var new_balances = make([]uint256.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		new_balances[i].Add(&old_balances[i], &amounts[i])
 	}
 	err = t.get_D_mem(t.extra.RateMultipliers, new_balances, amp, &D1)
@@ -637,7 +637,7 @@ func (t *PoolSimulator) AddLiquidityU256(amounts []uint256.Int) (*uint256.Int, e
 		var _fee = number.Div(number.Mul(t.extra.SwapFee, nCoinsBi),
 			number.Mul(uint256.NewInt(4), uint256.NewInt(uint64(nCoins-1))))
 		var _admin_fee = t.extra.AdminFee
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			var ideal_balance = number.Div(number.Mul(&D1, &old_balances[i]), &D0)
 			var difference uint256.Int
 			if ideal_balance.Cmp(&new_balances[i]) > 0 {
@@ -653,7 +653,7 @@ func (t *PoolSimulator) AddLiquidityU256(amounts []uint256.Int) (*uint256.Int, e
 		_ = t.get_D_mem(t.extra.RateMultipliers, new_balances, amp, &D2)
 		mint_amount.Div(number.Mul(&token_supply, number.Sub(&D2, &D0)), &D0)
 	} else {
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			t.reserves[i].Set(&new_balances[i])
 			number.FillBig(&t.reserves[i], t.Info.Reserves[i]) // always sync back update to t.Info, will be removed later
 		}

--- a/pkg/liquidity-source/curve/plain/pool_simulator.go
+++ b/pkg/liquidity-source/curve/plain/pool_simulator.go
@@ -99,7 +99,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 		useStandardRate = true
 	}
 
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 
 		reservesBI[i] = bignumber.NewBig10(entityPool.Reserves[i])

--- a/pkg/liquidity-source/curve/plain/pool_tracker.go
+++ b/pkg/liquidity-source/curve/plain/pool_tracker.go
@@ -249,7 +249,7 @@ func (t *PoolTracker) updateRateMultipliers(lg logger.Logger, extra *Extra, numT
 	extra.RateMultipliers = make([]uint256.Int, numTokens)
 	lg.Debugf("pool use stored rate %v", customRates)
 
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if overflow := extra.RateMultipliers[i].SetFromBig(customRates[i]); overflow {
 			lg.WithFields(logger.Fields{"storedRates": customRates}).Error("invalid stored rates")
 			return ErrInvalidStoredRates

--- a/pkg/liquidity-source/curve/shared/pools_list_updater.go
+++ b/pkg/liquidity-source/curve/shared/pools_list_updater.go
@@ -30,15 +30,15 @@ type (
 		DexID       string              `mapstructure:"dexID" json:"dexID,omitempty"`
 		ChainCode   string              `mapstructure:"chain_code" json:"chain_code,omitempty"`
 		ChainID     valueobject.ChainID `mapstructure:"chain_id" json:"chain_id,omitempty"`
-		HTTPConfig  HTTPConfig          `mapstructure:"http_config" json:"http_config,omitempty"`
+		HTTPConfig  HTTPConfig          `mapstructure:"http_config" json:"http_config"`
 		DataSources []CurveDataSource   `mapstructure:"data_sources" json:"data_sources,omitempty"`
 
-		FetchPoolsMinDuration durationjson.Duration `mapstructure:"fetch_pools_min_duration" json:"fetch_pools_min_duration,omitempty"`
+		FetchPoolsMinDuration durationjson.Duration `mapstructure:"fetch_pools_min_duration" json:"fetch_pools_min_duration"`
 	}
 
 	HTTPConfig struct {
 		BaseURL    string                `mapstructure:"base_url" json:"base_url,omitempty"`
-		Timeout    durationjson.Duration `mapstructure:"timeout" json:"timeout,omitempty"`
+		Timeout    durationjson.Duration `mapstructure:"timeout" json:"timeout"`
 		RetryCount int                   `mapstructure:"retry_count" json:"retry_count,omitempty"`
 	}
 )

--- a/pkg/liquidity-source/curve/stable-meta-ng/math.go
+++ b/pkg/liquidity-source/curve/stable-meta-ng/math.go
@@ -88,7 +88,7 @@ func (t *PoolSimulator) GetDyUnderlying(
 		// x = self._base_calc_token_amount(
 		//   dx, base_i, base_n_coins, BASE_POOL, True
 		// ) * rates[1] / PRECISION
-		for k := 0; k < baseNCoins; k += 1 {
+		for k := range baseNCoins {
 			addLiquidityInfo.Amounts[k].Clear()
 		}
 		addLiquidityInfo.Amounts[base_i].Set(_dx)
@@ -172,14 +172,14 @@ func (t *PoolSimulator) GetDxUnderlying(
 	//    2. get_dx on metapool for i = 0, and j = 1 (base lp token) with amt calculated in (1).
 	if output_is_base_coin {
 		baseInputs := make([]uint256.Int, baseNCoins)
-		for k := 0; k < baseNCoins; k++ {
+		for k := range baseNCoins {
 			baseInputs[k].Clear()
 		}
 		baseInputs[base_j].Set(dy)
 
 		var lpAmountBurnt uint256.Int
 		feeAmounts := make([]uint256.Int, baseNCoins)
-		for k := 0; k < baseNCoins; k++ {
+		for k := range baseNCoins {
 			feeAmounts[k].Clear()
 		}
 
@@ -231,7 +231,7 @@ func (t *PoolSimulator) GetDxUnderlying(
 	metaSwapInfo.AdminFee.Set(&adminFee)
 
 	// update addLiquidityInfo
-	for k := 0; k < baseNCoins; k++ {
+	for k := range baseNCoins {
 		addLiquidityInfo.Amounts[k].Clear()
 		addLiquidityInfo.FeeAmounts[k].Clear()
 	}

--- a/pkg/liquidity-source/curve/stable-meta-ng/pool_tracker.go
+++ b/pkg/liquidity-source/curve/stable-meta-ng/pool_tracker.go
@@ -173,7 +173,7 @@ func (t *PoolTracker) updateRateMultipliers(lg logger.Logger, extra *Extra, numT
 	extra.RateMultipliers = make([]uint256.Int, numTokens)
 	lg.Debugf("pool use stored rate %v", customRates)
 
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if customRates[i] == nil {
 			return ErrInvalidStoredRates
 		}

--- a/pkg/liquidity-source/curve/stable-ng/math.go
+++ b/pkg/liquidity-source/curve/stable-ng/math.go
@@ -27,7 +27,7 @@ func xpMem_inplace(
 	xp []uint256.Int,
 ) int {
 	numTokens := len(rates)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		xp[i].Div(number.SafeMul(&rates[i], &balances[i]), Precision)
 	}
 	return numTokens
@@ -95,7 +95,7 @@ func (t *PoolSimulator) getD(xp []uint256.Int, amp *uint256.Int, D *uint256.Int)
 	var nCoinsPlus1 uint256.Int
 	nCoinsPlus1.AddUint64(&t.NumTokensU256, 1)
 
-	for i := 0; i < 255; i++ {
+	for range 255 {
 		Dprev.Set(D)
 
 		D_P.Set(D)
@@ -216,7 +216,7 @@ func (t *PoolSimulator) GetY(
 
 	var yPrev uint256.Int
 	y.Set(&d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		// y_prev = y
 		yPrev.Set(y)
 
@@ -616,7 +616,7 @@ func (t *PoolSimulator) getYD(
 	)
 	var yPrev uint256.Int
 	y.Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		yPrev.Set(y)
 		// y = (y*y + c) / (2 * y + b - D)
 		y.Div(

--- a/pkg/liquidity-source/curve/stable-ng/pool_simulator.go
+++ b/pkg/liquidity-source/curve/stable-ng/pool_simulator.go
@@ -67,7 +67,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	sim.Reserves = make([]uint256.Int, numTokens)
 	sim.precisionMultipliers = make([]uint256.Int, numTokens)
 
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 
 		reservesBI[i] = bignumber.NewBig10(entityPool.Reserves[i])

--- a/pkg/liquidity-source/curve/stable-ng/pool_tracker.go
+++ b/pkg/liquidity-source/curve/stable-ng/pool_tracker.go
@@ -173,7 +173,7 @@ func (t *PoolTracker) updateRateMultipliers(lg logger.Logger, extra *Extra, numT
 	extra.RateMultipliers = make([]uint256.Int, numTokens)
 	lg.Debugf("pool use stored rate %v", customRates)
 
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if customRates[i] == nil {
 			return ErrInvalidStoredRates
 		}

--- a/pkg/liquidity-source/curve/tricrypto-ng/curve_tricrypto_optimized_weth.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/curve_tricrypto_optimized_weth.go
@@ -37,7 +37,7 @@ func (t *PoolSimulator) GetDy(
 	}
 
 	yOrg := number.Set(&t.Reserves[j])
-	for k := 0; k < NumTokens; k += 1 {
+	for k := range NumTokens {
 		if k == i {
 			number.SafeAddZ(&t.Reserves[k], dx, &xp[k])
 			continue
@@ -46,7 +46,7 @@ func (t *PoolSimulator) GetDy(
 	}
 
 	number.SafeMulZ(&xp[0], &t.precisionMultipliers[0], &xp[0])
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		xp[k+1].Div(
 			number.SafeMul(number.SafeMul(&xp[k+1], &t.Extra.PriceScale[k]), &t.precisionMultipliers[k+1]),
 			Precision,
@@ -99,7 +99,7 @@ func (t *PoolSimulator) GetDx(
 ) error {
 	_dy := number.Set(dy)
 
-	for k := 0; k < 5; k += 1 {
+	for range 5 {
 		var err = t._getDxFee(i, j, _dy, dx, K0, xp[:])
 		if err != nil {
 			return err
@@ -134,7 +134,7 @@ func (t *PoolSimulator) _getDxFee(
 	}
 
 	A, gamma := t._A_gamma()
-	for k := 0; k < NumTokens; k += 1 {
+	for k := range NumTokens {
 		xp[k].Set(&t.Reserves[k])
 	}
 
@@ -142,7 +142,7 @@ func (t *PoolSimulator) _getDxFee(
 
 	number.SafeMulZ(&xp[0], &t.precisionMultipliers[0], &xp[0])
 
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		xp[k+1].Div(
 			number.SafeMul(number.SafeMul(&xp[k+1], &t.Extra.PriceScale[k]), &t.precisionMultipliers[k+1]),
 			Precision,
@@ -215,14 +215,14 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 	if err != nil {
 		return err
 	}
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		lastPrices[k].Div(number.SafeMul(&lastPrices[k], &t.Extra.PriceScale[k]), U_1e18)
 	}
 
 	// # ---------- Update profit numbers without price adjustment first --------
 	var xp [NumTokens]uint256.Int
 	xp[0].Div(D_unadjusted, NumTokensU256)
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		xp[k+1].Div(
 			number.SafeMul(D_unadjusted, U_1e18),
 			number.SafeMul(NumTokensU256, &t.Extra.PriceScale[k]),
@@ -260,7 +260,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 		// #                Calculate the vector distance between price_scale and
 		// #                                                        price_oracle.
 		var norm = new(uint256.Int)
-		for k := 0; k < NumTokens-1; k += 1 {
+		for k := range NumTokens - 1 {
 			var ratio = number.Div(number.SafeMul(&t.Extra.PriceOracle[k], U_1e18), &t.Extra.PriceScale[k])
 			if ratio.Cmp(U_1e18) > 0 {
 				ratio = number.SafeSub(ratio, U_1e18)
@@ -287,7 +287,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			// # ------------------------------------- Calculate new price scale.
 
 			var p_new [NumTokens - 1]uint256.Int
-			for k := 0; k < NumTokens-1; k += 1 {
+			for k := range NumTokens - 1 {
 				p_new[k].Div(
 					number.SafeAdd(
 						number.SafeMul(&t.Extra.PriceScale[k], number.Sub(norm, adjustment_step)),
@@ -296,10 +296,10 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			}
 
 			// # ---------------- Update stale xp (using price_scale) with p_new.
-			for k := 0; k < NumTokens; k += 1 {
+			for k := range NumTokens {
 				xp[k].Set(&_xp[k])
 			}
-			for k := 0; k < NumTokens-1; k += 1 {
+			for k := range NumTokens - 1 {
 				xp[k+1].Div(number.SafeMul(&_xp[k+1], &p_new[k]), &t.Extra.PriceScale[k])
 			}
 
@@ -309,7 +309,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 				return err
 			}
 
-			for k := 0; k < NumTokens; k += 1 {
+			for k := range NumTokens {
 				frac := number.Div(number.SafeMul(&xp[k], U_1e18), D)
 				if frac.Cmp(MinFrac) < 0 || frac.Cmp(MaxFrac) > 0 {
 					return ErrUnsafeXi
@@ -317,7 +317,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			}
 
 			xp[0].Div(D, NumTokensU256)
-			for k := 0; k < NumTokens-1; k += 1 {
+			for k := range NumTokens - 1 {
 				xp[k+1].Div(number.SafeMul(D, U_1e18), number.SafeMul(NumTokensU256, &p_new[k]))
 			}
 
@@ -329,7 +329,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			// # ---------------------------- Proceed if we've got enough profit.
 			if old_virtual_price.Cmp(U_1e18) > 0 && number.SafeSub(number.SafeMul(number.Number_2, old_virtual_price),
 				U_1e18).Cmp(xcp_profit) > 0 {
-				for k := 0; k < NumTokens-1; k += 1 {
+				for k := range NumTokens - 1 {
 					priceScale[k].Set(&p_new[k])
 				}
 				d.Set(D)

--- a/pkg/liquidity-source/curve/tricrypto-ng/math.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/math.go
@@ -121,7 +121,7 @@ func newton_D(ANN *uint256.Int, gamma *uint256.Int, x_unsorted []uint256.Int, K0
 	}
 
 	var D_prev, K0, diff uint256.Int
-	for i := 0; i < 255; i += 1 {
+	for range 255 {
 		D_prev.Set(D)
 
 		// # K0 = 10**18 * x[0] * N_COINS / D * x[1] * N_COINS / D * x[2] * N_COINS / D
@@ -289,7 +289,7 @@ func get_y(
 		return ErrUnsafeD
 	}
 
-	for k := 0; k < NumTokens; k++ {
+	for k := range NumTokens {
 		if k == i {
 			continue
 		}
@@ -661,7 +661,7 @@ func newton_y(
 	Si.Clear()
 
 	var xSorted [NumTokens]uint256.Int
-	for j := 0; j < NumTokens; j += 1 {
+	for j := range NumTokens {
 		xSorted[j].Set(&x[j])
 	}
 	xSorted[i].Clear()
@@ -685,14 +685,14 @@ func newton_y(
 		y.Div(number.SafeMul(y, D), number.SafeMul(_x, NumTokensU256))
 		Si.Add(&Si, _x)
 	}
-	for j := 0; j < NumTokens-1; j += 1 {
+	for j := range NumTokens - 1 {
 		K0i.Div(number.SafeMul(number.SafeMul(&K0i, &xSorted[j]), NumTokensU256), D)
 	}
 
 	var yPrev, K0, S, _g1k0, mul1, yfprime uint256.Int
 	De18 := number.SafeMul(D, U_1e18)
 
-	for j := 0; j < 255; j += 1 {
+	for range 255 {
 		yPrev.Set(y)
 		K0.Div(number.SafeMul(number.SafeMul(&K0i, y), NumTokensU256), D)
 		S.Add(&Si, y)

--- a/pkg/liquidity-source/curve/tricrypto-ng/pool_simulator.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/pool_simulator.go
@@ -60,7 +60,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	sim.Reserves = make([]uint256.Int, numTokens)
 	sim.precisionMultipliers = make([]uint256.Int, numTokens)
 
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 
 		reservesBI[i] = bignumber.NewBig10(entityPool.Reserves[i])

--- a/pkg/liquidity-source/curve/tricrypto-ng/pool_tracker.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/pool_tracker.go
@@ -149,7 +149,7 @@ func (t *PoolTracker) getNewPoolState(
 		}, []any{&balances[i]})
 	}
 
-	for i := 0; i < numDepCoins; i++ {
+	for i := range numDepCoins {
 		calls.AddCall(&ethrpc.Call{
 			ABI:    curveTricryptoNGABI,
 			Target: p.Address,

--- a/pkg/liquidity-source/curve/twocrypto-ng/curve_twocrypto_optimized.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/curve_twocrypto_optimized.go
@@ -37,7 +37,7 @@ func (t *PoolSimulator) GetDy(
 	}
 
 	yOrg := number.Set(&t.Reserves[j])
-	for k := 0; k < NumTokens; k += 1 {
+	for k := range NumTokens {
 		if k == i {
 			number.SafeAddZ(&t.Reserves[k], dx, &xp[k])
 			continue
@@ -46,7 +46,7 @@ func (t *PoolSimulator) GetDy(
 	}
 
 	number.SafeMulZ(&xp[0], &t.precisionMultipliers[0], &xp[0])
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		xp[k+1].Div(
 			number.SafeMul(number.SafeMul(&xp[k+1], &t.Extra.PriceScale[k]), &t.precisionMultipliers[k+1]),
 			Precision,
@@ -99,7 +99,7 @@ func (t *PoolSimulator) GetDx(
 ) error {
 	_dy := number.Set(dy)
 
-	for k := 0; k < 5; k += 1 {
+	for range 5 {
 		var err = t._getDxFee(i, j, _dy, dx, K0, xp[:])
 		if err != nil {
 			return err
@@ -134,7 +134,7 @@ func (t *PoolSimulator) _getDxFee(
 	}
 
 	A, gamma := t._A_gamma()
-	for k := 0; k < NumTokens; k += 1 {
+	for k := range NumTokens {
 		xp[k].Set(&t.Reserves[k])
 	}
 
@@ -142,7 +142,7 @@ func (t *PoolSimulator) _getDxFee(
 
 	number.SafeMulZ(&xp[0], &t.precisionMultipliers[0], &xp[0])
 
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		xp[k+1].Div(
 			number.SafeMul(number.SafeMul(&xp[k+1], &t.Extra.PriceScale[k]), &t.precisionMultipliers[k+1]),
 			Precision,
@@ -215,14 +215,14 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 	if err != nil {
 		return err
 	}
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		lastPrices[k].Div(number.SafeMul(&lastPrices[k], &t.Extra.PriceScale[k]), U_1e18)
 	}
 
 	// # ---------- Update profit numbers without price adjustment first --------
 	var xp [NumTokens]uint256.Int
 	xp[0].Div(D_unadjusted, NumTokensU256)
-	for k := 0; k < NumTokens-1; k += 1 {
+	for k := range NumTokens - 1 {
 		xp[k+1].Div(
 			number.SafeMul(D_unadjusted, U_1e18),
 			number.SafeMul(NumTokensU256, &t.Extra.PriceScale[k]),
@@ -281,7 +281,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			// # ------------------------------------- Calculate new price scale.
 
 			var p_new [NumTokens - 1]uint256.Int
-			for k := 0; k < NumTokens-1; k += 1 {
+			for k := range NumTokens - 1 {
 				p_new[k].Div(
 					number.SafeAdd(
 						number.SafeMul(&t.Extra.PriceScale[k], number.Sub(norm, adjustment_step)),
@@ -290,10 +290,10 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			}
 
 			// # ---------------- Update stale xp (using price_scale) with p_new.
-			for k := 0; k < NumTokens; k += 1 {
+			for k := range NumTokens {
 				xp[k].Set(&_xp[k])
 			}
-			for k := 0; k < NumTokens-1; k += 1 {
+			for k := range NumTokens - 1 {
 				xp[k+1].Div(number.SafeMul(&_xp[k+1], &p_new[k]), &t.Extra.PriceScale[k])
 			}
 
@@ -303,7 +303,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 				return err
 			}
 
-			for k := 0; k < NumTokens; k += 1 {
+			for k := range NumTokens {
 				frac := number.Div(number.SafeMul(&xp[k], U_1e18), D)
 				if frac.Cmp(MinFrac) < 0 || frac.Cmp(MaxFrac) > 0 {
 					return ErrUnsafeXi
@@ -311,7 +311,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 			}
 
 			xp[0].Div(D, NumTokensU256)
-			for k := 0; k < NumTokens-1; k += 1 {
+			for k := range NumTokens - 1 {
 				xp[k+1].Div(number.SafeMul(D, U_1e18), number.SafeMul(NumTokensU256, &p_new[k]))
 			}
 
@@ -322,7 +322,7 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 
 			// # ---------------------------- Proceed if we've got enough profit.
 			if old_virtual_price.Cmp(U_1e18) > 0 && number.SafeSub(number.SafeMul(number.Number_2, old_virtual_price), U_1e18).Cmp(xcp_profit) > 0 {
-				for k := 0; k < NumTokens-1; k += 1 {
+				for k := range NumTokens - 1 {
 					priceScale[k].Set(&p_new[k])
 				}
 				d.Set(D)

--- a/pkg/liquidity-source/curve/twocrypto-ng/math.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/math.go
@@ -59,7 +59,7 @@ func _get_y_custom(
 	Ann.Mul(_amp, NumTokensU256) // Ann = _amp * N_COINS
 
 	// Calculate S_ and c
-	for _i := 0; _i < NumTokens; _i++ {
+	for _i := range NumTokens {
 		if _i != i {
 			_x.Set(&xp[_i])
 			S_.Add(&S_, &_x)
@@ -84,7 +84,7 @@ func _get_y_custom(
 	y.Set(D)
 
 	// Newton's method: y = (y*y + c) // (2 * y + b - D)
-	for _i := 0; _i < 255; _i++ {
+	for range 255 {
 		y_prev.Set(y)
 
 		// y = (y*y + c) // (2 * y + b - D)
@@ -94,9 +94,7 @@ func _get_y_custom(
 
 		denominator.Mul(number.Number_2, y) // 2*y
 		denominator.Add(&denominator, &b)   // 2*y + b
-		denominator.Sub(&denominator, D)    // 2*y + b - D
-
-		if denominator.IsZero() {
+		if _, underflow := denominator.SubOverflow(&denominator, D); underflow || denominator.IsZero() {
 			return ErrZero
 		}
 
@@ -431,7 +429,7 @@ func _newton_D(
 
 	var __g1k0 = number.Add(gamma, U_1e18)
 	var D_prev, K0, diff uint256.Int
-	for i := 0; i < 255; i += 1 {
+	for range 255 {
 		if D.Sign() <= 0 {
 			return nil, ErrUnsafeD
 		}
@@ -567,7 +565,7 @@ func _newton_D_custom(
 	nCoinsPow := new(uint256.Int).Set(NumTokensU256) // N_COINS^N_COINS
 	nCoinsPow.Mul(nCoinsPow, NumTokensU256)
 
-	for i := 0; i < 255; i++ {
+	for range 255 {
 		D_P.Set(D)
 		for _, x := range _xp {
 			D_P.Mul(&D_P, D)
@@ -813,7 +811,7 @@ func _newton_y(
 	var yPrev, K0, S, _g1k0, mul1, yfprime uint256.Int
 	De18 := number.SafeMul(D, U_1e18)
 
-	for j := 0; j < 255; j += 1 {
+	for range 255 {
 		yPrev.Set(y)
 		K0.Div(number.SafeMul(number.SafeMul(K0i, y), NumTokensU256), D)
 		S.Add(x_j, y)
@@ -1143,7 +1141,7 @@ func _get_p_custom(
 	ANN := new(uint256.Int).Mul(A, NumTokensU256)                            // ANN = _A_gamma[0] * N_COINS
 	Dr := new(uint256.Int).Div(_D, number.Mul(NumTokensU256, NumTokensU256)) // Dr = _D / N_COINS**N_COINS
 
-	for i := 0; i < NumTokens; i++ {
+	for i := range NumTokens {
 		Dr.Mul(Dr, _D)
 		Dr.Div(Dr, &_xp[i])
 	}

--- a/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator.go
@@ -60,7 +60,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	sim.Reserves = make([]uint256.Int, numTokens)
 	sim.precisionMultipliers = make([]uint256.Int, numTokens)
 
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 
 		reservesBI[i] = bignumber.NewBig10(entityPool.Reserves[i])

--- a/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator_test.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator_test.go
@@ -325,7 +325,7 @@ func TestMergeSwaps(t *testing.T) {
 			var totalAmountOut *big.Int
 			var chunkedErr error
 
-			for i := 0; i < 20; i++ {
+			for range 20 {
 				chunkTokenAmountIn := poolpkg.TokenAmount{
 					Token:  pool.Tokens[tokenIn].Address,
 					Amount: chunkAmount,

--- a/pkg/liquidity-source/curve/twocrypto-ng/pool_tracker.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/pool_tracker.go
@@ -155,7 +155,7 @@ func (t *PoolTracker) getNewPoolState(
 		}, []any{&balances[i]})
 	}
 
-	for i := 0; i < numDepCoins; i++ {
+	for i := range numDepCoins {
 		calls.AddCall(&ethrpc.Call{
 			ABI:    curveTwocryptoNGABI,
 			Target: p.Address,

--- a/pkg/source/curve/aave/math.go
+++ b/pkg/source/curve/aave/math.go
@@ -36,7 +36,7 @@ func _xp(
 	if numTokens != len(precisionMultipliers) {
 		return nil, ErrBalancesMustMatchMultipliers
 	}
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		xp = append(xp, new(big.Int).Mul(balances[i], precisionMultipliers[i]))
 	}
 	return xp, nil
@@ -98,7 +98,7 @@ func _getAPrecise(
 func getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var numTokens = len(xp)
 	var s = new(big.Int)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		s = s.Add(s, xp[i])
 	}
 	if s.Sign() == 0 {
@@ -109,9 +109,9 @@ func getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var d = new(big.Int).Set(s)
 	var nA = new(big.Int).Mul(a, numTokensBI)
 	var tmp, tmp2, mul big.Int
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		var dP = new(big.Int).Set(d)
-		for j := 0; j < numTokens; j++ {
+		for j := range numTokens {
 			dP = dP.Div(
 				dP.Mul(dP, d),
 				tmp.Add(tmp.Mul(xp[j], numTokensBI), bignumber.One), // +1 is to prevent /0 (https://github.com/curvefi/curve-contract/blob/d4e8589/contracts/pools/aave/StableSwapAave.vy#L299)
@@ -186,7 +186,7 @@ func getY(
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, numTokensBI)
 	var _x *big.Int
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i == tokenIndexFrom {
 			_x = new(big.Int).Set(x)
 		} else if i != tokenIndexTo {
@@ -216,12 +216,14 @@ func getY(
 	)
 	var yPrev *big.Int
 	var y = new(big.Int).Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	var denom big.Int
+	for range MaxLoopLimit {
 		yPrev = new(big.Int).Set(y)
-		y = new(big.Int).Div(
-			new(big.Int).Add(new(big.Int).Mul(y, y), c),
-			new(big.Int).Sub(new(big.Int).Add(new(big.Int).Mul(y, big.NewInt(2)), b), d),
-		)
+		denom.Sub(denom.Add(denom.Mul(y, big.NewInt(2)), b), d)
+		if denom.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
+		y = new(big.Int).Div(new(big.Int).Add(new(big.Int).Mul(y, y), c), &denom)
 		if new(big.Int).Sub(y, yPrev).CmpAbs(bignumber.One) <= 0 {
 			return y, nil
 		}
@@ -330,7 +332,7 @@ func getYD(
 	var c = new(big.Int).Set(d)
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, numTokensBI)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i != tokenIndex {
 			s = new(big.Int).Add(s, xp[i])
 			c = new(big.Int).Div(
@@ -358,21 +360,14 @@ func getYD(
 	)
 	var yPrev *big.Int
 	var y = new(big.Int).Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	var denom big.Int
+	for range MaxLoopLimit {
 		yPrev = new(big.Int).Set(y)
-		y = new(big.Int).Div(
-			new(big.Int).Add(
-				new(big.Int).Mul(y, y),
-				c,
-			),
-			new(big.Int).Sub(
-				new(big.Int).Add(
-					new(big.Int).Mul(y, bignumber.Two),
-					b,
-				),
-				d,
-			),
-		)
+		denom.Sub(denom.Add(denom.Mul(y, bignumber.Two), b), d)
+		if denom.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
+		y = new(big.Int).Div(new(big.Int).Add(new(big.Int).Mul(y, y), c), &denom)
 		if new(big.Int).Sub(y, yPrev).CmpAbs(bignumber.One) <= 0 {
 			return y, nil
 		}
@@ -450,7 +445,7 @@ func calculateWithdrawOneTokenDy(
 	}
 	var feePerToken = _feePerToken(swapFee, numTokens)
 	var xpReduced = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		var norm *big.Int
 		if i == tokenIndex {
 			norm = new(big.Int).Sub(new(big.Int).Div(new(big.Int).Mul(xp[i], d1), d0), newY)
@@ -595,7 +590,7 @@ func calculateTokenAmount(
 		return nil, err
 	}
 	var balances1 = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if deposit {
 			balances1[i] = new(big.Int).Add(balances[i], amounts[i])
 		} else {
@@ -644,7 +639,7 @@ func CalculateAddLiquidityOneToken(
 ) (*big.Int, *big.Int, error) {
 	var numTokens = len(balances)
 	var amounts = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		amounts[i] = big.NewInt(0)
 	}
 	amounts[tokenIndex] = new(big.Int).Set(tokenAmount)

--- a/pkg/source/curve/aave/pool_simulator.go
+++ b/pkg/source/curve/aave/pool_simulator.go
@@ -49,7 +49,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	var tokens = make([]string, numTokens)
 	var reserves = make([]*big.Int, numTokens)
 	var multipliers = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 		multipliers[i] = bignumber.NewBig10(staticExtra.PrecisionMultipliers[i])
@@ -230,7 +230,7 @@ func (t *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {
 func (t *PoolSimulator) getDPrecision(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var nCoins = len(xp)
 	_xp := make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		_xp[i] = new(big.Int).Mul(xp[i], t.Multipliers[i])
 	}
 	return getD(_xp, a)
@@ -241,7 +241,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 	var nCoinsBi = big.NewInt(int64(nCoins))
 	var amp = _getAPrecise(t.FutureATime, t.FutureA, t.InitialATime, t.InitialA)
 	var old_balances = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		old_balances[i] = t.Info.Reserves[i]
 	}
 	D0, err := t.getDPrecision(old_balances, amp)
@@ -250,7 +250,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 	}
 	var token_supply = t.LpSupply
 	var new_balances = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		new_balances[i] = new(big.Int).Add(old_balances[i], amounts[i])
 	}
 	D1, err := t.getDPrecision(new_balances, amp)
@@ -266,7 +266,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 		var _fee = new(big.Int).Div(new(big.Int).Mul(t.Info.SwapFee, nCoinsBi),
 			new(big.Int).Mul(bignumber.Four, big.NewInt(int64(nCoins-1))))
 		_feemul := t.OffpegFeeMultiplier
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			t.Info.Reserves[i] = new_balances[i] // cannot determine real amount transferred, so use this, close enough
 			var ideal_balance = new(big.Int).Div(new(big.Int).Mul(D1, old_balances[i]), D0)
 			var difference *big.Int
@@ -283,7 +283,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 		fmt.Println(err)
 		mint_amount = new(big.Int).Div(new(big.Int).Mul(token_supply, new(big.Int).Sub(D2, D0)), D0)
 	} else {
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			t.Info.Reserves[i] = new_balances[i]
 		}
 		mint_amount = D1
@@ -334,7 +334,7 @@ func (t *PoolSimulator) RemoveLiquidityOneCoin(tokenAmount *big.Int, i int) (*bi
 func (t *PoolSimulator) GetDy(i int, j int, dx *big.Int, dCached *big.Int) (*big.Int, *big.Int, error) {
 	var nTokens = len(t.Info.Tokens)
 	xp := make([]*big.Int, nTokens)
-	for _i := 0; _i < nTokens; _i += 1 {
+	for _i := range nTokens {
 		xp[_i] = new(big.Int).Mul(t.Multipliers[_i], t.Info.Reserves[_i])
 	}
 

--- a/pkg/source/curve/base/math.go
+++ b/pkg/source/curve/base/math.go
@@ -16,7 +16,7 @@ func _xpMem(
 		return nil, ErrBalancesMustMatchMultipliers
 	}
 	xp := make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		xp[i] = new(big.Int).Div(new(big.Int).Mul(rates[i], balances[i]), Precision)
 	}
 	return xp, nil
@@ -25,7 +25,7 @@ func _xpMem(
 func (t *PoolSimulator) _xp() []*big.Int {
 	var nTokens = len(t.Info.Tokens)
 	result := make([]*big.Int, nTokens)
-	for i := 0; i < nTokens; i += 1 {
+	for i := range nTokens {
 		result[i] = new(big.Int).Div(new(big.Int).Mul(t.Rates[i], t.Info.Reserves[i]), Precision)
 	}
 	return result
@@ -85,7 +85,7 @@ func (t *PoolSimulator) APrecise() *big.Int {
 func (t *PoolSimulator) getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var numTokens = len(xp)
 	var s = new(big.Int).SetInt64(0)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		s = new(big.Int).Add(s, xp[i])
 	}
 	if s.Sign() == 0 {
@@ -121,11 +121,11 @@ func (t *PoolSimulator) getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	nA_mul_s_div_APrec.Div(&nA_mul_s_div_APrec, t.APrecision)
 	nA_sub_APrec.Sub(&nA, t.APrecision)
 
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		// D_P: uint256 = D
 		dP.Set(&d)
 
-		for j := 0; j < numTokens; j++ {
+		for j := range numTokens {
 			// D_P = D_P * D / (_x * N_COINS +1)
 			// +1 is to prevent /0 (https://github.com/curvefi/curve-contract/blob/d4e8589/contracts/pools/aave/StableSwapAave.vy#L299)
 
@@ -198,7 +198,7 @@ func (t *PoolSimulator) GetY(
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, t.numTokensBI)
 	var _x *big.Int
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i == tokenIndexFrom {
 			_x = new(big.Int).Set(x)
 		} else if i != tokenIndexTo {
@@ -247,7 +247,7 @@ func (t *PoolSimulator) GetY(
 	var y big.Int
 	y.Set(d)
 	var diff big.Int
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		// y_prev = y
 		yPrev.Set(&y)
 
@@ -256,6 +256,9 @@ func (t *PoolSimulator) GetY(
 		tmp.Mul(&y, bignumber.Two)
 		tmp.Add(&tmp, b)
 		tmp.Sub(&tmp, d)
+		if tmp.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
 		// then calc nominator into tmp1
 		tmp1.Mul(&y, &y)
 		tmp1.Add(&tmp1, c)
@@ -315,7 +318,7 @@ func (t *PoolSimulator) getYD(
 	var c = new(big.Int).Set(d)
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, t.numTokensBI)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i != tokenIndex {
 			s = new(big.Int).Add(s, xp[i])
 			c = new(big.Int).Div(
@@ -337,20 +340,16 @@ func (t *PoolSimulator) getYD(
 	)
 	var yPrev *big.Int
 	var y = new(big.Int).Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	var denom big.Int
+	for range MaxLoopLimit {
 		yPrev = new(big.Int).Set(y)
+		denom.Sub(denom.Add(denom.Mul(y, bignumber.Two), b), d)
+		if denom.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
 		y = new(big.Int).Div(
-			new(big.Int).Add(
-				new(big.Int).Mul(y, y),
-				c,
-			),
-			new(big.Int).Sub(
-				new(big.Int).Add(
-					new(big.Int).Mul(y, bignumber.Two),
-					b,
-				),
-				d,
-			),
+			new(big.Int).Add(new(big.Int).Mul(y, y), c),
+			&denom,
 		)
 		if new(big.Int).Sub(y, yPrev).CmpAbs(bignumber.One) <= 0 {
 			return y, nil
@@ -400,7 +399,7 @@ func (t *PoolSimulator) CalculateWithdrawOneCoin(
 	var xpReduced = make([]*big.Int, nCoins)
 	var nCoinBI = big.NewInt(int64(nCoins))
 	var fee = new(big.Int).Div(new(big.Int).Mul(t.Info.SwapFee, nCoinBI), new(big.Int).Mul(bignumber.Four, new(big.Int).Sub(nCoinBI, bignumber.One)))
-	for j := 0; j < nCoins; j += 1 {
+	for j := range nCoins {
 		var dxExpected *big.Int
 		if j == i {
 			dxExpected = new(big.Int).Sub(new(big.Int).Div(new(big.Int).Mul(xp[j], D1), D0), newY)
@@ -430,7 +429,7 @@ func (t *PoolSimulator) CalculateTokenAmount(
 		return nil, err
 	}
 	var balances1 = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if deposit {
 			balances1[i] = new(big.Int).Add(t.Info.Reserves[i], amounts[i])
 		} else {
@@ -460,7 +459,7 @@ func (t *PoolSimulator) CalculateAddLiquidityOneToken(
 ) (*big.Int, *big.Int, error) {
 	var numTokens = len(t.Info.Reserves)
 	var amounts = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		amounts[i] = big.NewInt(0)
 	}
 	amounts[tokenIndex] = new(big.Int).Set(tokenAmount)
@@ -475,7 +474,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 	var nCoinsBi = big.NewInt(int64(nCoins))
 	var amp = t._A()
 	var old_balances = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		old_balances[i] = t.Info.Reserves[i]
 	}
 	D0, err := t.get_D_mem(old_balances, amp)
@@ -484,7 +483,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 	}
 	var token_supply = t.LpSupply
 	var new_balances = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		new_balances[i] = new(big.Int).Add(old_balances[i], amounts[i])
 	}
 	D1, err := t.get_D_mem(new_balances, amp)
@@ -499,7 +498,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 		var _fee = new(big.Int).Div(new(big.Int).Mul(t.Info.SwapFee, nCoinsBi),
 			new(big.Int).Mul(bignumber.Four, big.NewInt(int64(nCoins-1))))
 		var _admin_fee = t.AdminFee
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			var ideal_balance = new(big.Int).Div(new(big.Int).Mul(D1, old_balances[i]), D0)
 			var difference *big.Int
 			if ideal_balance.Cmp(new_balances[i]) > 0 {
@@ -514,7 +513,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 		D2, _ := t.get_D_mem(new_balances, amp)
 		mint_amount = new(big.Int).Div(new(big.Int).Mul(token_supply, new(big.Int).Sub(D2, D0)), D0)
 	} else {
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			t.Info.Reserves[i] = new_balances[i]
 		}
 		mint_amount = D1

--- a/pkg/source/curve/base/pool_simulator.go
+++ b/pkg/source/curve/base/pool_simulator.go
@@ -54,7 +54,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	var multipliers = make([]*big.Int, numTokens)
 	var rates = make([]*big.Int, numTokens)
 
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 		multipliers[i] = bignumber.NewBig10(staticExtra.PrecisionMultipliers[i])

--- a/pkg/source/curve/compound/error.go
+++ b/pkg/source/curve/compound/error.go
@@ -9,4 +9,5 @@ var (
 	ErrTokenFromEqualsTokenTo       = errors.New("can't compare token to itself")
 	ErrTokenIndexesOutOfRange       = errors.New("token index out of range")
 	ErrAmountOutNotConverge         = errors.New("approximation did not converge")
+	ErrDenominatorZero              = errors.New("denominator should not be 0")
 )

--- a/pkg/source/curve/compound/math.go
+++ b/pkg/source/curve/compound/math.go
@@ -16,7 +16,7 @@ func _xp(
 	if numTokens != len(rates) {
 		return nil, ErrBalancesMustMatchMultipliers
 	}
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		xp = append(xp, new(big.Int).Div(new(big.Int).Mul(balances[i], new(big.Int).Mul(rates[i], tokenPrecisionMultipliers[i])), bignumber.BONE))
 	}
 
@@ -27,7 +27,7 @@ func getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 
 	var numTokens = len(xp)
 	var s = new(big.Int).SetInt64(0)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		s = new(big.Int).Add(s, xp[i])
 	}
 	if s.Sign() == 0 {
@@ -37,9 +37,9 @@ func getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var prevD *big.Int
 	var d = new(big.Int).Set(s)
 	var nA = new(big.Int).Mul(a, numTokensBI)
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		var dP = new(big.Int).Set(d)
-		for j := 0; j < numTokens; j++ {
+		for j := range numTokens {
 			dP = new(big.Int).Div(
 				new(big.Int).Mul(dP, d),
 				new(big.Int).Add(new(big.Int).Mul(xp[j], numTokensBI), bignumber.One), // +1 is to prevent /0 (https://github.com/curvefi/curve-contract/blob/d4e8589/contracts/pools/aave/StableSwapAave.vy#L299)
@@ -90,7 +90,7 @@ func getY(
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, numTokensBI)
 	var _x *big.Int
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i == tokenIndexFrom {
 			_x = new(big.Int).Set(x)
 		} else if i != tokenIndexTo {
@@ -121,12 +121,14 @@ func getY(
 	)
 	var yPrev *big.Int
 	var y = new(big.Int).Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	var denom big.Int
+	for range MaxLoopLimit {
 		yPrev = new(big.Int).Set(y)
-		y = new(big.Int).Div(
-			new(big.Int).Add(new(big.Int).Mul(y, y), c),
-			new(big.Int).Sub(new(big.Int).Add(new(big.Int).Mul(y, big.NewInt(2)), b), d),
-		)
+		denom.Sub(denom.Add(denom.Mul(y, big.NewInt(2)), b), d)
+		if denom.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
+		y = new(big.Int).Div(new(big.Int).Add(new(big.Int).Mul(y, y), c), &denom)
 		if new(big.Int).Sub(y, yPrev).CmpAbs(bignumber.One) <= 0 {
 			return y, nil
 		}

--- a/pkg/source/curve/compound/pool_simulator.go
+++ b/pkg/source/curve/compound/pool_simulator.go
@@ -44,7 +44,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	tokens := make([]string, numTokens)
 	reserves := make([]*big.Int, numTokens)
 	multipliers := make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = staticExtra.UnderlyingTokens[i]
 		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 		multipliers[i] = bignumber.NewBig10(staticExtra.PrecisionMultipliers[i])

--- a/pkg/source/curve/helper.go
+++ b/pkg/source/curve/helper.go
@@ -55,7 +55,7 @@ func initConfig(config *Config, ethrpcClient *ethrpc.Client) error {
 
 func getAPrecisions(aList, aPreciseList []*big.Int) ([]*big.Int, error) {
 	var aPrecisions = make([]*big.Int, len(aList))
-	for i := 0; i < len(aPrecisions); i++ {
+	for i := range aPrecisions {
 		if aList[i] != nil && aPreciseList[i] != nil {
 			aPrecisions[i] = new(big.Int).Div(aPreciseList[i], aList[i])
 		} else if aList[i] != nil {

--- a/pkg/source/curve/meta/pool_simulator.go
+++ b/pkg/source/curve/meta/pool_simulator.go
@@ -168,6 +168,9 @@ func (t *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 				Gas: t.gas.Exchange,
 			}, nil
 		}
+		// Both tokens are direct meta pool tokens; exchange_underlying does not apply.
+		// Do not fall through — that path misroutes idx==maxCoin as a base pool token.
+		return &pool.CalcAmountOutResult{Gas: t.gas.Exchange}, fmt.Errorf("zero output for meta exchange from index %v to %v", idxIn, idxOut)
 	}
 	// check exchange_underlying
 	var baseInputIndex = t.basePool.GetTokenIndex(tokenAmountIn.Token)

--- a/pkg/source/curve/meta/pool_simulator_test.go
+++ b/pkg/source/curve/meta/pool_simulator_test.go
@@ -271,6 +271,65 @@ func TestUpdateBalance(t *testing.T) {
 	}
 }
 
+// TestBBTCPoolOverquote reproduces the bug where swapping sbtcCRV -> bBTC in pool
+// 0x071c661b4deefb59e2a3ddb20db036821eee8f4b returns a non-zero value instead of an error.
+// On-chain, the tx reverts because y > xp[j] (the pool can't fill the order), but our code
+// computes a wrong y due to incorrect handling of convergence in _get_y.
+func TestBBTCPoolOverquote(t *testing.T) {
+	t.Parallel()
+	// On-chain state captured from Ethereum mainnet
+	// sBTC base pool: 0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714
+	basePool, err := base.NewPoolSimulator(entity.Pool{
+		Exchange: "curve",
+		Type:     "curve-base",
+		Reserves: entity.PoolReserves{
+			"864312888",             // renBTC (8 decimals)
+			"148139312",             // wBTC (8 decimals)
+			"136938252654095145849", // sBTC (18 decimals)
+			"125597240793439340254", // sbtcCRV LP supply
+		},
+		Tokens: []*entity.PoolToken{
+			{Address: "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"}, // renBTC
+			{Address: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"}, // wBTC
+			{Address: "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6"}, // sBTC
+		},
+		Extra:       `{"initialA":"100","futureA":"100","initialATime":0,"futureATime":0,"swapFee":"4000000","adminFee":"5000000000"}`,
+		StaticExtra: `{"lpToken":"0x075b1bb99792c9e1041ba13afef80c91a1e70fb3","aPrecision":"1","precisionMultipliers":["10000000000","10000000000","1"],"rates":["10000000000000000000000000000","10000000000000000000000000000","1000000000000000000"]}`,
+	})
+	require.NoError(t, err)
+
+	// bBTC meta pool: 0x071c661b4deefb59e2a3ddb20db036821eee8f4b
+	metaPool, err := NewPoolSimulator(entity.Pool{
+		Exchange: "curve",
+		Type:     "curve-meta",
+		Reserves: entity.PoolReserves{
+			"11788596",              // bBTC (8 decimals)
+			"14561935246859023484",  // sbtcCRV (18 decimals)
+			"125597240793439340254", // LP supply
+		},
+		Tokens: []*entity.PoolToken{
+			{Address: "0x9be89d2a4cd102d8fecc6bf9da793be995c22541"}, // bBTC
+			{Address: "0x075b1bb99792c9e1041ba13afef80c91a1e70fb3"}, // sbtcCRV
+		},
+		Extra:       `{"initialA":"20000","futureA":"20000","initialATime":0,"futureATime":0,"swapFee":"4000000","adminFee":"5000000000"}`,
+		StaticExtra: `{"lpToken":"0x071c661b4deefb59e2a3ddb20db036821eee8f4b","basePool":"0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714","rateMultiplier":"10000000000000000000000000000","aPrecision":"100","underlyingTokens":["0x9be89d2a4cd102d8fecc6bf9da793be995c22541","0xeb4c2781e4eba804ce9a9803c67d0893436bb27d","0x2260fac5e5542a773aa44fbcfedf7c193bc2c599","0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6"],"precisionMultipliers":["10000000000","1"],"rates":["",""]}`,
+	}, map[string]pool.IPoolSimulator{
+		"0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714": basePool,
+	})
+	require.NoError(t, err)
+
+	// Swap 1000000000 sbtcCRV -> bBTC: on-chain tx reverts, so expected is error
+	amountIn, _ := new(big.Int).SetString("1000000000", 10)
+	_, err = metaPool.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x075b1bb99792c9e1041ba13afef80c91a1e70fb3", // sbtcCRV
+			Amount: amountIn,
+		},
+		TokenOut: "0x9be89d2a4cd102d8fecc6bf9da793be995c22541", // bBTC
+	})
+	assert.Error(t, err, "swap should fail: on-chain tx reverts because pool cannot fill this order")
+}
+
 func BenchmarkGetDyUnderlying(b *testing.B) {
 
 	// {"Am", 1000, "A", 31},

--- a/pkg/source/curve/plain-oracle/math.go
+++ b/pkg/source/curve/plain-oracle/math.go
@@ -20,7 +20,7 @@ func _xpMem(
 		return nil, ErrBalancesMustMatchMultipliers
 	}
 	xp := make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		xp[i] = new(big.Int).Div(new(big.Int).Mul(rates[i], balances[i]), Precision)
 	}
 	return xp, nil
@@ -29,7 +29,7 @@ func _xpMem(
 func (t *PoolSimulator) _xp() []*big.Int {
 	var nTokens = len(t.GetInfo().Tokens)
 	result := make([]*big.Int, nTokens)
-	for i := 0; i < nTokens; i += 1 {
+	for i := range nTokens {
 		result[i] = new(big.Int).Div(new(big.Int).Mul(t.Rates[i], t.Info.Reserves[i]), Precision)
 	}
 	return result
@@ -80,7 +80,7 @@ func (t *PoolSimulator) _A() *big.Int {
 func (t *PoolSimulator) getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var numTokens = len(xp)
 	var s = new(big.Int).SetInt64(0)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		s = new(big.Int).Add(s, xp[i])
 	}
 	if s.Sign() == 0 {
@@ -90,9 +90,9 @@ func (t *PoolSimulator) getD(xp []*big.Int, a *big.Int) (*big.Int, error) {
 	var prevD *big.Int
 	var d = new(big.Int).Set(s)
 	var nA = new(big.Int).Mul(a, numTokensBI)
-	for i := 0; i < MaxLoopLimit; i++ {
+	for range MaxLoopLimit {
 		var dP = new(big.Int).Set(d)
-		for j := 0; j < numTokens; j++ {
+		for j := range numTokens {
 			dP = new(big.Int).Div(
 				new(big.Int).Mul(dP, d),
 				new(big.Int).Add(new(big.Int).Mul(xp[j], numTokensBI), bignumber.One), // +1 is to prevent /0 (https://github.com/curvefi/curve-contract/blob/d4e8589/contracts/pools/aave/StableSwapAave.vy#L299)
@@ -151,7 +151,7 @@ func (t *PoolSimulator) getY(
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, numTokensBI)
 	var _x *big.Int
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i == tokenIndexFrom {
 			_x = new(big.Int).Set(x)
 		} else if i != tokenIndexTo {
@@ -181,12 +181,14 @@ func (t *PoolSimulator) getY(
 	)
 	var yPrev *big.Int
 	var y = new(big.Int).Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	var denom big.Int
+	for range MaxLoopLimit {
 		yPrev = new(big.Int).Set(y)
-		y = new(big.Int).Div(
-			new(big.Int).Add(new(big.Int).Mul(y, y), c),
-			new(big.Int).Sub(new(big.Int).Add(new(big.Int).Mul(y, big.NewInt(2)), b), d),
-		)
+		denom.Sub(denom.Add(denom.Mul(y, big.NewInt(2)), b), d)
+		if denom.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
+		y = new(big.Int).Div(new(big.Int).Add(new(big.Int).Mul(y, y), c), &denom)
 		if new(big.Int).Sub(y, yPrev).CmpAbs(bignumber.One) <= 0 {
 			return y, nil
 		}
@@ -238,7 +240,7 @@ func (t *PoolSimulator) getYD(
 	var c = new(big.Int).Set(d)
 	var s = big.NewInt(0)
 	var nA = new(big.Int).Mul(a, numTokensBI)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if i != tokenIndex {
 			s = new(big.Int).Add(s, xp[i])
 			c = new(big.Int).Div(
@@ -260,21 +262,14 @@ func (t *PoolSimulator) getYD(
 	)
 	var yPrev *big.Int
 	var y = new(big.Int).Set(d)
-	for i := 0; i < MaxLoopLimit; i++ {
+	var denom big.Int
+	for range MaxLoopLimit {
 		yPrev = new(big.Int).Set(y)
-		y = new(big.Int).Div(
-			new(big.Int).Add(
-				new(big.Int).Mul(y, y),
-				c,
-			),
-			new(big.Int).Sub(
-				new(big.Int).Add(
-					new(big.Int).Mul(y, bignumber.Two),
-					b,
-				),
-				d,
-			),
-		)
+		denom.Sub(denom.Add(denom.Mul(y, bignumber.Two), b), d)
+		if denom.Sign() <= 0 {
+			return nil, ErrDenominatorZero
+		}
+		y = new(big.Int).Div(new(big.Int).Add(new(big.Int).Mul(y, y), c), &denom)
 		if new(big.Int).Sub(y, yPrev).CmpAbs(bignumber.One) <= 0 {
 			return y, nil
 		}
@@ -302,7 +297,7 @@ func (t *PoolSimulator) CalculateWithdrawOneCoin(
 	var xpReduced = make([]*big.Int, nCoins)
 	var nCoinBI = big.NewInt(int64(nCoins))
 	var fee = new(big.Int).Div(new(big.Int).Mul(t.Info.SwapFee, nCoinBI), new(big.Int).Mul(bignumber.Four, new(big.Int).Sub(nCoinBI, bignumber.One)))
-	for j := 0; j < nCoins; j += 1 {
+	for j := range nCoins {
 		var dxExpected *big.Int
 		if j == i {
 			dxExpected = new(big.Int).Sub(new(big.Int).Div(new(big.Int).Mul(xp[j], D1), D0), newY)
@@ -332,7 +327,7 @@ func (t *PoolSimulator) CalculateTokenAmount(
 		return nil, err
 	}
 	var balances1 = make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i++ {
+	for i := range numTokens {
 		if deposit {
 			balances1[i] = new(big.Int).Add(t.Info.Reserves[i], amounts[i])
 		} else {
@@ -361,7 +356,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 	var nCoinsBi = big.NewInt(int64(nCoins))
 	var amp = t._A()
 	var old_balances = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		old_balances[i] = t.Info.Reserves[i]
 	}
 	D0, err := t.get_D_mem(old_balances, amp)
@@ -370,7 +365,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 	}
 	var token_supply = t.LpSupply
 	var new_balances = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		new_balances[i] = new(big.Int).Add(old_balances[i], amounts[i])
 	}
 	D1, err := t.get_D_mem(new_balances, amp)
@@ -386,7 +381,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 		var _fee = new(big.Int).Div(new(big.Int).Mul(t.Info.SwapFee, nCoinsBi),
 			new(big.Int).Mul(bignumber.Four, big.NewInt(int64(nCoins-1))))
 		var _admin_fee = t.AdminFee
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			var ideal_balance = new(big.Int).Div(new(big.Int).Mul(D1, old_balances[i]), D0)
 			var difference *big.Int
 			if ideal_balance.Cmp(new_balances[i]) > 0 {
@@ -401,7 +396,7 @@ func (t *PoolSimulator) AddLiquidity(amounts []*big.Int) (*big.Int, error) {
 		D2, _ = t.get_D_mem(new_balances, amp)
 		mint_amount = new(big.Int).Div(new(big.Int).Mul(token_supply, new(big.Int).Sub(D2, D0)), D0)
 	} else {
-		for i := 0; i < nCoins; i += 1 {
+		for i := range nCoins {
 			t.Info.Reserves[i] = new_balances[i]
 		}
 		mint_amount = D1

--- a/pkg/source/curve/plain-oracle/pool_simulator.go
+++ b/pkg/source/curve/plain-oracle/pool_simulator.go
@@ -49,7 +49,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	var multipliers = make([]*big.Int, numTokens)
 	var rates = make([]*big.Int, numTokens)
 
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 		multipliers[i] = bignumber.NewBig10(staticExtra.PrecisionMultipliers[i])

--- a/pkg/source/curve/pool_lists_classifier.go
+++ b/pkg/source/curve/pool_lists_classifier.go
@@ -224,7 +224,7 @@ func (d *PoolsListUpdater) isPlainOraclePool(oracleAddress common.Address) bool 
 // isBasePool BasePool should
 // have underlying coins equals coins
 func (d *PoolsListUpdater) isBasePool(coins [8]common.Address, underlyingCoins [8]common.Address) bool {
-	for i := 0; i < len(coins); i++ {
+	for i := range len(coins) {
 		if !strings.EqualFold(underlyingCoins[i].Hex(), addressZero) && !strings.EqualFold(coins[i].Hex(), underlyingCoins[i].Hex()) {
 			return false
 		}

--- a/pkg/source/curve/pools_list_updater.go
+++ b/pkg/source/curve/pools_list_updater.go
@@ -86,7 +86,7 @@ func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 	)
 
 	if !d.config.SkipInitFactory {
-		for i := 0; i < len(registryOrFactoryList); i++ {
+		for i := range registryOrFactoryList {
 			if strings.EqualFold(registryOrFactoryList[i].Address, addressZero) {
 				logger.Debugf("skip zero factory %v", i)
 				continue
@@ -105,7 +105,7 @@ func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 				return nil, nil, err
 			}
 
-			for j := 0; j < len(poolAddresses); j++ {
+			for j := range poolAddresses {
 				// Skip unsupported pools
 				if poolTypes[j] == PoolTypeUnsupported {
 					continue

--- a/pkg/source/curve/tricrypto/math.go
+++ b/pkg/source/curve/tricrypto/math.go
@@ -12,13 +12,13 @@ import (
 func sortArray(A0 []*big.Int) []*big.Int {
 	var nCoins = len(A0)
 	var ret = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		ret[i] = A0[i]
 	}
 	for i := 1; i < nCoins; i += 1 {
 		var x = ret[i]
 		var cur = i
-		for j := 0; j < nCoins; j += 1 {
+		for range nCoins {
 			var y = ret[cur-1]
 			if y.Cmp(x) > 0 {
 				break
@@ -43,7 +43,7 @@ func _geometric_mean(unsorted_x []*big.Int, sort bool) (*big.Int, error) {
 	}
 	var D = x[0]
 	var diff = bignumber.ZeroBI
-	for i := 0; i < 255; i += 1 {
+	for range 255 {
 		var D_prev = D
 		var tmp = bignumber.BONE
 		for _, _x := range x {
@@ -68,7 +68,7 @@ func sqrt_int(x *big.Int) (*big.Int, error) {
 	}
 	var z = new(big.Int).Div(new(big.Int).Add(x, bignumber.BONE), bignumber.Two)
 	var y = x
-	for i := 0; i < 256; i += 1 {
+	for range 256 {
 		if z.Cmp(y) == 0 {
 			return y, nil
 		}
@@ -104,7 +104,7 @@ func newton_D(ANN *big.Int, gamma *big.Int, x_unsorted []*big.Int) (*big.Int, er
 	for _, x_i := range x {
 		S = new(big.Int).Add(S, x_i)
 	}
-	for i := 0; i < 255; i += 1 {
+	for range 255 {
 		var D_prev = D
 		var K0 = bignumber.BONE
 		for _, _x := range x {
@@ -189,7 +189,7 @@ func newtonY(ann *big.Int, gamma *big.Int, x []*big.Int, D *big.Int, i int) (*bi
 	if D.Cmp(new(big.Int).Add(new(big.Int).Mul(bignumber.TenPowInt(15), bignumber.TenPowInt(18)), bignumber.One)) >= 0 {
 		return nil, errors.New("unsafe values D")
 	}
-	for k := 0; k < 3; k++ {
+	for k := range 3 {
 		if k == i {
 			continue
 		}
@@ -206,7 +206,7 @@ func newtonY(ann *big.Int, gamma *big.Int, x []*big.Int, D *big.Int, i int) (*bi
 	var Si = bignumber.ZeroBI
 
 	var xSorted = make([]*big.Int, nCoins)
-	for j := 0; j < nCoins; j += 1 {
+	for j := range nCoins {
 		xSorted[j] = x[j]
 	}
 	xSorted[i] = bignumber.ZeroBI
@@ -232,7 +232,7 @@ func newtonY(ann *big.Int, gamma *big.Int, x []*big.Int, D *big.Int, i int) (*bi
 	for j := 0; j < nCoins-1; j += 1 {
 		K0i = new(big.Int).Div(new(big.Int).Mul(new(big.Int).Mul(K0i, xSorted[j]), nCoinBi), D)
 	}
-	for j := 0; j < 255; j += 1 {
+	for range 255 {
 		var yPrev = y
 		var K0 = new(big.Int).Div(new(big.Int).Mul(new(big.Int).Mul(K0i, y), nCoinBi), D)
 		var S = new(big.Int).Add(Si, y)
@@ -414,16 +414,16 @@ func (t *PoolSimulator) FeeCalc(xp []*big.Int) *big.Int {
 func (t *PoolSimulator) GetDy(i int, j int, dx *big.Int) (*big.Int, *big.Int, error) {
 	var xp = make([]*big.Int, 3)
 	var price_scale = make([]*big.Int, 2)
-	for k := 0; k < 2; k += 1 {
+	for k := range 2 {
 		price_scale[k] = t.price_scale(uint(k))
 	}
-	for k := 0; k < 3; k += 1 {
+	for k := range 3 {
 		xp[k] = t.Info.Reserves[k]
 	}
 	xp[i] = new(big.Int).Add(xp[i], dx)
 	xp[0] = new(big.Int).Mul(xp[0], t.Precisions[0])
 
-	for k := 0; k < 2; k += 1 {
+	for k := range 2 {
 		xp[k+1] = new(big.Int).Div(new(big.Int).Mul(new(big.Int).Mul(xp[k+1], price_scale[k]), t.Precisions[k+1]), Precision)
 	}
 	var y, err = newtonY(t.A, t.Gamma, xp, t.D, j)
@@ -456,7 +456,7 @@ func (t *PoolSimulator) Exchange(i int, j int, dx *big.Int) (*big.Int, error) {
 
 	var A_gamma = t._A_gamma()
 	var xp = make([]*big.Int, nCoins)
-	for k := 0; k < nCoins; k += 1 {
+	for k := range nCoins {
 		xp[k] = t.Info.Reserves[k]
 	}
 	var ix = j
@@ -595,7 +595,7 @@ func (t *PoolSimulator) tweak_price(A_gamma []*big.Int, _xp []*big.Int, i int, p
 		}
 	} else {
 		var __xp = make([]*big.Int, nCoins)
-		for k := 0; k < nCoins; k += 1 {
+		for k := range nCoins {
 			__xp[k] = new(big.Int).Set(_xp[k])
 		}
 		var dx_price = new(big.Int).Div(__xp[0], bignumber.TenPowInt(6))
@@ -673,7 +673,7 @@ func (t *PoolSimulator) tweak_price(A_gamma []*big.Int, _xp []*big.Int, i int, p
 						new(big.Int).Mul(adjustment_step, price_oracle[k]),
 					), norm)
 			}
-			for k := 0; k < nCoins; k += 1 {
+			for k := range nCoins {
 				xp[k] = new(big.Int).Set(_xp[k])
 			}
 			for k := 0; k < nCoins-1; k += 1 {

--- a/pkg/source/curve/tricrypto/math_test.go
+++ b/pkg/source/curve/tricrypto/math_test.go
@@ -33,13 +33,13 @@ func TestNewtonY(t *testing.T) {
 	var i = 0
 
 	var xp = make([]*big.Int, 3)
-	for k := 0; k < 3; k += 1 {
+	for k := range 3 {
 		xp[k] = balances[k]
 	}
 	xp[i] = new(big.Int).Add(xp[i], dx)
 	xp[0] = new(big.Int).Mul(xp[0], precisions[0])
 
-	for k := 0; k < 2; k += 1 {
+	for k := range 2 {
 		xp[k+1] = new(big.Int).Div(new(big.Int).Mul(new(big.Int).Mul(xp[k+1], priceScale[k]), precisions[k+1]), precision)
 	}
 	var ret, err = newtonY(ann, gamma, xp, D, 2)

--- a/pkg/source/curve/tricrypto/pool_simulator.go
+++ b/pkg/source/curve/tricrypto/pool_simulator.go
@@ -64,7 +64,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	tokens := make([]string, numTokens)
 	reserves := make([]*big.Int, numTokens)
 	precisions := make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 		precisions[i] = bignumber.NewBig10(staticExtra.PrecisionMultipliers[i])

--- a/pkg/source/curve/two/math.go
+++ b/pkg/source/curve/two/math.go
@@ -12,13 +12,13 @@ import (
 func sortArray(A0 []*big.Int) []*big.Int {
 	var nCoins = len(A0)
 	var ret = make([]*big.Int, nCoins)
-	for i := 0; i < nCoins; i += 1 {
+	for i := range nCoins {
 		ret[i] = A0[i]
 	}
 	for i := 1; i < nCoins; i += 1 {
 		var x = ret[i]
 		var cur = i
-		for j := 0; j < nCoins; j += 1 {
+		for range nCoins {
 			var y = ret[cur-1]
 			if y.Cmp(x) > 0 {
 				break
@@ -43,7 +43,7 @@ func geometricMean(unsortedX []*big.Int, sort bool) (*big.Int, error) {
 	}
 	var D = x[0]
 	var diff = bignumber.ZeroBI
-	for i := 0; i < 255; i += 1 {
+	for range 255 {
 		var DPrev = D
 		var tmp = bignumber.BONE
 		for _, _x := range x {
@@ -72,7 +72,7 @@ func sqrtInt(x *big.Int) (*big.Int, error) {
 	}
 	var z = new(big.Int).Div(new(big.Int).Add(x, bignumber.BONE), bignumber.Two)
 	var y = x
-	for i := 0; i < 256; i += 1 {
+	for range 256 {
 		if z.Cmp(y) == 0 {
 			return y, nil
 		}
@@ -107,7 +107,7 @@ func newtonD(ANN *big.Int, gamma *big.Int, xUnsorted []*big.Int) (*big.Int, erro
 	for _, xI := range x {
 		S = new(big.Int).Add(S, xI)
 	}
-	for i := 0; i < 255; i += 1 {
+	for range 255 {
 		var DPrev = D
 		var K0 = bignumber.BONE
 		for _, _x := range x {
@@ -225,7 +225,7 @@ func newtonY(ann *big.Int, gamma *big.Int, x []*big.Int, D *big.Int, i int) (*bi
 	var Si = bignumber.ZeroBI
 
 	var xSorted = make([]*big.Int, nCoins)
-	for j := 0; j < nCoins; j += 1 {
+	for j := range nCoins {
 		xSorted[j] = x[j]
 	}
 	xSorted[i] = bignumber.ZeroBI
@@ -251,7 +251,7 @@ func newtonY(ann *big.Int, gamma *big.Int, x []*big.Int, D *big.Int, i int) (*bi
 	for j := 0; j < nCoins-1; j += 1 {
 		K0i = new(big.Int).Div(new(big.Int).Mul(new(big.Int).Mul(K0i, xSorted[j]), nCoinBi), D)
 	}
-	for j := 0; j < 255; j += 1 {
+	for range 255 {
 		var yPrev = y
 		var K0 = new(big.Int).Div(new(big.Int).Mul(new(big.Int).Mul(K0i, y), nCoinBi), D)
 		var S = new(big.Int).Add(Si, y)
@@ -494,7 +494,7 @@ func (t *PoolSimulator) Exchange(i int, j int, dx *big.Int) (*big.Int, error) {
 
 	var AGamma = t.aGamma()
 	var xp = make([]*big.Int, nCoins)
-	for k := 0; k < nCoins; k += 1 {
+	for k := range nCoins {
 		xp[k] = t.Info.Reserves[k]
 	}
 	var ix = j
@@ -648,7 +648,7 @@ func (t *PoolSimulator) tweakPrice(AGamma []*big.Int, _xp []*big.Int, i int, pI 
 		}
 	} else {
 		var __xp = make([]*big.Int, nCoins)
-		for k := 0; k < nCoins; k += 1 {
+		for k := range nCoins {
 			__xp[k] = new(big.Int).Set(_xp[k])
 		}
 		var dxPrice = new(big.Int).Div(__xp[0], bignumber.TenPowInt(6))
@@ -736,7 +736,7 @@ func (t *PoolSimulator) tweakPrice(AGamma []*big.Int, _xp []*big.Int, i int, pI 
 					), norm,
 				)
 			}
-			for k := 0; k < nCoins; k += 1 {
+			for k := range nCoins {
 				xp[k] = new(big.Int).Set(_xp[k])
 			}
 			for k := 0; k < nCoins-1; k += 1 {

--- a/pkg/source/curve/two/math_test.go
+++ b/pkg/source/curve/two/math_test.go
@@ -33,13 +33,13 @@ func TestNewtonY(t *testing.T) {
 	var i = 0
 
 	var xp = make([]*big.Int, 3)
-	for k := 0; k < 3; k += 1 {
+	for k := range 3 {
 		xp[k] = balances[k]
 	}
 	xp[i] = new(big.Int).Add(xp[i], dx)
 	xp[0] = new(big.Int).Mul(xp[0], precisions[0])
 
-	for k := 0; k < 2; k += 1 {
+	for k := range 2 {
 		xp[k+1] = new(big.Int).Div(
 			new(big.Int).Mul(new(big.Int).Mul(xp[k+1], priceScale[k]), precisions[k+1]), precision,
 		)

--- a/pkg/source/curve/two/pool_simulator.go
+++ b/pkg/source/curve/two/pool_simulator.go
@@ -64,7 +64,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	tokens := make([]string, numTokens)
 	reserves := make([]*big.Int, numTokens)
 	precisions := make([]*big.Int, numTokens)
-	for i := 0; i < numTokens; i += 1 {
+	for i := range numTokens {
 		tokens[i] = entityPool.Tokens[i].Address
 		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
 		precisions[i] = bignumber.NewBig10(staticExtra.PrecisionMultipliers[i])


### PR DESCRIPTION
- meta pool: return error when GetDy yields 0 for direct meta token pairs,
  preventing fallthrough to GetDyUnderlying which misroutes idx==maxCoin
  as a base pool token (causing spurious non-zero output)
- base, aave, compound, plain-oracle: add Sign()<=0 guard on big.Int Newton
  denominator (2y+b-D) to match Vyper uint256 immediate revert on underflow
- twocrypto-ng: replace Sub+IsZero with SubOverflow to catch uint256 wrap-around
- modernize: for-loop range int across all curve packages (Go 1.22+)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
