### PR TITLE
feat(unipool): update validate spread check

### DIFF
--- a/pkg/liquidity-source/unipool/pool_list_tracker_integration_test.go
+++ b/pkg/liquidity-source/unipool/pool_list_tracker_integration_test.go
@@ -286,85 +286,132 @@ func (ts *PoolListTrackerIntegrationSuite) assertValidExtra(e Extra, label strin
 
 // TestCrossCheckQuoter is the strongest correctness check: for the same
 // (tokenIn, tokenOut, amountIn) we ask the on-chain UniPoolQuoter and our
-// off-chain simulator. The two amountsOut should match exactly when the pool
-// has no pending liquidations (the only piece our simulator skips).
+// off-chain simulator and require an EXACT match.
+//
+// Determinism: we read the pair state AND every Quoter.getAmountOut in ONE
+// atomic multicall, so they all evaluate at the same block. We then read that
+// block's timestamp and inject it into the simulator clock, so our VR
+// projection uses the exact same instant as the on-chain quote. With state,
+// timestamp and quote all aligned to one block, getAmountOut must match to the
+// wei (the only thing we skip — pending liquidations — would otherwise be the
+// sole source of divergence).
 func (ts *PoolListTrackerIntegrationSuite) TestCrossCheckQuoter_WETHUSDT() {
 	quoterABI, err := abi.JSON(bytes.NewReader(quoterABIJsonForTest))
 	ts.Require().NoError(err)
 
-	// Track the pair so we have the same Extra a production simulator would see.
-	updated, err := ts.tracker.GetNewPoolState(
-		context.Background(),
-		entity.Pool{
-			Address: uniPoolArbWETHUSDTPair,
-			Type:    DexType,
-			Tokens: []*entity.PoolToken{
-				{Address: arbWETHAddr, Swappable: true},
-				{Address: arbUSDTAddr, Swappable: true},
-			},
-			Reserves: entity.PoolReserves{"0", "0"},
-		},
-		pool.GetNewPoolStateParams{},
-	)
-	ts.Require().NoError(err)
-
-	sim, err := NewPoolSimulator(updated)
-	ts.Require().NoError(err)
-
-	// Probe with several input sizes / both directions.
 	cases := []struct {
-		name        string
-		tokenIn     string
-		tokenOut    string
-		amountIn    *big.Int
-		maxAbsDiff  *big.Int // tolerance (wei) for rounding-only / micro-timing drift
+		name     string
+		tokenIn  string
+		tokenOut string
+		amountIn *big.Int
 	}{
-		{"0.001 WETH -> USDT", arbWETHAddr, arbUSDTAddr, big.NewInt(1e15), big.NewInt(2)},
-		{"0.1 WETH -> USDT", arbWETHAddr, arbUSDTAddr, big.NewInt(1e17), big.NewInt(2)},
-		{"1 USDT -> WETH", arbUSDTAddr, arbWETHAddr, big.NewInt(1e6), big.NewInt(2)},
-		{"1000 USDT -> WETH", arbUSDTAddr, arbWETHAddr, big.NewInt(1e9), big.NewInt(2)},
+		{"0.001 WETH -> USDT", arbWETHAddr, arbUSDTAddr, big.NewInt(1e15)},
+		{"0.1 WETH -> USDT", arbWETHAddr, arbUSDTAddr, big.NewInt(1e17)},
+		{"1 USDT -> WETH", arbUSDTAddr, arbWETHAddr, big.NewInt(1e6)},
+		{"1000 USDT -> WETH", arbUSDTAddr, arbWETHAddr, big.NewInt(1e9)},
 	}
 
-	for _, tc := range cases {
+	mc3ABI, err := abi.JSON(strings.NewReader(
+		`[{"inputs":[],"name":"getCurrentBlockTimestamp","outputs":[{"type":"uint256"}],"stateMutability":"view","type":"function"}]`))
+	ts.Require().NoError(err)
+
+	var (
+		blockTsBig      = new(big.Int)
+		reserves        reservesABI
+		vrWrap          struct{ Reserves virtualReservesABI }
+		lastUpdate      = new(big.Int)
+		priceDecay      = new(big.Int)
+		fees            feesBpsABI
+		totalBorrowed0  = new(big.Int)
+		totalBorrowed1  = new(big.Int)
+		swapPriceTolBps uint16
+		quoterOut       = make([]*big.Int, len(cases))
+	)
+	reserves.Reserve0, reserves.Reserve1 = new(big.Int), new(big.Int)
+
+	req := ts.client.NewRequest().SetContext(context.Background())
+	pair := uniPoolArbWETHUSDTPair
+	req.AddCall(&ethrpc.Call{ABI: mc3ABI, Target: arbitrumMulticall3, Method: "getCurrentBlockTimestamp"}, []any{&blockTsBig})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetReserves}, []any{&reserves})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetVirtualReserves}, []any{&vrWrap})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetLastUpdateTimestamp}, []any{&lastUpdate})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetPriceDecay}, []any{&priceDecay})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetFeesBps}, []any{&fees})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetTotalBorrowed0}, []any{&totalBorrowed0})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetTotalBorrowed1}, []any{&totalBorrowed1})
+	req.AddCall(&ethrpc.Call{ABI: uniPoolPairABI, Target: pair, Method: pairMethodGetSwapPriceToleranceBps}, []any{&swapPriceTolBps})
+	for i := range cases {
+		quoterOut[i] = new(big.Int)
+		req.AddCall(&ethrpc.Call{
+			ABI:    quoterABI,
+			Target: uniPoolArbQuoterAddr,
+			Method: "getAmountOut",
+			Params: []any{common.HexToAddress(cases[i].tokenIn), common.HexToAddress(cases[i].tokenOut), cases[i].amountIn},
+		}, []any{&quoterOut[i]})
+	}
+	_, err = req.TryBlockAndAggregate()
+	ts.Require().NoError(err)
+
+	extra := Extra{
+		Reserve0:              reserves.Reserve0,
+		Reserve1:              reserves.Reserve1,
+		VirtualReserve0In:     vrWrap.Reserves.VirtualReserve0In,
+		VirtualReserve0Out:    vrWrap.Reserves.VirtualReserve0Out,
+		VirtualReserve1In:     vrWrap.Reserves.VirtualReserve1In,
+		VirtualReserve1Out:    vrWrap.Reserves.VirtualReserve1Out,
+		LastUpdateTimestamp:   lastUpdate.Uint64(),
+		PriceDecay:            priceDecay.Uint64(),
+		FeeLpBps:              fees.FeeLpBps,
+		FeePoolBps:            fees.FeePoolBps,
+		TotalBorrowed0:        totalBorrowed0,
+		TotalBorrowed1:        totalBorrowed1,
+		SwapPriceToleranceBps: swapPriceTolBps,
+	}
+	extraBytes, err := json.Marshal(extra)
+	ts.Require().NoError(err)
+
+	blockTs := blockTsBig.Int64()
+	ts.Require().Positive(blockTs, "multicall must report a block timestamp")
+	restore := nowUnix
+	nowUnix = func() int64 { return blockTs }
+	defer func() { nowUnix = restore }()
+
+	sim, err := NewPoolSimulator(entity.Pool{
+		Address:  pair,
+		Exchange: DexType,
+		Type:     DexType,
+		Tokens: []*entity.PoolToken{
+			{Address: arbWETHAddr, Swappable: true},
+			{Address: arbUSDTAddr, Swappable: true},
+		},
+		Reserves: entity.PoolReserves{reserves.Reserve0.String(), reserves.Reserve1.String()},
+		Extra:    string(extraBytes),
+	})
+	ts.Require().NoError(err)
+
+	for i, tc := range cases {
 		ts.Run(tc.name, func() {
-			// Off-chain quote.
 			ours, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
 				TokenAmountIn: pool.TokenAmount{Token: tc.tokenIn, Amount: tc.amountIn},
 				TokenOut:      tc.tokenOut,
 			})
 			ts.Require().NoError(err)
 
-			// On-chain quote via UniPoolQuoter.getAmountOut(tokenIn, tokenOut, amountIn).
-			var onchain *big.Int
-			req := ts.client.NewRequest().SetContext(context.Background())
-			req.AddCall(&ethrpc.Call{
-				ABI:    quoterABI,
-				Target: uniPoolArbQuoterAddr,
-				Method: "getAmountOut",
-				Params: []any{
-					common.HexToAddress(tc.tokenIn),
-					common.HexToAddress(tc.tokenOut),
-					tc.amountIn,
-				},
-			}, []any{&onchain})
-			_, err = req.Call()
-			ts.Require().NoError(err)
+			diff := new(big.Int).Sub(ours.TokenAmountOut.Amount, quoterOut[i])
+			ts.T().Logf("[xcheck @ts %d] %-22s simulator=%s on-chain=%s diff=%s",
+				blockTs, tc.name, ours.TokenAmountOut.Amount, quoterOut[i], diff)
 
-			diff := new(big.Int).Sub(ours.TokenAmountOut.Amount, onchain)
-			absDiff := new(big.Int).Abs(diff)
-
-			ts.T().Logf("[xcheck] %-22s simulator=%s on-chain=%s diff=%s",
-				tc.name, ours.TokenAmountOut.Amount, onchain, diff)
-
-			ts.Require().LessOrEqualf(absDiff.Cmp(tc.maxAbsDiff), 0,
-				"%s: off-chain vs on-chain quote diverges by %s wei (> tolerance %s)",
-				tc.name, absDiff, tc.maxAbsDiff)
+			ts.Require().Truef(diff.Sign() == 0,
+				"%s: off-chain vs on-chain quote must match exactly (same block), diff=%s",
+				tc.name, diff)
 		})
 	}
 }
 
 func TestPoolListTrackerIntegrationSuite(t *testing.T) {
-	t.Parallel()
+	// NOT parallel on purpose: TestCrossCheckQuoter overrides the package-level
+	// nowUnix clock. Running in the sequential phase guarantees no parallel unit
+	// test observes the override (parallel tests run only after sequential ones).
 	test.SkipCI(t)
 	suite.Run(t, new(PoolListTrackerIntegrationSuite))
 }

--- a/pkg/liquidity-source/unipool/pool_simulator.go
+++ b/pkg/liquidity-source/unipool/pool_simulator.go
@@ -14,6 +14,11 @@ import (
 
 var bpsDivisorU = uint256.NewInt(bpsDivisor)
 
+// nowUnix returns the current wall-clock time used to project the virtual
+// reserves forward. It is a package var so tests can pin it to a specific block
+// timestamp and compare against the on-chain quoter deterministically.
+var nowUnix = func() int64 { return time.Now().Unix() }
+
 // PoolSimulator replays UniPool's swap math fully off-chain.
 //
 // State stored: real reserves at lastUpdateTimestamp, the 4 virtual reserves at
@@ -144,7 +149,7 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	}
 
 	// Project the 4 VRs forward in time (port of previewVirtualReservesElapsed).
-	now := uint64(time.Now().Unix())
+	now := uint64(nowUnix())
 	vr0In, vr0Out, vr1In, vr1Out := s.projectVirtualReserves(now)
 
 	// Pick the effective reserves used by the AMM (port of getSwapInfo).
@@ -188,17 +193,12 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	}
 
 	// Spread validation (port of UniPoolPairSwap._validateSpreads). The contract
-	// runs it with: post-swap reserves, the pre-swap projected VRs, and the
-	// NET amountIn (= amountIn - poolFee).
+	// runs it with the post-swap reserves and the pre-swap projected VRs.
 	netAmountIn := poolFeeNetIn(amountIn, s.feePoolBps)
 	newReserveIn := new(uint256.Int).Add(realIn, netAmountIn)
 	newReserveOut := new(uint256.Int).Sub(realOut, amountOut)
-	isVrInUpdated := effIn.Cmp(realIn) != 0
-	isVrOutUpdated := effOut.Cmp(realOut) != 0
 	if err := s.validateSpreads(
 		isToken0Out, newReserveIn, newReserveOut,
-		isVrInUpdated, isVrOutUpdated,
-		netAmountIn, amountOut,
 		vr0In, vr0Out, vr1In, vr1Out,
 	); err != nil {
 		return nil, err
@@ -222,7 +222,7 @@ func poolFeeNetIn(amountIn, feePoolBps *uint256.Int) *uint256.Int {
 
 // CalcAmountIn is the exact-out counterpart of CalcAmountOut: given a desired
 // amountOut, compute the minimum amountIn required. Port of UniPoolPairSwap's
-// `getAmountIn` (UniPoolPairSwap.sol:339-350) which rounds the division UP so
+// `getAmountIn` (UniPoolPairSwap.sol) which rounds the division UP so
 // the user always supplies at least enough input on-chain.
 func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
 	tokenAmountOut, tokenIn := params.TokenAmountOut, params.TokenIn
@@ -241,7 +241,7 @@ func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.Calc
 		return nil, ErrFeeExceedsMax
 	}
 
-	now := uint64(time.Now().Unix())
+	now := uint64(nowUnix())
 	vr0In, vr0Out, vr1In, vr1Out := s.projectVirtualReserves(now)
 
 	isToken0Out := indexOut == 0
@@ -358,7 +358,7 @@ func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
 // UpdateBalance applies a swap to local state so subsequent CalcAmountOut calls
 // on the same simulator see the post-swap reserves.
 //
-// We mirror the on-chain UniPoolPairSwap.swap finalization (lines ~221-231):
+// We mirror the on-chain UniPoolPairSwap.swap finalization:
 //   - real reserves: in += netAmountIn (= amountIn * (BPS - feePoolBps)/BPS), out -= amountOut
 //   - virtualReserveIn  of input token  set to effectiveIn + netAmountIn  (if it was clamped up)
 //   - virtualReserveOut of output token set to effectiveOut - amountOut   (if it was clamped down)
@@ -383,7 +383,7 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 
 	netAmountIn := poolFeeNetIn(amtIn, s.feePoolBps)
 
-	now := uint64(time.Now().Unix())
+	now := uint64(nowUnix())
 	vr0In, vr0Out, vr1In, vr1Out := s.projectVirtualReserves(now)
 
 	var reserveIn, reserveOut, effIn, effOut, newReserveIn, newReserveOut *uint256.Int
@@ -514,17 +514,20 @@ func min256(a, b *uint256.Int) *uint256.Int {
 
 // validateSpreads is the port of UniPoolPairSwap._validateSpreads.
 //
-// It bounds the spread between the AMM mid-price and the buy/sell prices induced
-// by the swap. The contract reverts with UniPoolPairExcessiveSpread if any of the
-// two |Δprice| / midprice ratios exceeds swapPriceToleranceBps.
+// It only checks the spread on the side OPPOSITE to the swap direction, using the
+// pre-swap (projected) virtual reserves. The active side is intentionally NOT
+// checked so that healing swaps (e.g. after a liquidation that left the active
+// side above tolerance) are not blocked; MEV stays bounded by the opposite-side
+// check. The contract reverts with UniPoolPairExcessiveSpread when:
 //
-// We compute in math/big to avoid uint256 overflow on the `abs * BPS` and
-// `tolerance * comp` products (worst case ~2^286).
+//	|reserveIn*max - reserveOut*min| * BPS  >  tolerance * min(reserveOut*min, reserveIn*max)
+//
+// where (max, min) select the opposite-side virtual reserves. reserveIn/Out are
+// the POST-swap reserves. We compute in math/big to avoid uint256 overflow on the
+// `abs * BPS` and `tolerance * comp` products (worst case ~2^286).
 func (s *PoolSimulator) validateSpreads(
 	isToken0Out bool,
 	newReserveIn, newReserveOut *uint256.Int,
-	isVrInUpdated, isVrOutUpdated bool,
-	netAmountIn, amountOut *uint256.Int,
 	vr0In, vr0Out, vr1In, vr1Out *uint256.Int,
 ) error {
 	if s.swapPriceToleranceBps == swapPriceToleranceDisabled {
@@ -547,70 +550,29 @@ func (s *PoolSimulator) validateSpreads(
 
 	rIn := toBI(newReserveIn)
 	rOut := toBI(newReserveOut)
-	nAmtIn := toBI(netAmountIn)
-	aOut := toBI(amountOut)
 	v0InB, v0OutB := toBI(vr0In), toBI(vr0Out)
 	v1InB, v1OutB := toBI(vr1In), toBI(vr1Out)
-	bpsBI := big.NewInt(bpsDivisor)
-	tolBI := big.NewInt(int64(s.swapPriceToleranceBps))
 
-	// check enforces:  |rL*maxVal - rR*minVal| * BPS  <=  tolerance * min(rR*minVal, rL*maxVal)
-	check := func(maxVal, minVal, rL, rR *big.Int) error {
-		rLmax := new(big.Int).Mul(rL, maxVal)
-		rRmin := new(big.Int).Mul(rR, minVal)
-		abs := new(big.Int).Sub(rLmax, rRmin)
-		abs.Abs(abs)
-		comp := bigMin(rRmin, rLmax)
-		lhs := new(big.Int).Mul(abs, bpsBI)
-		rhs := new(big.Int).Mul(tolBI, comp)
-		if lhs.Cmp(rhs) > 0 {
-			return ErrExcessiveSpread
-		}
-		return nil
+	// Select the opposite-side virtual reserves.
+	var maxVal, minVal *big.Int
+	if isToken0Out {
+		maxVal = bigMax(rOut, v0InB)
+		minVal = bigMin(rIn, v1OutB)
+	} else {
+		maxVal = bigMax(rOut, v1InB)
+		minVal = bigMin(rIn, v0OutB)
 	}
 
-	if isToken0Out {
-		// Check 1: buy-side, uses POST-update virtual reserves on the touched sides.
-		var inVR *big.Int
-		if isVrInUpdated {
-			inVR = new(big.Int).Add(v1InB, nAmtIn)
-		} else {
-			inVR = v1InB
-		}
-		var outVR *big.Int
-		if isVrOutUpdated {
-			outVR = new(big.Int).Sub(v0OutB, aOut)
-		} else {
-			outVR = v0OutB
-		}
-		if err := check(bigMax(rIn, inVR), bigMin(rOut, outVR), rOut, rIn); err != nil {
-			return err
-		}
-		// Check 2: sell-side, uses pre-swap (projected) virtual reserves untouched.
-		if err := check(bigMax(rOut, v0InB), bigMin(rIn, v1OutB), rIn, rOut); err != nil {
-			return err
-		}
-	} else {
-		// Check 1: sell-side, pre-swap VRs.
-		if err := check(bigMax(rOut, v1InB), bigMin(rIn, v0OutB), rIn, rOut); err != nil {
-			return err
-		}
-		// Check 2: buy-side, post-update VRs.
-		var inVR *big.Int
-		if isVrInUpdated {
-			inVR = new(big.Int).Add(v0InB, nAmtIn)
-		} else {
-			inVR = v0InB
-		}
-		var outVR *big.Int
-		if isVrOutUpdated {
-			outVR = new(big.Int).Sub(v1OutB, aOut)
-		} else {
-			outVR = v1OutB
-		}
-		if err := check(bigMax(rIn, inVR), bigMin(rOut, outVR), rOut, rIn); err != nil {
-			return err
-		}
+	rLmax := new(big.Int).Mul(rIn, maxVal)
+	rRmin := new(big.Int).Mul(rOut, minVal)
+	abs := new(big.Int).Sub(rLmax, rRmin)
+	abs.Abs(abs)
+	comp := bigMin(rRmin, rLmax)
+
+	lhs := new(big.Int).Mul(abs, big.NewInt(bpsDivisor))
+	rhs := new(big.Int).Mul(big.NewInt(int64(s.swapPriceToleranceBps)), comp)
+	if lhs.Cmp(rhs) > 0 {
+		return ErrExcessiveSpread
 	}
 	return nil
 }

--- a/pkg/liquidity-source/unipool/pool_simulator_test.go
+++ b/pkg/liquidity-source/unipool/pool_simulator_test.go
@@ -581,13 +581,16 @@ func TestSpread_F2_VRsAlignedWithReserves_NoError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSpread_F3_VRsFarFromReserves_TripsSpread(t *testing.T) {
+func TestSpread_F3_OppositeSideVRFar_TripsSpread(t *testing.T) {
 	t.Parallel()
 	r := pow10(18)
 	extra := makeExtra(r, r)
-	// Token0 in -> effIn = max(VR0In, r0). Inflate VR0In by 10x to force a huge
-	// gap between post-update reserveIn and the spread reference.
-	extra.VirtualReserve0In = new(big.Int).Mul(r, big.NewInt(10))
+	// token0 in, token1 out => isToken0Out=false. The spread check reads the
+	// OPPOSITE-side VRs: max(reserveOut, vr1In) and min(reserveIn, vr0Out).
+	// Inflate vr1In 10x to blow past tolerance. Note vr1In does NOT feed the
+	// swap math (effIn uses vr0In, effOut uses vr1Out), so this isolates the
+	// spread check.
+	extra.VirtualReserve1In = new(big.Int).Mul(r, big.NewInt(10))
 	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000 // freeze
 	extra.SwapPriceToleranceBps = 100                              // 1%
 	sim := makePool(t, tokenA, tokenB, extra)
@@ -597,6 +600,26 @@ func TestSpread_F3_VRsFarFromReserves_TripsSpread(t *testing.T) {
 		TokenOut:      tokenB,
 	})
 	assert.ErrorIs(t, err, ErrExcessiveSpread)
+}
+
+// TestSpread_F3b_ActiveSideVRNotChecked: the spread guard only checks the side
+// opposite to the swap direction. Inflating ONLY the active-side input VR (vr0In
+// for a token0-in swap) must NOT trip the guard — it still bends the swap curve
+// via effIn, but the opposite-side spread stays within tolerance.
+func TestSpread_F3b_ActiveSideVRNotChecked(t *testing.T) {
+	t.Parallel()
+	r := pow10(18)
+	extra := makeExtra(r, r)
+	extra.VirtualReserve0In = new(big.Int).Mul(r, big.NewInt(2)) // active side only
+	extra.LastUpdateTimestamp = uint64(time.Now().Unix()) + 10_000
+	extra.SwapPriceToleranceBps = 100
+	sim := makePool(t, tokenA, tokenB, extra)
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenA, Amount: pow10(15)},
+		TokenOut:      tokenB,
+	})
+	assert.NoError(t, err)
 }
 
 func TestSpread_F4_ToleranceZero_RevertsOnAnySwap(t *testing.T) {


### PR DESCRIPTION
## Why did we need it?
Align the UniPool simulator with the latest UniPool contracts, which simplify `_validateSpreads` to a single check on the side opposite to the swap direction (the active-side check is dropped on-chain to allow healing swaps after liquidations).

Changes:
- **`pool_simulator.go`** : `validateSpreads` simplified to one check on the side opposite to the swap direction; signature trimmed (no more `isVrInUpdated/isVrOutUpdated/netAmountIn/amountOut`). Also added a `nowUnix` package-level clock seam so tests can pin the simulator clock to a chosen block timestamp.
- **`pool_simulator_test.go`** : spread tests updated for the new single-check semantics (`F3` exercises the opposite-side trip via `vr1In`; new `F3b` confirms an inflated active-side VR is intentionally *not* rejected).
- **`pool_list_tracker_integration_test.go`** : `TestCrossCheckQuoter_WETHUSDT` made deterministic — pair state, every `UniPoolQuoter.getAmountOut` and `multicall3.getCurrentBlockTimestamp` are now read in a single atomic multicall, and that `block.timestamp` is injected into the simulator clock via `nowUnix`, so both sides evaluate at the exact same instant.

## Related Issue
N/A

## Release Note
Spread guard is now strictly more permissive: previously-rejected swaps that only failed the active-side check are now accepted (matches the deployed contract). No `entity.Pool` shape change, no config or migration required.

## How Has This Been Tested?
- Unit tests for the new single-check spread logic pass (F1–F4 + F3b).
- Live integration suite on Arbitrum against the deployed contracts: `TestCrossCheckQuoter_WETHUSDT` matches the on-chain `UniPoolQuoter` **wei-perfect (diff=0)** across 4 input sizes / both directions.
- `go test -race` clean, `staticcheck` 0 warning, `gofmt`/`go vet` clean.

## Screenshots
N/A
