### PR TITLE
ft: integrate ghost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Integrate `nadswap` (nadfun-contract-v2 DEX) on Monad. Supports meme-token pairs with asymmetric quote-token fee model and general pairs with LP-only constant-product math.
+- Integrate `ghost` (cross-collateral router) on Ethereum, Arbitrum, and Base. Supports directional stablecoin pairs with a linear-then-capped input fee and a target-side reserve limit.
 
 
 ## [v0.11.6] - 2023-09-11

--- a/pkg/liquidity-source/ghost/abis.go
+++ b/pkg/liquidity-source/ghost/abis.go
@@ -1,0 +1,29 @@
+package ghost
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	feeABI        abi.ABI
+	routerABI     abi.ABI
+	routingFeeABI abi.ABI
+)
+
+func init() {
+	var err error
+	feeABI, err = abi.JSON(bytes.NewReader(feeABIData))
+	if err != nil {
+		panic(err)
+	}
+	routerABI, err = abi.JSON(bytes.NewReader(routerABIData))
+	if err != nil {
+		panic(err)
+	}
+	routingFeeABI, err = abi.JSON(bytes.NewReader(routingFeeABIData))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/liquidity-source/ghost/abis/CrossCollateralRouter.json
+++ b/pkg/liquidity-source/ghost/abis/CrossCollateralRouter.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "quoteTransferRemoteTo",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {"name": "_destination", "type": "uint32"},
+      {"name": "_recipient", "type": "bytes32"},
+      {"name": "_amount", "type": "uint256"},
+      {"name": "_targetRouter", "type": "bytes32"}
+    ],
+    "outputs": [
+      {
+        "name": "quotes",
+        "type": "tuple[]",
+        "components": [
+          {"name": "token", "type": "address"},
+          {"name": "amount", "type": "uint256"}
+        ]
+      }
+    ]
+  },
+  {
+    "name": "localDomain",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "uint32"}]
+  },
+  {
+    "name": "feeRecipient",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "address"}]
+  }
+]

--- a/pkg/liquidity-source/ghost/abis/OffchainQuotedLinearFee.json
+++ b/pkg/liquidity-source/ghost/abis/OffchainQuotedLinearFee.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "feeType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "uint8"}]
+  },
+  {
+    "name": "maxFee",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "uint256"}]
+  },
+  {
+    "name": "halfAmount",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "uint256"}]
+  },
+  {
+    "name": "quotes",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {"name": "destination", "type": "uint32"},
+      {"name": "recipient", "type": "bytes32"}
+    ],
+    "outputs": [
+      {"name": "maxFee", "type": "uint256"},
+      {"name": "halfAmount", "type": "uint256"},
+      {"name": "issuedAt", "type": "uint256"},
+      {"name": "expiry", "type": "uint256"}
+    ]
+  }
+]

--- a/pkg/liquidity-source/ghost/abis/RoutingFee.json
+++ b/pkg/liquidity-source/ghost/abis/RoutingFee.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "feeType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "uint8"}]
+  },
+  {
+    "name": "feeContracts",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {"name": "domain", "type": "uint32"},
+      {"name": "router", "type": "bytes32"}
+    ],
+    "outputs": [{"name": "", "type": "address"}]
+  }
+]

--- a/pkg/liquidity-source/ghost/config.go
+++ b/pkg/liquidity-source/ghost/config.go
@@ -1,0 +1,6 @@
+package ghost
+
+type Config struct {
+	DexID    string `json:"dexID"`
+	PoolPath string `json:"poolPath"`
+}

--- a/pkg/liquidity-source/ghost/constant.go
+++ b/pkg/liquidity-source/ghost/constant.go
@@ -1,0 +1,40 @@
+package ghost
+
+import "errors"
+
+const (
+	DexType = "ghost"
+
+	defaultReserves = "100000000000"
+
+	DefaultGas int64 = 220_000
+
+	feeMethodMaxFee     = "maxFee"
+	feeMethodHalfAmount = "halfAmount"
+	feeMethodQuotes     = "quotes"
+
+	feeTypeCrossCollateralRouting uint8 = 5
+	feeTypeOffchainQuotedLinear  uint8 = 6
+)
+
+// DEFAULT_ROUTER is the fallback bytes32 key used in feeContracts() lookups.
+var defaultRouterKey [32]byte
+
+func init() {
+	// 0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47
+	b := [32]byte{
+		0x6e, 0x08, 0x6c, 0xd6, 0x47, 0xd6, 0xeb, 0x8b,
+		0x51, 0x68, 0x56, 0x66, 0x6e, 0x2c, 0x14, 0x65,
+		0xfb, 0x8a, 0x6a, 0x58, 0xd3, 0xa7, 0x59, 0x38,
+		0x36, 0x2a, 0xcc, 0x67, 0x4e, 0xac, 0xaf, 0x47,
+	}
+	defaultRouterKey = b
+}
+
+var (
+	ErrInsufficientLiquidity = errors.New("ghost: insufficient liquidity")
+	ErrInvalidToken          = errors.New("ghost: invalid token")
+	ErrOverflow              = errors.New("ghost: uint256 overflow")
+	ErrUnsupportedFeeType = errors.New("ghost: unsupported fee contract type")
+	ErrNoFeeContract      = errors.New("ghost: could not resolve fee contract")
+)

--- a/pkg/liquidity-source/ghost/constant.go
+++ b/pkg/liquidity-source/ghost/constant.go
@@ -7,34 +7,29 @@ const (
 
 	defaultReserves = "100000000000"
 
-	DefaultGas int64 = 220_000
+	DefaultGas int64 = 250_000
 
 	feeMethodMaxFee     = "maxFee"
 	feeMethodHalfAmount = "halfAmount"
 	feeMethodQuotes     = "quotes"
 
 	feeTypeCrossCollateralRouting uint8 = 5
-	feeTypeOffchainQuotedLinear  uint8 = 6
+	feeTypeOffchainQuotedLinear   uint8 = 6
 )
 
 // DEFAULT_ROUTER is the fallback bytes32 key used in feeContracts() lookups.
-var defaultRouterKey [32]byte
-
-func init() {
-	// 0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47
-	b := [32]byte{
-		0x6e, 0x08, 0x6c, 0xd6, 0x47, 0xd6, 0xeb, 0x8b,
-		0x51, 0x68, 0x56, 0x66, 0x6e, 0x2c, 0x14, 0x65,
-		0xfb, 0x8a, 0x6a, 0x58, 0xd3, 0xa7, 0x59, 0x38,
-		0x36, 0x2a, 0xcc, 0x67, 0x4e, 0xac, 0xaf, 0x47,
-	}
-	defaultRouterKey = b
+// 0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47
+var defaultRouterKey = [32]byte{
+	0x6e, 0x08, 0x6c, 0xd6, 0x47, 0xd6, 0xeb, 0x8b,
+	0x51, 0x68, 0x56, 0x66, 0x6e, 0x2c, 0x14, 0x65,
+	0xfb, 0x8a, 0x6a, 0x58, 0xd3, 0xa7, 0x59, 0x38,
+	0x36, 0x2a, 0xcc, 0x67, 0x4e, 0xac, 0xaf, 0x47,
 }
 
 var (
 	ErrInsufficientLiquidity = errors.New("ghost: insufficient liquidity")
 	ErrInvalidToken          = errors.New("ghost: invalid token")
 	ErrOverflow              = errors.New("ghost: uint256 overflow")
-	ErrUnsupportedFeeType = errors.New("ghost: unsupported fee contract type")
-	ErrNoFeeContract      = errors.New("ghost: could not resolve fee contract")
+	ErrUnsupportedFeeType    = errors.New("ghost: unsupported fee contract type")
+	ErrNoFeeContract         = errors.New("ghost: could not resolve fee contract")
 )

--- a/pkg/liquidity-source/ghost/embed.go
+++ b/pkg/liquidity-source/ghost/embed.go
@@ -1,0 +1,27 @@
+package ghost
+
+import _ "embed"
+
+//go:embed abis/OffchainQuotedLinearFee.json
+var feeABIData []byte
+
+//go:embed abis/CrossCollateralRouter.json
+var routerABIData []byte
+
+//go:embed abis/RoutingFee.json
+var routingFeeABIData []byte
+
+//go:embed pools/ethereum.json
+var ethereumPoolData []byte
+
+//go:embed pools/arbitrum.json
+var arbitrumPoolData []byte
+
+//go:embed pools/base.json
+var basePoolData []byte
+
+var bytesByPath = map[string][]byte{
+	"pools/ethereum.json": ethereumPoolData,
+	"pools/arbitrum.json": arbitrumPoolData,
+	"pools/base.json":     basePoolData,
+}

--- a/pkg/liquidity-source/ghost/pool_simulator.go
+++ b/pkg/liquidity-source/ghost/pool_simulator.go
@@ -1,0 +1,261 @@
+package ghost
+
+import (
+	"fmt"
+	"math/big"
+	"slices"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+
+	staticExtra StaticExtra
+
+	maxFee           *uint256.Int
+	halfAmount       *uint256.Int
+	reserve          *uint256.Int // nil = no limit
+	scaleNumerator   *uint256.Int
+	scaleDenominator *uint256.Int
+
+	gas int64
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
+	if len(entityPool.Tokens) != 2 || len(entityPool.Reserves) != 2 {
+		return nil, fmt.Errorf("ghost: pool %s requires exactly 2 tokens", entityPool.Address)
+	}
+
+	var se StaticExtra
+	if err := json.Unmarshal([]byte(entityPool.StaticExtra), &se); err != nil {
+		return nil, fmt.Errorf("ghost: unmarshal StaticExtra: %w", err)
+	}
+
+	var ex Extra
+	if entityPool.Extra != "" && entityPool.Extra != "{}" {
+		if err := json.Unmarshal([]byte(entityPool.Extra), &ex); err != nil {
+			return nil, fmt.Errorf("ghost: unmarshal Extra: %w", err)
+		}
+	}
+
+	tokens := make([]string, 2)
+	reserves := make([]*big.Int, 2)
+	for i := 0; i < 2; i++ {
+		tokens[i] = entityPool.Tokens[i].Address
+		reserves[i] = bignumber.NewBig10(entityPool.Reserves[i])
+	}
+
+	maxFee := bigToUint256OrZero(ex.MaxFee)
+	halfAmount := bigToUint256OrZero(ex.HalfAmount)
+
+	var reserve *uint256.Int
+	if ex.Reserve != nil {
+		r, _ := uint256.FromBig(ex.Reserve)
+		reserve = r
+	}
+
+	scaleNum := uint256.NewInt(1)
+	if se.ScaleNumerator != "" {
+		if n, err := uint256.FromDecimal(se.ScaleNumerator); err == nil {
+			scaleNum = n
+		}
+	}
+	scaleDen := uint256.NewInt(1)
+	if se.ScaleDenominator != "" {
+		if d, err := uint256.FromDecimal(se.ScaleDenominator); err == nil && !d.IsZero() {
+			scaleDen = d
+		}
+	}
+
+	return &PoolSimulator{
+		Pool: pool.Pool{
+			Info: pool.PoolInfo{
+				Address:  strings.ToLower(entityPool.Address),
+				Exchange: entityPool.Exchange,
+				Type:     entityPool.Type,
+				Tokens:   tokens,
+				Reserves: reserves,
+			},
+		},
+		staticExtra:      se,
+		maxFee:           maxFee,
+		halfAmount:       halfAmount,
+		reserve:          reserve,
+		scaleNumerator:   scaleNum,
+		scaleDenominator: scaleDen,
+		gas:              DefaultGas,
+	}, nil
+}
+
+func bigToUint256OrZero(b *big.Int) *uint256.Int {
+	if b == nil {
+		return new(uint256.Int)
+	}
+	u, _ := uint256.FromBig(b)
+	return u
+}
+
+func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	tokenIn := param.TokenAmountIn.Token
+	tokenOut := param.TokenOut
+	amountInBig := param.TokenAmountIn.Amount
+
+	if p.GetTokenIndex(tokenIn) != 0 || p.GetTokenIndex(tokenOut) != 1 {
+		return nil, ErrInvalidToken
+	}
+
+	if amountInBig == nil || amountInBig.Sign() <= 0 {
+		return nil, ErrInvalidToken
+	}
+
+	amountIn, overflow := uint256.FromBig(amountInBig)
+	if overflow {
+		return nil, ErrOverflow
+	}
+
+	principal, fee := inverseFee(amountIn, p.maxFee, p.halfAmount)
+	if principal.IsZero() {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	var amountOut uint256.Int
+	if _, overflow := amountOut.MulDivOverflow(principal, p.scaleNumerator, p.scaleDenominator); overflow {
+		return nil, ErrOverflow
+	}
+
+	if p.reserve != nil && amountOut.Gt(p.reserve) {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{
+			Token:  tokenOut,
+			Amount: amountOut.ToBig(),
+		},
+		Fee: &pool.TokenAmount{
+			Token:  tokenIn,
+			Amount: fee.ToBig(),
+		},
+		Gas:      p.gas,
+		SwapInfo: SwapInfo{Amount: principal},
+	}, nil
+}
+
+// inverseFee solves for the principal such that principal + fee(principal) ≈ amountIn,
+// with at most 1 unit of dust from integer division.
+//
+//	Linear region:  principal = amountIn * 2 * halfAmount / (2 * halfAmount + maxFee)
+//	Capped region:  principal = amountIn - maxFee
+func inverseFee(amountIn, maxFee, halfAmount *uint256.Int) (principal, fee *uint256.Int) {
+	if maxFee.IsZero() || halfAmount.IsZero() {
+		return amountIn.Clone(), new(uint256.Int)
+	}
+
+	var twoHalf uint256.Int
+	twoHalf.Mul(halfAmount, uint256.NewInt(2))
+
+	if !amountIn.Lt(maxFee) {
+		var cappedPrincipal uint256.Int
+		cappedPrincipal.Sub(amountIn, maxFee)
+		if !cappedPrincipal.Lt(&twoHalf) {
+			return cappedPrincipal.Clone(), maxFee.Clone()
+		}
+	}
+
+	var denom uint256.Int
+	denom.Add(&twoHalf, maxFee)
+
+	principal = new(uint256.Int)
+	if _, overflow := principal.MulDivOverflow(amountIn, &twoHalf, &denom); overflow {
+		return new(uint256.Int), new(uint256.Int)
+	}
+
+	fee = calcFee(principal, maxFee, halfAmount)
+	return principal, fee
+}
+
+// calcFee implements: fee = min(maxFee, amount * maxFee / (2 * halfAmount))
+func calcFee(amount, maxFee, halfAmount *uint256.Int) *uint256.Int {
+	if maxFee.IsZero() || halfAmount.IsZero() {
+		return new(uint256.Int)
+	}
+
+	var twoHalf uint256.Int
+	twoHalf.Mul(halfAmount, uint256.NewInt(2))
+
+	var linearFee uint256.Int
+	if _, overflow := linearFee.MulDivOverflow(amount, maxFee, &twoHalf); overflow {
+		return maxFee.Clone()
+	}
+
+	if linearFee.Gt(maxFee) {
+		return maxFee.Clone()
+	}
+	return linearFee.Clone()
+}
+
+func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	amountOutBig := params.TokenAmountOut.Amount
+	if amountOutBig == nil {
+		return
+	}
+	if p.reserve != nil {
+		amountOut, _ := uint256.FromBig(amountOutBig)
+		p.reserve = new(uint256.Int).Sub(p.reserve, amountOut)
+	}
+	if len(p.Info.Reserves) > 1 {
+		p.Info.Reserves[1] = new(big.Int).Sub(p.Info.Reserves[1], amountOutBig)
+	}
+}
+
+func (p *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *p
+	cloned.Info.Reserves = slices.Clone(p.Info.Reserves)
+	if p.reserve != nil {
+		cloned.reserve = p.reserve.Clone()
+	}
+	return &cloned
+}
+
+func (p *PoolSimulator) CanSwapTo(address string) []string {
+	if strings.EqualFold(p.Info.Tokens[1], address) {
+		return []string{p.Info.Tokens[0]}
+	}
+	return nil
+}
+
+func (p *PoolSimulator) CanSwapFrom(address string) []string {
+	if strings.EqualFold(p.Info.Tokens[0], address) {
+		return []string{p.Info.Tokens[1]}
+	}
+	return nil
+}
+
+func (p *PoolSimulator) CalculateLimit() map[string]*big.Int {
+	if p.reserve == nil {
+		return nil
+	}
+	return map[string]*big.Int{
+		p.Info.Tokens[1]: p.reserve.ToBig(),
+	}
+}
+
+func (p *PoolSimulator) GetMetaInfo(_ string, _ string) any {
+	addr := common.HexToAddress(p.staticExtra.TargetRouter)
+	targetRouterBytes32 := common.BytesToHash(addr.Bytes()).Hex()
+
+	return PoolMeta{
+		SourceRouter:        p.staticExtra.SourceRouter,
+		TargetRouterBytes32: targetRouterBytes32,
+	}
+}

--- a/pkg/liquidity-source/ghost/pool_simulator.go
+++ b/pkg/liquidity-source/ghost/pool_simulator.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
 
@@ -60,8 +59,9 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 
 	var reserve *uint256.Int
 	if ex.Reserve != nil {
-		r, _ := uint256.FromBig(ex.Reserve)
-		reserve = r
+		if r, overflow := uint256.FromBig(ex.Reserve); !overflow {
+			reserve = r
+		}
 	}
 
 	scaleNum := uint256.NewInt(1)
@@ -146,15 +146,15 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 			Token:  tokenIn,
 			Amount: fee.ToBig(),
 		},
-		Gas:      p.gas,
-		SwapInfo: SwapInfo{Amount: principal},
+		Gas: p.gas,
 	}, nil
 }
 
-// inverseFee solves for the principal such that principal + fee(principal) ≈ amountIn,
-// with at most 1 unit of dust from integer division.
+// inverseFee solves for the largest principal such that principal + fee(principal)
+// <= amountIn, recovering the integer-division dust so the quoted principal equals
+// what the swap transfers on-chain.
 //
-//	Linear region:  principal = amountIn * 2 * halfAmount / (2 * halfAmount + maxFee)
+//	Linear region:  principal = amountIn * 2 * halfAmount / (2 * halfAmount + maxFee), then +1 dust recovery
 //	Capped region:  principal = amountIn - maxFee
 func inverseFee(amountIn, maxFee, halfAmount *uint256.Int) (principal, fee *uint256.Int) {
 	if maxFee.IsZero() || halfAmount.IsZero() {
@@ -178,6 +178,23 @@ func inverseFee(amountIn, maxFee, halfAmount *uint256.Int) (principal, fee *uint
 	principal = new(uint256.Int)
 	if _, overflow := principal.MulDivOverflow(amountIn, &twoHalf, &denom); overflow {
 		return new(uint256.Int), new(uint256.Int)
+	}
+
+	// Recover up to 1 unit of integer-division dust when principal+1 still fits
+	// within amountIn, so the quoted principal matches what the swap transfers
+	// on-chain. We are provably in the linear region here (principal < twoHalf),
+	// so fee(principal+1) scales linearly and cannot exceed maxFee — no cap check
+	// needed.
+	var candidate uint256.Int
+	candidate.AddUint64(principal, 1)
+
+	var feeUp uint256.Int
+	if _, overflow := feeUp.MulDivOverflow(&candidate, maxFee, &twoHalf); !overflow {
+		var total uint256.Int
+		total.Add(&candidate, &feeUp)
+		if !total.Gt(amountIn) {
+			principal.Set(&candidate)
+		}
 	}
 
 	fee = calcFee(principal, maxFee, halfAmount)
@@ -210,8 +227,9 @@ func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 		return
 	}
 	if p.reserve != nil {
-		amountOut, _ := uint256.FromBig(amountOutBig)
-		p.reserve = new(uint256.Int).Sub(p.reserve, amountOut)
+		if amountOut, overflow := uint256.FromBig(amountOutBig); !overflow {
+			p.reserve = new(uint256.Int).Sub(p.reserve, amountOut)
+		}
 	}
 	if len(p.Info.Reserves) > 1 {
 		p.Info.Reserves[1] = new(big.Int).Sub(p.Info.Reserves[1], amountOutBig)
@@ -251,11 +269,8 @@ func (p *PoolSimulator) CalculateLimit() map[string]*big.Int {
 }
 
 func (p *PoolSimulator) GetMetaInfo(_ string, _ string) any {
-	addr := common.HexToAddress(p.staticExtra.TargetRouter)
-	targetRouterBytes32 := common.BytesToHash(addr.Bytes()).Hex()
-
 	return PoolMeta{
-		SourceRouter:        p.staticExtra.SourceRouter,
-		TargetRouterBytes32: targetRouterBytes32,
+		SourceRouter: p.staticExtra.SourceRouter,
+		TargetRouter: p.staticExtra.TargetRouter,
 	}
 }

--- a/pkg/liquidity-source/ghost/pool_simulator_test.go
+++ b/pkg/liquidity-source/ghost/pool_simulator_test.go
@@ -1,0 +1,366 @@
+package ghost
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poolPkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+)
+
+func mustMarshal(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func makePool(
+	maxFee, halfAmount, reserve int64,
+	scaleNum, scaleDen string,
+) entity.Pool {
+	se := StaticExtra{
+		SourceRouter:     "0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F",
+		TargetRouter:     "0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3",
+		LocalDomain:      1,
+		ScaleNumerator:   scaleNum,
+		ScaleDenominator: scaleDen,
+	}
+	ex := Extra{
+		MaxFee:     big.NewInt(maxFee),
+		HalfAmount: big.NewInt(halfAmount),
+		Reserve:    big.NewInt(reserve),
+	}
+
+	return entity.Pool{
+		Address:  "0xa9c9a8fb36ce3e5ffbac3757da7141262723541f:0xeb1b48b238e15a62e1858a601b6bffdf41163ae3",
+		Exchange: "ghost",
+		Type:     DexType,
+		Reserves: []string{"10000000000", "10000000000"},
+		Tokens: []*entity.PoolToken{
+			{Address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", Symbol: "USDC", Decimals: 6, Swappable: true},
+			{Address: "0xdac17f958d2ee523a2206206994597c13d831ec7", Symbol: "USDT", Decimals: 6, Swappable: true},
+		},
+		StaticExtra: mustMarshal(se),
+		Extra:       mustMarshal(ex),
+	}
+}
+
+func TestCalcAmountOut_LinearRegion(t *testing.T) {
+	t.Parallel()
+
+	// maxFee=10000 (1 cent), halfAmount=5_000_000 (5 USDC)
+	// inverseFee(1_000_000): principal = 1_000_000 * 10_000_000 / 10_010_000 = 999_000
+	// fee = calcFee(999_000) = 999_000 * 10_000 / 10_000_000 = 999
+	// amountOut = 999_000 (scale 1:1), dust = 1_000_000 - (999_000 + 999) = 1
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(1_000_000),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(999_000), result.TokenAmountOut.Amount)
+	assert.Equal(t, big.NewInt(999), result.Fee.Amount)
+	assert.Equal(t, DefaultGas, result.Gas)
+}
+
+func TestCalcAmountOut_CapRegion(t *testing.T) {
+	t.Parallel()
+
+	// maxFee=10000, halfAmount=5_000_000
+	// inverseFee(20_000_000): cappedPrincipal = 20_000_000 - 10_000 = 19_990_000
+	// 19_990_000 >= 2 * 5_000_000 → capped region
+	// principal = 19_990_000, fee = 10_000
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(20_000_000),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(19_990_000), result.TokenAmountOut.Amount)
+	assert.Equal(t, big.NewInt(10_000), result.Fee.Amount)
+}
+
+func TestCalcAmountOut_WithScale(t *testing.T) {
+	t.Parallel()
+
+	// scaleNumerator=2, scaleDenominator=1 means output is 2x the principal
+	// amountIn=1_000_000, principal=999_000, fee=999
+	// amountOut = 999_000 * 2 / 1 = 1_998_000
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "2", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(1_000_000),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(1_998_000), result.TokenAmountOut.Amount)
+}
+
+func TestCalcAmountOut_InsufficientReserve(t *testing.T) {
+	t.Parallel()
+
+	// reserve=500_000, amountOut would be ~999_000 > 500_000
+	p := makePool(10_000, 5_000_000, 500_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	_, err = testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(1_000_000),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
+}
+
+func TestCalcAmountOut_ZeroAmount(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	_, err = testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(0),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	assert.Error(t, err)
+}
+
+func TestCalcAmountOut_WrongDirection(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	// Try swapping token1 → token0 (wrong direction for this unidirectional pool)
+	_, err = testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xdac17f958d2ee523a2206206994597c13d831ec7",
+				Amount: big.NewInt(1_000_000),
+			},
+			TokenOut: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+		})
+	})
+
+	assert.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestCalcAmountOut_ZeroFee(t *testing.T) {
+	t.Parallel()
+
+	// maxFee=0, halfAmount=0 → fee=0
+	p := makePool(0, 0, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(1_000_000),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(1_000_000), result.TokenAmountOut.Amount)
+	assert.Equal(t, 0, result.Fee.Amount.Sign())
+}
+
+func TestCalcAmountOut_ExactlyAtHalfAmount(t *testing.T) {
+	t.Parallel()
+
+	// maxFee=10000, halfAmount=5_000_000
+	// inverseFee(5_000_000): principal = 5_000_000 * 10_000_000 / 10_010_000 = 4_995_004
+	// fee = calcFee(4_995_004) = 4_995_004 * 10_000 / 10_000_000 = 4_995
+	// dust = 5_000_000 - (4_995_004 + 4_995) = 1
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+			TokenAmountIn: poolPkg.TokenAmount{
+				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				Amount: big.NewInt(5_000_000),
+			},
+			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		})
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(4_995_004), result.TokenAmountOut.Amount)
+	assert.Equal(t, big.NewInt(4_995), result.Fee.Amount)
+}
+
+func TestUpdateBalance(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	result, err := sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+		TokenAmountIn: poolPkg.TokenAmount{
+			Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+			Amount: big.NewInt(1_000_000),
+		},
+		TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+	})
+	require.NoError(t, err)
+
+	sim.UpdateBalance(poolPkg.UpdateBalanceParams{
+		TokenAmountIn:  poolPkg.TokenAmount{Token: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", Amount: big.NewInt(1_000_000)},
+		TokenAmountOut: *result.TokenAmountOut,
+	})
+
+	expectedReserve := new(big.Int).Sub(big.NewInt(10_000_000), result.TokenAmountOut.Amount)
+	assert.Equal(t, expectedReserve, sim.reserve.ToBig())
+}
+
+func TestCanSwapDirections(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	// CanSwapTo: given output token (token1), returns valid input tokens
+	from := sim.CanSwapTo("0xdac17f958d2ee523a2206206994597c13d831ec7")
+	assert.Equal(t, []string{"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"}, from)
+
+	// CanSwapTo: given wrong output token (token0), returns nil
+	from = sim.CanSwapTo("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+	assert.Nil(t, from)
+
+	// CanSwapFrom: given input token (token0), returns valid output tokens
+	to := sim.CanSwapFrom("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+	assert.Equal(t, []string{"0xdac17f958d2ee523a2206206994597c13d831ec7"}, to)
+
+	// CanSwapFrom: given wrong input token (token1), returns nil
+	to = sim.CanSwapFrom("0xdac17f958d2ee523a2206206994597c13d831ec7")
+	assert.Nil(t, to)
+}
+
+func TestGetMetaInfo(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	meta := sim.GetMetaInfo("", "")
+	pm, ok := meta.(PoolMeta)
+	require.True(t, ok)
+
+	assert.Equal(t, "0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F", pm.SourceRouter)
+	// bytes32(uint256(uint160(0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3)))
+	assert.Equal(t, "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3", pm.TargetRouterBytes32)
+}
+
+func TestCalculateLimit(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	limits := sim.CalculateLimit()
+	require.NotNil(t, limits)
+	assert.Equal(t, big.NewInt(10_000_000_000), limits["0xdac17f958d2ee523a2206206994597c13d831ec7"])
+}
+
+func TestCloneState(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	clone := sim.CloneState().(*PoolSimulator)
+	clone.reserve = uint256.NewInt(1)
+	assert.Equal(t, "10000000", sim.reserve.Dec())
+}
+
+func TestCloneState_InfoReservesIndependent(t *testing.T) {
+	t.Parallel()
+
+	p := makePool(10_000, 5_000_000, 10_000_000, "1", "1")
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+
+	clone := sim.CloneState().(*PoolSimulator)
+	clone.Info.Reserves[0] = big.NewInt(1)
+	assert.Equal(t, "10000000000", sim.Info.Reserves[0].String())
+}
+
+func TestCalcFee(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		amount     uint64
+		maxFee     uint64
+		halfAmount uint64
+		expected   uint64
+	}{
+		{"below cap", 1_000_000, 10_000, 5_000_000, 1000},
+		{"at cap boundary", 10_000_000, 10_000, 5_000_000, 10_000},
+		{"above cap", 20_000_000, 10_000, 5_000_000, 10_000},
+		{"at halfAmount", 5_000_000, 10_000, 5_000_000, 5_000},
+		{"small amount", 100, 10_000, 5_000_000, 0},
+		{"zero maxFee", 1_000_000, 0, 5_000_000, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fee := calcFee(uint256.NewInt(tc.amount), uint256.NewInt(tc.maxFee), uint256.NewInt(tc.halfAmount))
+			assert.Equal(t, uint256.NewInt(tc.expected), fee)
+		})
+	}
+}

--- a/pkg/liquidity-source/ghost/pool_simulator_test.go
+++ b/pkg/liquidity-source/ghost/pool_simulator_test.go
@@ -50,192 +50,133 @@ func makePool(
 	}
 }
 
-func TestCalcAmountOut_LinearRegion(t *testing.T) {
+func TestCalcAmountOut(t *testing.T) {
 	t.Parallel()
 
-	// maxFee=10000 (1 cent), halfAmount=5_000_000 (5 USDC)
-	// inverseFee(1_000_000): principal = 1_000_000 * 10_000_000 / 10_010_000 = 999_000
-	// fee = calcFee(999_000) = 999_000 * 10_000 / 10_000_000 = 999
-	// amountOut = 999_000 (scale 1:1), dust = 1_000_000 - (999_000 + 999) = 1
-	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
+	const (
+		token0 = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+		token1 = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+	)
 
-	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(1_000_000),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+	tests := []struct {
+		name                        string
+		maxFee, halfAmount, reserve int64
+		scaleNum, scaleDen          string
+		tokenIn, tokenOut           string // default to token0 -> token1 when empty
+		amountIn                    *big.Int
+
+		wantOut *big.Int // expected output amount on success
+		wantFee *big.Int // expected fee amount; nil skips the assertion
+		errIs   error    // when set, expect this sentinel via errors.Is
+		wantErr bool     // when true (and errIs nil), expect any error
+	}{
+		{
+			// maxFee=10000 (1 cent), halfAmount=5_000_000 (5 USDC)
+			// inverseFee(1_000_000): truncated principal = 999_000, +1 dust recovery → 999_001
+			// fee = calcFee(999_001) = 999_001 * 10_000 / 10_000_000 = 999
+			// amountOut = 999_001 (scale 1:1), dust = 1_000_000 - (999_001 + 999) = 0
+			name:   "linear region",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(1_000_000), wantOut: big.NewInt(999_001), wantFee: big.NewInt(999),
+		},
+		{
+			// inverseFee(20_000_000): cappedPrincipal = 20_000_000 - 10_000 = 19_990_000
+			// 19_990_000 >= 2 * 5_000_000 → capped region
+			// principal = 19_990_000, fee = 10_000
+			name:   "cap region",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(20_000_000), wantOut: big.NewInt(19_990_000), wantFee: big.NewInt(10_000),
+		},
+		{
+			// scaleNumerator=2, scaleDenominator=1 means output is 2x the principal
+			// amountIn=1_000_000, principal=999_001 (with dust recovery), fee=999 → amountOut = 999_001 * 2 / 1 = 1_998_002
+			name:   "with scale",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "2", scaleDen: "1",
+			amountIn: big.NewInt(1_000_000), wantOut: big.NewInt(1_998_002), wantFee: big.NewInt(999),
+		},
+		{
+			// maxFee=0, halfAmount=0 → fee=0, principal passes through unchanged
+			name:   "zero fee",
+			maxFee: 0, halfAmount: 0, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(1_000_000), wantOut: big.NewInt(1_000_000), wantFee: big.NewInt(0),
+		},
+		{
+			// inverseFee(5_000_000): truncated principal = 4_995_004, +1 dust recovery → 4_995_005
+			// fee = calcFee(4_995_005) = 4_995_005 * 10_000 / 10_000_000 = 4_995
+			// dust = 5_000_000 - (4_995_005 + 4_995) = 0
+			name:   "exactly at halfAmount",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(5_000_000), wantOut: big.NewInt(4_995_005), wantFee: big.NewInt(4_995),
+		},
+		{
+			// Linear region where amountIn divides evenly (amountIn = 1001 * 1000):
+			// principal = 1_001_000 * 10_000_000 / 10_010_000 = 1_000_000 exactly, no division dust.
+			// The +1 recovery check fails (1_000_001 + 1_000 = 1_001_001 > amountIn), so principal
+			// is NOT bumped — exercises the conditional dust-recovery path that does not fire.
+			// fee = calcFee(1_000_000) = 1_000, dust = 1_001_000 - (1_000_000 + 1_000) = 0
+			name:   "linear region no dust recovery",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(1_001_000), wantOut: big.NewInt(1_000_000), wantFee: big.NewInt(1_000),
+		},
+		{
+			// reserve=500_000, amountOut would be ~999_000 > 500_000
+			name:   "insufficient reserve",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 500_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(1_000_000), errIs: ErrInsufficientLiquidity,
+		},
+		{
+			name:   "zero amount",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			amountIn: big.NewInt(0), wantErr: true,
+		},
+		{
+			// swapping token1 → token0 (wrong direction for this unidirectional pool)
+			name:   "wrong direction",
+			maxFee: 10_000, halfAmount: 5_000_000, reserve: 10_000_000_000, scaleNum: "1", scaleDen: "1",
+			tokenIn: token1, tokenOut: token0,
+			amountIn: big.NewInt(1_000_000), errIs: ErrInvalidToken,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tokenIn, tokenOut := tc.tokenIn, tc.tokenOut
+			if tokenIn == "" {
+				tokenIn = token0
+			}
+			if tokenOut == "" {
+				tokenOut = token1
+			}
+
+			sim, err := NewPoolSimulator(makePool(tc.maxFee, tc.halfAmount, tc.reserve, tc.scaleNum, tc.scaleDen))
+			require.NoError(t, err)
+
+			result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
+				return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
+					TokenAmountIn: poolPkg.TokenAmount{Token: tokenIn, Amount: tc.amountIn},
+					TokenOut:      tokenOut,
+				})
+			})
+
+			if tc.errIs != nil {
+				assert.ErrorIs(t, err, tc.errIs)
+				return
+			}
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOut, result.TokenAmountOut.Amount)
+			assert.Equal(t, DefaultGas, result.Gas)
+			if tc.wantFee != nil {
+				assert.Zerof(t, tc.wantFee.Cmp(result.Fee.Amount), "fee: want %s got %s", tc.wantFee, result.Fee.Amount)
+			}
 		})
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(999_000), result.TokenAmountOut.Amount)
-	assert.Equal(t, big.NewInt(999), result.Fee.Amount)
-	assert.Equal(t, DefaultGas, result.Gas)
-}
-
-func TestCalcAmountOut_CapRegion(t *testing.T) {
-	t.Parallel()
-
-	// maxFee=10000, halfAmount=5_000_000
-	// inverseFee(20_000_000): cappedPrincipal = 20_000_000 - 10_000 = 19_990_000
-	// 19_990_000 >= 2 * 5_000_000 → capped region
-	// principal = 19_990_000, fee = 10_000
-	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(20_000_000),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-		})
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(19_990_000), result.TokenAmountOut.Amount)
-	assert.Equal(t, big.NewInt(10_000), result.Fee.Amount)
-}
-
-func TestCalcAmountOut_WithScale(t *testing.T) {
-	t.Parallel()
-
-	// scaleNumerator=2, scaleDenominator=1 means output is 2x the principal
-	// amountIn=1_000_000, principal=999_000, fee=999
-	// amountOut = 999_000 * 2 / 1 = 1_998_000
-	p := makePool(10_000, 5_000_000, 10_000_000_000, "2", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(1_000_000),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-		})
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(1_998_000), result.TokenAmountOut.Amount)
-}
-
-func TestCalcAmountOut_InsufficientReserve(t *testing.T) {
-	t.Parallel()
-
-	// reserve=500_000, amountOut would be ~999_000 > 500_000
-	p := makePool(10_000, 5_000_000, 500_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	_, err = testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(1_000_000),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-		})
-	})
-
-	assert.ErrorIs(t, err, ErrInsufficientLiquidity)
-}
-
-func TestCalcAmountOut_ZeroAmount(t *testing.T) {
-	t.Parallel()
-
-	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	_, err = testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(0),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-		})
-	})
-
-	assert.Error(t, err)
-}
-
-func TestCalcAmountOut_WrongDirection(t *testing.T) {
-	t.Parallel()
-
-	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	// Try swapping token1 → token0 (wrong direction for this unidirectional pool)
-	_, err = testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xdac17f958d2ee523a2206206994597c13d831ec7",
-				Amount: big.NewInt(1_000_000),
-			},
-			TokenOut: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-		})
-	})
-
-	assert.ErrorIs(t, err, ErrInvalidToken)
-}
-
-func TestCalcAmountOut_ZeroFee(t *testing.T) {
-	t.Parallel()
-
-	// maxFee=0, halfAmount=0 → fee=0
-	p := makePool(0, 0, 10_000_000_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(1_000_000),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-		})
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(1_000_000), result.TokenAmountOut.Amount)
-	assert.Equal(t, 0, result.Fee.Amount.Sign())
-}
-
-func TestCalcAmountOut_ExactlyAtHalfAmount(t *testing.T) {
-	t.Parallel()
-
-	// maxFee=10000, halfAmount=5_000_000
-	// inverseFee(5_000_000): principal = 5_000_000 * 10_000_000 / 10_010_000 = 4_995_004
-	// fee = calcFee(4_995_004) = 4_995_004 * 10_000 / 10_000_000 = 4_995
-	// dust = 5_000_000 - (4_995_004 + 4_995) = 1
-	p := makePool(10_000, 5_000_000, 10_000_000_000, "1", "1")
-	sim, err := NewPoolSimulator(p)
-	require.NoError(t, err)
-
-	result, err := testutil.MustConcurrentSafe(t, func() (*poolPkg.CalcAmountOutResult, error) {
-		return sim.CalcAmountOut(poolPkg.CalcAmountOutParams{
-			TokenAmountIn: poolPkg.TokenAmount{
-				Token:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-				Amount: big.NewInt(5_000_000),
-			},
-			TokenOut: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-		})
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(4_995_004), result.TokenAmountOut.Amount)
-	assert.Equal(t, big.NewInt(4_995), result.Fee.Amount)
+	}
 }
 
 func TestUpdateBalance(t *testing.T) {
@@ -299,8 +240,7 @@ func TestGetMetaInfo(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F", pm.SourceRouter)
-	// bytes32(uint256(uint160(0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3)))
-	assert.Equal(t, "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3", pm.TargetRouterBytes32)
+	assert.Equal(t, "0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3", pm.TargetRouter)
 }
 
 func TestCalculateLimit(t *testing.T) {

--- a/pkg/liquidity-source/ghost/pool_tracker.go
+++ b/pkg/liquidity-source/ghost/pool_tracker.go
@@ -1,0 +1,258 @@
+package ghost
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+	utilabi "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/abi"
+)
+
+// WILDCARD_RECIPIENT = bytes32(type(uint256).max) = 0xfff…fff
+var wildcardRecipient [32]byte
+
+func init() {
+	for i := range wildcardRecipient {
+		wildcardRecipient[i] = 0xff
+	}
+}
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(
+	cfg *Config,
+	ethrpcClient *ethrpc.Client,
+) *PoolTracker {
+	return &PoolTracker{
+		config:       cfg,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	logger.WithFields(logger.Fields{
+		"exchange": p.Exchange,
+		"address":  p.Address,
+	}).Infof("[%s] Start getting new state of pool", DexType)
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return entity.Pool{}, err
+	}
+
+	extra, blockNumber, err := t.fetchState(ctx, p, staticExtra)
+	if err != nil {
+		return p, err
+	}
+
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return p, err
+	}
+
+	p.Extra = string(extraBytes)
+	p.BlockNumber = blockNumber
+	p.Timestamp = time.Now().Unix()
+
+	if len(p.Tokens) >= 2 {
+		reserves := make(entity.PoolReserves, len(p.Reserves))
+		copy(reserves, p.Reserves)
+		reserves[1] = extra.Reserve.String()
+		p.Reserves = reserves
+	}
+
+	logger.WithFields(logger.Fields{
+		"exchange": p.Exchange,
+		"address":  p.Address,
+	}).Infof("[%s] Finish getting new state of pool", DexType)
+
+	return p, nil
+}
+
+type storedQuoteResult struct {
+	MaxFee     *big.Int
+	HalfAmount *big.Int
+	IssuedAt   *big.Int
+	Expiry     *big.Int
+}
+
+func (t *PoolTracker) fetchState(
+	ctx context.Context,
+	p entity.Pool,
+	se StaticExtra,
+) (Extra, uint64, error) {
+	feeContract, err := t.resolveFeeContract(ctx, se)
+	if err != nil {
+		return Extra{}, 0, err
+	}
+
+	var (
+		immutableMaxFee     *big.Int
+		immutableHalfAmount *big.Int
+		standing            storedQuoteResult
+		reserve             *big.Int
+	)
+
+	outputToken := ""
+	if len(p.Tokens) >= 2 {
+		outputToken = p.Tokens[1].Address
+	}
+
+	targetRouterAddr := common.HexToAddress(se.TargetRouter)
+	feeTarget := strings.ToLower(feeContract.Hex())
+
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+
+	req.AddCall(&ethrpc.Call{
+		ABI:    feeABI,
+		Target: feeTarget,
+		Method: feeMethodMaxFee,
+	}, []any{&immutableMaxFee})
+
+	req.AddCall(&ethrpc.Call{
+		ABI:    feeABI,
+		Target: feeTarget,
+		Method: feeMethodHalfAmount,
+	}, []any{&immutableHalfAmount})
+
+	req.AddCall(&ethrpc.Call{
+		ABI:    feeABI,
+		Target: feeTarget,
+		Method: feeMethodQuotes,
+		Params: []any{se.LocalDomain, wildcardRecipient},
+	}, []any{&standing})
+
+	req.AddCall(&ethrpc.Call{
+		ABI:    utilabi.Erc20ABI,
+		Target: outputToken,
+		Method: utilabi.Erc20BalanceOfMethod,
+		Params: []any{targetRouterAddr},
+	}, []any{&reserve})
+
+	resp, err := req.Aggregate()
+	if err != nil {
+		return Extra{}, 0, err
+	}
+
+	blockNumber := uint64(0)
+	if resp.BlockNumber != nil {
+		blockNumber = resp.BlockNumber.Uint64()
+	}
+
+	effectiveMaxFee := immutableMaxFee
+	effectiveHalfAmount := immutableHalfAmount
+
+	if standing.Expiry != nil && standing.Expiry.Sign() > 0 {
+		now := time.Now().Unix()
+		if standing.Expiry.Int64() > now {
+			effectiveMaxFee = standing.MaxFee
+			effectiveHalfAmount = standing.HalfAmount
+		}
+	}
+
+	return Extra{
+		MaxFee:     effectiveMaxFee,
+		HalfAmount: effectiveHalfAmount,
+		Reserve:    reserve,
+	}, blockNumber, nil
+}
+
+func (t *PoolTracker) resolveFeeContract(ctx context.Context, se StaticExtra) (common.Address, error) {
+	var feeRecipient common.Address
+	_, err := t.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI:    routerABI,
+		Target: strings.ToLower(se.SourceRouter),
+		Method: "feeRecipient",
+	}, []any{&feeRecipient}).Call()
+	if err != nil {
+		return common.Address{}, fmt.Errorf("ghost: feeRecipient() call failed: %w", err)
+	}
+
+	if feeRecipient == (common.Address{}) {
+		return common.Address{}, ErrNoFeeContract
+	}
+
+	var recipientFeeType uint8
+	_, err = t.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI:    routingFeeABI,
+		Target: strings.ToLower(feeRecipient.Hex()),
+		Method: "feeType",
+	}, []any{&recipientFeeType}).Call()
+	if err != nil {
+		return common.Address{}, fmt.Errorf("ghost: feeType() on feeRecipient failed: %w", err)
+	}
+
+	var resolved common.Address
+	targetRouterAddr := common.HexToAddress(se.TargetRouter)
+	targetRouterBytes32 := common.BytesToHash(targetRouterAddr.Bytes())
+
+	switch recipientFeeType {
+	case feeTypeCrossCollateralRouting:
+		_, err = t.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+			ABI:    routingFeeABI,
+			Target: strings.ToLower(feeRecipient.Hex()),
+			Method: "feeContracts",
+			Params: []any{se.LocalDomain, targetRouterBytes32},
+		}, []any{&resolved}).Call()
+		if err != nil {
+			return common.Address{}, fmt.Errorf("ghost: feeContracts() call failed: %w", err)
+		}
+
+		if resolved == (common.Address{}) {
+			_, err = t.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+				ABI:    routingFeeABI,
+				Target: strings.ToLower(feeRecipient.Hex()),
+				Method: "feeContracts",
+				Params: []any{se.LocalDomain, defaultRouterKey},
+			}, []any{&resolved}).Call()
+			if err != nil {
+				return common.Address{}, fmt.Errorf("ghost: feeContracts() fallback call failed: %w", err)
+			}
+		}
+
+	case feeTypeOffchainQuotedLinear:
+		resolved = feeRecipient
+
+	default:
+		return common.Address{}, fmt.Errorf("%w: feeRecipient has feeType %d", ErrUnsupportedFeeType, recipientFeeType)
+	}
+
+	if resolved == (common.Address{}) {
+		return common.Address{}, ErrNoFeeContract
+	}
+
+	var resolvedFeeType uint8
+	_, err = t.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI:    feeABI,
+		Target: strings.ToLower(resolved.Hex()),
+		Method: "feeType",
+	}, []any{&resolvedFeeType}).Call()
+	if err != nil {
+		return common.Address{}, fmt.Errorf("ghost: feeType() on resolved fee contract failed: %w", err)
+	}
+
+	if resolvedFeeType != feeTypeOffchainQuotedLinear {
+		return common.Address{}, fmt.Errorf("%w: got %d", ErrUnsupportedFeeType, resolvedFeeType)
+	}
+
+	return resolved, nil
+}

--- a/pkg/liquidity-source/ghost/pool_tracker.go
+++ b/pkg/liquidity-source/ghost/pool_tracker.go
@@ -19,12 +19,11 @@ import (
 )
 
 // WILDCARD_RECIPIENT = bytes32(type(uint256).max) = 0xfff…fff
-var wildcardRecipient [32]byte
-
-func init() {
-	for i := range wildcardRecipient {
-		wildcardRecipient[i] = 0xff
-	}
+var wildcardRecipient = [32]byte{
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 }
 
 type PoolTracker struct {
@@ -201,9 +200,11 @@ func (t *PoolTracker) resolveFeeContract(ctx context.Context, se StaticExtra) (c
 		return common.Address{}, fmt.Errorf("ghost: feeType() on feeRecipient failed: %w", err)
 	}
 
-	var resolved common.Address
-	targetRouterAddr := common.HexToAddress(se.TargetRouter)
-	targetRouterBytes32 := common.BytesToHash(targetRouterAddr.Bytes())
+	var (
+		resolved            common.Address
+		targetRouterAddr    = common.HexToAddress(se.TargetRouter)
+		targetRouterBytes32 = common.BytesToHash(targetRouterAddr.Bytes())
+	)
 
 	switch recipientFeeType {
 	case feeTypeCrossCollateralRouting:

--- a/pkg/liquidity-source/ghost/pools/arbitrum.json
+++ b/pkg/liquidity-source/ghost/pools/arbitrum.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "0xebc079d41c41a0ef7e54aa7af867df9a621c9be0:0x75a9297db5f0349fd1d6f4030953fe17175e06d4",
+    "type": "ghost",
+    "tokens": [
+      {
+        "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      },
+      {
+        "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"
+      }
+    ],
+    "staticExtra": {
+      "sourceRouter": "0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0",
+      "targetRouter": "0x75a9297db5F0349fd1d6f4030953Fe17175e06d4",
+      "localDomain": 42161,
+      "scaleNumerator": "1",
+      "scaleDenominator": "1"
+    }
+  },
+  {
+    "id": "0x75a9297db5f0349fd1d6f4030953fe17175e06d4:0xebc079d41c41a0ef7e54aa7af867df9a621c9be0",
+    "type": "ghost",
+    "tokens": [
+      {
+        "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"
+      },
+      {
+        "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      }
+    ],
+    "staticExtra": {
+      "sourceRouter": "0x75a9297db5F0349fd1d6f4030953Fe17175e06d4",
+      "targetRouter": "0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0",
+      "localDomain": 42161,
+      "scaleNumerator": "1",
+      "scaleDenominator": "1"
+    }
+  }
+]

--- a/pkg/liquidity-source/ghost/pools/base.json
+++ b/pkg/liquidity-source/ghost/pools/base.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "0x253821543c24623ecd3cebced704359af16cf38f:0x7abbb4ea8a5895127500cf0c15830c9eb9f61f96",
+    "type": "ghost",
+    "tokens": [
+      {
+        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+      },
+      {
+        "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2"
+      }
+    ],
+    "staticExtra": {
+      "sourceRouter": "0x253821543C24623ecD3ceBCEd704359AF16CF38f",
+      "targetRouter": "0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96",
+      "localDomain": 8453,
+      "scaleNumerator": "1",
+      "scaleDenominator": "1"
+    }
+  },
+  {
+    "id": "0x7abbb4ea8a5895127500cf0c15830c9eb9f61f96:0x253821543c24623ecd3cebced704359af16cf38f",
+    "type": "ghost",
+    "tokens": [
+      {
+        "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2"
+      },
+      {
+        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+      }
+    ],
+    "staticExtra": {
+      "sourceRouter": "0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96",
+      "targetRouter": "0x253821543C24623ecD3ceBCEd704359AF16CF38f",
+      "localDomain": 8453,
+      "scaleNumerator": "1",
+      "scaleDenominator": "1"
+    }
+  }
+]

--- a/pkg/liquidity-source/ghost/pools/ethereum.json
+++ b/pkg/liquidity-source/ghost/pools/ethereum.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "0xa9c9a8fb36ce3e5ffbac3757da7141262723541f:0xeb1b48b238e15a62e1858a601b6bffdf41163ae3",
+    "type": "ghost",
+    "tokens": [
+      {
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      },
+      {
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      }
+    ],
+    "staticExtra": {
+      "sourceRouter": "0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F",
+      "targetRouter": "0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3",
+      "localDomain": 1,
+      "scaleNumerator": "1",
+      "scaleDenominator": "1"
+    }
+  },
+  {
+    "id": "0xeb1b48b238e15a62e1858a601b6bffdf41163ae3:0xa9c9a8fb36ce3e5ffbac3757da7141262723541f",
+    "type": "ghost",
+    "tokens": [
+      {
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      },
+      {
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      }
+    ],
+    "staticExtra": {
+      "sourceRouter": "0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3",
+      "targetRouter": "0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F",
+      "localDomain": 1,
+      "scaleNumerator": "1",
+      "scaleDenominator": "1"
+    }
+  }
+]

--- a/pkg/liquidity-source/ghost/pools_list_updater.go
+++ b/pkg/liquidity-source/ghost/pools_list_updater.go
@@ -1,0 +1,101 @@
+package ghost
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config         *Config
+	ethrpcClient   *ethrpc.Client
+	hasInitialized bool
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(
+	cfg *Config,
+	ethrpcClient *ethrpc.Client,
+) *PoolsListUpdater {
+	return &PoolsListUpdater{
+		config:       cfg,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	if d.hasInitialized {
+		return nil, nil, nil
+	}
+
+	pools, err := d.initPools()
+	if err != nil {
+		logger.WithFields(logger.Fields{"error": err}).Errorf("[%s] failed to init pools", DexType)
+		return nil, nil, err
+	}
+
+	return pools, nil, nil
+}
+
+func (d *PoolsListUpdater) initPools() ([]entity.Pool, error) {
+	byteData, ok := bytesByPath[d.config.PoolPath]
+	if !ok {
+		return nil, errors.New("misconfigured poolPath")
+	}
+
+	var poolItems []PoolItem
+	if err := json.Unmarshal(byteData, &poolItems); err != nil {
+		return nil, err
+	}
+
+	pools := make([]entity.Pool, 0, len(poolItems))
+	for i := range poolItems {
+		p, err := d.buildPool(&poolItems[i])
+		if err != nil {
+			return nil, err
+		}
+		pools = append(pools, p)
+	}
+
+	d.hasInitialized = true
+
+	return pools, nil
+}
+
+func (d *PoolsListUpdater) buildPool(item *PoolItem) (entity.Pool, error) {
+	tokens := make([]*entity.PoolToken, 0, len(item.Tokens))
+	reserves := make(entity.PoolReserves, 0, len(item.Tokens))
+
+	for _, tok := range item.Tokens {
+		tokens = append(tokens, &entity.PoolToken{
+			Address:   strings.ToLower(tok.Address),
+			Swappable: true,
+		})
+		reserves = append(reserves, defaultReserves)
+	}
+
+	staticExtraBytes, err := json.Marshal(item.StaticExtra)
+	if err != nil {
+		return entity.Pool{}, err
+	}
+
+	return entity.Pool{
+		Address:     item.ID,
+		Exchange:    d.config.DexID,
+		Type:        DexType,
+		Timestamp:   time.Now().Unix(),
+		Reserves:    reserves,
+		Tokens:      tokens,
+		StaticExtra: string(staticExtraBytes),
+		Extra:       "{}",
+	}, nil
+}

--- a/pkg/liquidity-source/ghost/quote_verification_test.go
+++ b/pkg/liquidity-source/ghost/quote_verification_test.go
@@ -1,0 +1,122 @@
+package ghost
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	pool_pkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+const (
+	rpcURL     = "https://ethereum-rpc.publicnode.com"
+	multicall3 = "0xcA11bde05977b3631167028862bE2a173976CA11"
+)
+
+type onChainQuote struct {
+	Token  common.Address
+	Amount *big.Int
+}
+
+func quoteOnChain(t *testing.T, client *ethrpc.Client, sourceRouter string, principal *big.Int, targetRouterBytes32 common.Hash) *big.Int {
+	t.Helper()
+
+	var quotes []onChainQuote
+	_, err := client.NewRequest().AddCall(&ethrpc.Call{
+		ABI:    routerABI,
+		Target: sourceRouter,
+		Method: "quoteTransferRemoteTo",
+		Params: []any{
+			uint32(1),
+			wildcardRecipient,
+			principal,
+			targetRouterBytes32,
+		},
+	}, []any{&quotes}).Call()
+	require.NoError(t, err, "quoteTransferRemoteTo failed for principal=%s", principal)
+	require.GreaterOrEqual(t, len(quotes), 2)
+
+	return quotes[1].Amount
+}
+
+func TestInverseFee_MatchesOnChainQuote(t *testing.T) {
+	client := ethrpc.New(rpcURL).
+		SetMulticallContract(common.HexToAddress(multicall3))
+
+	// Use the pool tracker to fetch fee params — same as production.
+	tracker := NewPoolTracker(&Config{DexID: DexType}, client)
+
+	poolData := ethereumPoolData
+	var items []PoolItem
+	require.NoError(t, json.Unmarshal(poolData, &items))
+	require.NotEmpty(t, items)
+
+	item := items[0]
+	pool := entity.Pool{
+		Address:  item.ID,
+		Exchange: DexType,
+		Type:     item.Type,
+		Tokens: []*entity.PoolToken{
+			{Address: item.Tokens[0].Address},
+			{Address: item.Tokens[1].Address},
+		},
+		Reserves:    []string{"0", "0"},
+		StaticExtra: mustMarshal(item.StaticExtra),
+	}
+
+	updated, err := tracker.GetNewPoolState(context.Background(), pool, pool_pkg.GetNewPoolStateParams{})
+	require.NoError(t, err,
+		"tracker.GetNewPoolState failed — leaf fee contract resolution from router.feeRecipient() "+
+			"likely returned an unsupported fee type or zero address")
+
+	var extra Extra
+	require.NoError(t, json.Unmarshal([]byte(updated.Extra), &extra))
+	require.NotNil(t, extra.MaxFee, "maxFee is nil — tracker failed to fetch fee params")
+	require.NotNil(t, extra.HalfAmount, "halfAmount is nil — tracker failed to fetch fee params")
+
+	maxFee, _ := uint256.FromBig(extra.MaxFee)
+	halfAmount, _ := uint256.FromBig(extra.HalfAmount)
+	t.Logf("tracker fetched: maxFee=%s halfAmount=%s reserve=%s", extra.MaxFee, extra.HalfAmount, extra.Reserve)
+
+	// Now verify: for various amountIn values, inverseFee with tracker's params
+	// produces a principal that the on-chain router quotes back to amountIn.
+	targetRouterAddr := common.HexToAddress(item.StaticExtra.TargetRouter)
+	targetRouterBytes32 := common.BytesToHash(targetRouterAddr.Bytes())
+
+	amountsIn := []uint64{
+		1_000_000,      // 1 USDC
+		5_000_000,      // 5 USDC
+		10_000_000,     // 10 USDC
+		100_000_000,    // 100 USDC
+		1_000_000_000,  // 1000 USDC
+		10_000_000_000, // 10000 USDC
+	}
+
+	for _, amtIn := range amountsIn {
+		amountIn := uint256.NewInt(amtIn)
+		principal, fee := inverseFee(amountIn, maxFee, halfAmount)
+
+		// Quote the principal on-chain to get the real total cost
+		totalCost := quoteOnChain(t, client, item.StaticExtra.SourceRouter, principal.ToBig(), targetRouterBytes32)
+		totalCostU, _ := uint256.FromBig(totalCost)
+
+		var diff uint256.Int
+		if totalCostU.Gt(amountIn) {
+			diff.Sub(totalCostU, amountIn)
+		} else {
+			diff.Sub(amountIn, totalCostU)
+		}
+
+		assert.False(t, diff.Gt(uint256.NewInt(1)),
+			"amountIn=%d principal=%s fee=%s totalCost=%s diff=%s (expected ≤ 1)",
+			amtIn, principal, fee, totalCostU, &diff)
+	}
+}

--- a/pkg/liquidity-source/ghost/type.go
+++ b/pkg/liquidity-source/ghost/type.go
@@ -3,16 +3,14 @@ package ghost
 import (
 	"math/big"
 
-	"github.com/holiman/uint256"
-
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 )
 
 type PoolItem struct {
-	ID      string             `json:"id"`
-	Type    string             `json:"type"`
-	Tokens  []entity.PoolToken `json:"tokens"`
-	StaticExtra StaticExtra    `json:"staticExtra"`
+	ID          string             `json:"id"`
+	Type        string             `json:"type"`
+	Tokens      []entity.PoolToken `json:"tokens"`
+	StaticExtra StaticExtra        `json:"staticExtra"`
 }
 
 type StaticExtra struct {
@@ -30,10 +28,6 @@ type Extra struct {
 }
 
 type PoolMeta struct {
-	SourceRouter        string `json:"sourceRouter"`
-	TargetRouterBytes32 string `json:"targetRouterBytes32"`
-}
-
-type SwapInfo struct {
-	Amount *uint256.Int `json:"amount"`
+	SourceRouter string `json:"sourceRouter"`
+	TargetRouter string `json:"targetRouter"`
 }

--- a/pkg/liquidity-source/ghost/type.go
+++ b/pkg/liquidity-source/ghost/type.go
@@ -1,0 +1,39 @@
+package ghost
+
+import (
+	"math/big"
+
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+)
+
+type PoolItem struct {
+	ID      string             `json:"id"`
+	Type    string             `json:"type"`
+	Tokens  []entity.PoolToken `json:"tokens"`
+	StaticExtra StaticExtra    `json:"staticExtra"`
+}
+
+type StaticExtra struct {
+	SourceRouter     string `json:"sourceRouter"`
+	TargetRouter     string `json:"targetRouter"`
+	LocalDomain      uint32 `json:"localDomain"`
+	ScaleNumerator   string `json:"scaleNumerator"`
+	ScaleDenominator string `json:"scaleDenominator"`
+}
+
+type Extra struct {
+	MaxFee     *big.Int `json:"maxFee"`
+	HalfAmount *big.Int `json:"halfAmount"`
+	Reserve    *big.Int `json:"reserve"`
+}
+
+type PoolMeta struct {
+	SourceRouter        string `json:"sourceRouter"`
+	TargetRouterBytes32 string `json:"targetRouterBytes32"`
+}
+
+type SwapInfo struct {
+	Amount *uint256.Int `json:"amount"`
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -81,6 +81,7 @@ import (
 	pkg_liquiditysource_frax_sfrxethconvertor "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/frax/sfrxeth-convertor"
 	pkg_liquiditysource_genericarm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/generic-arm"
 	pkg_liquiditysource_genericsimplerate "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/generic-simple-rate"
+	pkg_liquiditysource_ghost "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ghost"
 	pkg_liquiditysource_gohm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/gohm"
 	pkg_liquiditysource_gsm4626 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/gsm-4626"
 	pkg_liquiditysource_gyroscope_2clp "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/gyroscope/2clp"
@@ -320,6 +321,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_frax_sfrxethconvertor.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_genericarm.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_genericsimplerate.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_ghost.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_gohm.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_gsm4626.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_gyroscope_2clp.PoolSimulator{})

--- a/pkg/pooltypes/factory_test.go
+++ b/pkg/pooltypes/factory_test.go
@@ -89,7 +89,7 @@ func TestPoolListerFactory(t *testing.T) {
 		"sfrxeth-convertor", "etherfi-vampire", "algebra-integral", "virtual-fun", "beets-ss", "swap-x-v2",
 		"etherfi-ebtc", "uniswap-v4", "sky-psm", "honey", "curve-llamma", "curve-lending", "balancer-v3-eclp", "ekubo",
 		"ekubo-v3", "erc4626", "hyeth", "brownfi", "midas", "arbera-den", "cusd", "arbera-zap", "kelp-rseth-l2",
-		"unipool", "valantis-stex", "nabla", "lunarbase"}
+		"unipool", "valantis-stex", "nabla", "lunarbase", "ghost"}
 
 	for _, poolLister := range poolListers {
 		t.Run(poolLister, func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestPoolTrackerFactory(t *testing.T) {
 		"ringswap", "generic-simple-rate", "primeeth", "staderethx", "meth", "ondo-usdy", "deltaswap-v1", "sfrxeth",
 		"sfrxeth-convertor", "etherfi-vampire", "algebra-integral", "virtual-fun", "beets-ss", "swap-x-v2",
 		"etherfi-ebtc", "uniswap-v4", "sky-psm", "honey", "curve-llamma", "curve-lending", "balancer-v3-eclp", "ekubo",
-		"ekubo-v3", "erc4626", "hyeth", "brownfi", "cusd", "kelp-rseth-l2", "unipool", "valantis-stex", "nabla", "lunarbase"}
+		"ekubo-v3", "erc4626", "hyeth", "brownfi", "cusd", "kelp-rseth-l2", "unipool", "valantis-stex", "nabla", "lunarbase", "ghost"}
 	t.Logf("%#v", poolTrackers)
 
 	for _, poolTracker := range poolTrackers {

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -74,6 +74,7 @@ import (
 	sfrxethconvertor "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/frax/sfrxeth-convertor"
 	genericarm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/generic-arm"
 	genericsimplerate "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/generic-simple-rate"
+	ghost "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ghost"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/gohm"
 	gsm4626 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/gsm-4626"
 	gyro2clp "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/gyroscope/2clp"
@@ -375,6 +376,7 @@ type Types struct {
 	HiddenOcean                string
 	HyETH                      string
 	HyperAMM                   string
+	Ghost                      string
 	MimSwap                    string
 	Mooniswap                  string
 	InfinityPools              string
@@ -599,6 +601,7 @@ var (
 		HiddenOcean:                hiddenocean.DexType,
 		HyETH:                      hyeth.DexType,
 		HyperAMM:                   hyperamm.DexType,
+		Ghost:                      ghost.DexType,
 		MimSwap:                    mimswap.DexType,
 		Mooniswap:                  mooniswap.DexType,
 		InfinityPools:              infinitypools.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -129,6 +129,7 @@ const (
 	ExchangeHyeth                      = "hyeth"
 	ExchangeHyperAMM                   = "hyperamm"
 	ExchangeHyperpieV2                 = "hyperpie-v2"
+	ExchangeGhost                      = "ghost"
 	ExchangeInfinifi                   = "infinifi-gateway"
 	ExchangeInfinityPools              = "infinitypools"
 	ExchangeIntegral                   = "integral"


### PR DESCRIPTION
## Why did we need it?
Integrates the `ghost` liquidity source so the aggregator can route through
Ghost's cross-collateral router.

**Background.** Ghost settles a swap between a fixed token pair by calling the
source router, which credits the recipient on the target side. Each direction
of a pair is its own pool, and pricing follows an on-chain fee curve rather
than an AMM reserve curve.

**Pricing.** The router charges a size-based fee on the input that is capped at
a maximum. `CalcAmountOut` inverts that curve to recover the net amount,
applies decimal scaling, and caps the output at the target router's available
balance. Fee parameters and that balance are read on-chain by the tracker.

## Related Issue
New partner integration — no tracking issue.

## Release Note
Adds `ghost` liquidity source (Ethereum, Arbitrum, Base). No breaking changes.
CHANGELOG `[Unreleased]` updated.

## How Has This Been Tested?
- `pool_simulator_test.go` — pricing, fee cap, scaling, reserve limit.
- `quote_verification_test.go` — simulator output compared against live on-chain quotes.
- `go generate ./...` clean; `go test ./pkg/liquidity-source/ghost/...` passing.
