### PR TITLE
fix: lista-stable checkPriceDiff false rejection for 6-decimal pools

### DIFF
--- a/pkg/liquidity-source/lista/stable/constants.go
+++ b/pkg/liquidity-source/lista/stable/constants.go
@@ -1,10 +1,3 @@
 package stable
 
-import "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
-
 const DexType = "lista-stable"
-
-var (
-	Precision      = bignumber.NewBig10("1000000000000000000") // 1e18
-	FeeDenominator = bignumber.NewBig10("10000000000")         // 1e10
-)

--- a/pkg/liquidity-source/lista/stable/math.go
+++ b/pkg/liquidity-source/lista/stable/math.go
@@ -14,22 +14,25 @@ func (t *PoolSimulator) getDyWithoutFee(
 ) (*big.Int, error) {
 	xp := t._xp(updatedBalances)
 
-	x := new(big.Int).Add(xp[i], new(big.Int).Div(new(big.Int).Mul(dx, t.baseSim.Rates[i]), Precision))
+	// x = xp[i] + dx * rates[i] / PRECISION
+	x := bignumber.MulDivDown(new(big.Int), dx, t.baseSim.Rates[i], bignumber.BONE)
+	x.Add(xp[i], x)
+
 	y, err := t.baseSim.GetY(i, j, x, xp, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	dy := new(big.Int).Sub(new(big.Int).Sub(xp[j], y), bignumber.One)
-
-	return dy, nil
+	// dy = (xp[j] - y - 1) * PRECISION / rates[j], converting XP → raw token units (matches get_dy_without_fee on-chain)
+	x.Sub(xp[j], y)
+	x.Sub(x, bignumber.One)
+	return bignumber.MulDivDown(x, x, bignumber.BONE, t.baseSim.Rates[j]), nil
 }
 
 func (t *PoolSimulator) _xp(balances []*big.Int) []*big.Int {
-	var nTokens = len(t.Info.Tokens)
-	result := make([]*big.Int, nTokens)
-	for i := 0; i < nTokens; i += 1 {
-		result[i] = new(big.Int).Div(new(big.Int).Mul(t.baseSim.Rates[i], balances[i]), Precision)
+	result := make([]*big.Int, len(t.Info.Tokens))
+	for i := range t.Info.Tokens {
+		result[i] = bignumber.MulDivDown(new(big.Int), t.baseSim.Rates[i], balances[i], bignumber.BONE)
 	}
 	return result
 }

--- a/pkg/liquidity-source/lista/stable/pool_simulator.go
+++ b/pkg/liquidity-source/lista/stable/pool_simulator.go
@@ -6,12 +6,12 @@ import (
 	"slices"
 
 	"github.com/goccy/go-json"
-	"github.com/samber/lo"
+	"github.com/holiman/uint256"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/curve/base"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
@@ -26,8 +26,8 @@ type PoolSimulator struct {
 	baseSim            *base.PoolSimulator
 	decimals           []uint8
 	isNativeCoins      []bool
-	oraclePrices       [2]*big.Int
-	priceDiffThreshold [2]*big.Int
+	oraclePrices       [2]*uint256.Int
+	priceDiffThreshold [2]*uint256.Int
 }
 
 var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
@@ -58,8 +58,8 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 		baseSim:            curveBaseSimulator,
 		decimals:           decimals,
 		isNativeCoins:      staticExtra.IsNativeCoins,
-		oraclePrices:       extra.OraclePrices,
-		priceDiffThreshold: extra.PriceDiffThreshold,
+		oraclePrices:       [2]*uint256.Int{uint256.MustFromBig(extra.OraclePrices[0]), uint256.MustFromBig(extra.OraclePrices[1])},
+		priceDiffThreshold: [2]*uint256.Int{uint256.MustFromBig(extra.PriceDiffThreshold[0]), uint256.MustFromBig(extra.PriceDiffThreshold[1])},
 	}, nil
 }
 
@@ -78,9 +78,6 @@ func (t *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		return nil, err
 	}
 
-	// Now we check if the oracle prices are still satisfied
-	// after the swap (checkPriceDiff() in the contract).
-	// Prepare to update balance (without actually modifying the simulator state).
 	updatedBalances := t.prepareUpdateBalance(param, res)
 
 	if err := t.checkPriceDiff(updatedBalances); err != nil {
@@ -121,33 +118,29 @@ func (s *PoolSimulator) SwapReturnNativeOut(tokenIn, tokenOut string, _ valueobj
 	return meta.TokenOutIsNative
 }
 
-// prepareUpdateBalance has the same logic as UpdateBalance,
-// but returns the updated balances value instead of modifying the simulator state.
+// prepareUpdateBalance mirrors the on-chain balance update after exchange,
+// returning the post-swap stored balances that checkPriceDiff operates on.
 func (t *PoolSimulator) prepareUpdateBalance(
 	param pool.CalcAmountOutParams,
 	res *pool.CalcAmountOutResult,
 ) []*big.Int {
-	var inputAmount = param.TokenAmountIn.Amount
-	var outputAmount = res.TokenAmountOut.Amount
-	// swap fee
-	// output = output + output * swapFee * adminFee
-	outputAmount = new(big.Int).Add(
-		outputAmount,
-		new(big.Int).Div(
-			new(big.Int).Mul(
-				new(big.Int).Div(new(big.Int).Mul(outputAmount, t.Info.SwapFee), FeeDenominator),
-				t.baseSim.AdminFee,
-			),
-			FeeDenominator,
-		),
-	)
+	outAmt := uint256.MustFromBig(res.TokenAmountOut.Amount)
+	fd := big256.TenPow(10)
+
+	// admin_fee = outAmt * swapFee / fd * adminFee / fd
+	out := big256.MulDivDown(new(uint256.Int), outAmt, uint256.MustFromBig(t.Info.SwapFee), fd)
+	big256.MulDivDown(out, out, uint256.MustFromBig(t.baseSim.AdminFee), fd)
+	out.Add(outAmt, out) // balance decrease = user output + admin fee portion
+
 	updatedBalances := make([]*big.Int, len(t.Info.Reserves))
-	for i := range t.Info.Tokens {
-		if t.Info.Tokens[i] == param.TokenAmountIn.Token {
-			updatedBalances[i] = new(big.Int).Add(t.Info.Reserves[i], inputAmount)
+	for i, tok := range t.Info.Tokens {
+		if tok == param.TokenAmountIn.Token {
+			r := uint256.MustFromBig(t.Info.Reserves[i])
+			updatedBalances[i] = r.Add(r, uint256.MustFromBig(param.TokenAmountIn.Amount)).ToBig()
 		}
-		if t.Info.Tokens[i] == param.TokenOut {
-			updatedBalances[i] = new(big.Int).Sub(t.Info.Reserves[i], outputAmount)
+		if tok == param.TokenOut {
+			r := uint256.MustFromBig(t.Info.Reserves[i])
+			updatedBalances[i] = r.Sub(r, out).ToBig()
 		}
 	}
 
@@ -161,69 +154,56 @@ func (t *PoolSimulator) checkPriceDiff(updatedBalances []*big.Int) error {
 		return ErrInvalidValue
 	}
 
-	value := bignumber.NewBig10("100000000000000000000") // (100 * 1e18)
-	dsp0 := t.decimals[0]
-	dsp1 := t.decimals[1]
+	// dx = $100 worth of each token in raw units: 100 * 10^(18+decimals) / oraclePrice
+	hundred := uint256.NewInt(100)
+	dx0 := big256.MulDivDown(new(uint256.Int), hundred, big256.TenPow(int(t.decimals[0])+18), t.oraclePrices[0])
+	dx1 := big256.MulDivDown(hundred, hundred, big256.TenPow(int(t.decimals[1])+18), t.oraclePrices[1])
 
-	dx0 := new(big.Int).Div(
-		new(big.Int).Mul(
-			value,
-			bignumber.TenPowInt(dsp0),
-		),
-		t.oraclePrices[0],
-	)
-
-	dx1 := new(big.Int).Div(
-		new(big.Int).Mul(
-			value,
-			bignumber.TenPowInt(dsp1),
-		),
-		t.oraclePrices[1],
-	)
-
-	dy1, err := t.getDyWithoutFee(updatedBalances, 0, 1, dx0)
+	dy1, err := t.getDyWithoutFee(updatedBalances, 0, 1, dx0.ToBig())
 	if err != nil {
 		return err
 	}
-	dy0, err := t.getDyWithoutFee(updatedBalances, 1, 0, dx1)
+	dy0, err := t.getDyWithoutFee(updatedBalances, 1, 0, dx1.ToBig())
 	if err != nil {
 		return err
 	}
 
-	price0 := new(big.Int).Div(
-		new(big.Int).Mul(
-			new(big.Int).Mul(dx1, t.baseSim.Multipliers[1]),
-			t.oraclePrices[1],
-		),
-		new(big.Int).Mul(dy0, t.baseSim.Multipliers[0]),
-	)
-	price1 := new(big.Int).Div(
-		new(big.Int).Mul(
-			new(big.Int).Mul(dx0, t.baseSim.Multipliers[0]),
-			t.oraclePrices[0],
-		),
-		new(big.Int).Mul(dy1, t.baseSim.Multipliers[1]),
-	)
+	mul0 := uint256.MustFromBig(t.baseSim.Multipliers[0])
+	mul1 := uint256.MustFromBig(t.baseSim.Multipliers[1])
 
-	priceDiff0 := lo.Ternary(
-		price0.Cmp(t.oraclePrices[0]) > 0,
-		new(big.Int).Sub(price0, t.oraclePrices[0]),
-		new(big.Int).Sub(t.oraclePrices[0], price0),
-	)
+	// price0 = (dx1 * mul1 * oracle1) / (dy0 * mul0)  — implied price of token0 in oracle units
+	dx1.Mul(dx1, mul1)                                                  // dx1 = dx1_xp
+	dy0u := uint256.MustFromBig(dy0)
+	dy0u.Mul(dy0u, mul0)                                                // dy0u = dy0_xp
+	price0 := big256.MulDivDown(dx1, dx1, t.oraclePrices[1], dy0u)    // reuse dx1 as price0
 
-	priceDiff1 := lo.Ternary(
-		price1.Cmp(t.oraclePrices[1]) > 0,
-		new(big.Int).Sub(price1, t.oraclePrices[1]),
-		new(big.Int).Sub(t.oraclePrices[1], price1),
-	)
+	// price1 = (dx0 * mul0 * oracle0) / (dy1 * mul1)  — implied price of token1 in oracle units
+	dx0.Mul(dx0, mul0)                                                  // dx0 = dx0_xp
+	dy1u := uint256.MustFromBig(dy1)
+	dy1u.Mul(dy1u, mul1)                                                // dy1u = dy1_xp
+	price1 := big256.MulDivDown(dx0, dx0, t.oraclePrices[0], dy1u)    // reuse dx0 as price1
 
-	priceDiff0.Mul(priceDiff0, bignumber.TenPowInt(18))
-	if priceDiff0.Cmp(new(big.Int).Mul(t.oraclePrices[0], t.priceDiffThreshold[0])) > 0 {
+	// check: |price - oracle| * 1e18 <= oracle * threshold
+	var diff, rhs uint256.Int
+	if price0.Gt(t.oraclePrices[0]) {
+		diff.Sub(price0, t.oraclePrices[0])
+	} else {
+		diff.Sub(t.oraclePrices[0], price0)
+	}
+	diff.Mul(&diff, big256.BONE)
+	rhs.Mul(t.oraclePrices[0], t.priceDiffThreshold[0])
+	if diff.Gt(&rhs) {
 		return ErrPriceDiffToken0
 	}
 
-	priceDiff1.Mul(priceDiff1, bignumber.TenPowInt(18))
-	if priceDiff1.Cmp(new(big.Int).Mul(t.oraclePrices[1], t.priceDiffThreshold[1])) > 0 {
+	if price1.Gt(t.oraclePrices[1]) {
+		diff.Sub(price1, t.oraclePrices[1])
+	} else {
+		diff.Sub(t.oraclePrices[1], price1)
+	}
+	diff.Mul(&diff, big256.BONE)
+	rhs.Mul(t.oraclePrices[1], t.priceDiffThreshold[1])
+	if diff.Gt(&rhs) {
 		return ErrPriceDiffToken1
 	}
 

--- a/pkg/liquidity-source/lista/stable/pool_simulator_test.go
+++ b/pkg/liquidity-source/lista/stable/pool_simulator_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/goccy/go-json"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
@@ -38,4 +40,99 @@ func TestCloneState(t *testing.T) {
 		},
 		TokenOut: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
 	}, nil)
+}
+
+// USD1/USDT — 0xd46bfa2b03a8467d3fe1685d8d79eb195cb19675 on Ethereum
+// token[0] = USD1 (18-dec), token[1] = USDT (6-dec); balanced ~101k each
+// on-chain get_dy(0,1,100e18)=99424932  get_dy(1,0,100e6)=99424931844444344496
+var (
+	entityUSD1USDT entity.Pool
+	_              = json.Unmarshal([]byte(`{
+		"address":"0xd46bfa2b03a8467d3fe1685d8d79eb195cb19675",
+		"exchange":"lista-stable",
+		"type":"lista-stable",
+		"reserves":["101194664603798614406","101194664","202389327724267031814"],
+		"tokens":[
+			{"address":"0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d","symbol":"USD1","decimals":18,"swappable":true},
+			{"address":"0xdac17f958d2ee523a2206206994597c13d831ec7","symbol":"USDT","decimals":6,"swappable":true}
+		],
+		"extra":"{\"initialA\":\"500000\",\"futureA\":\"500000\",\"initialATime\":0,\"futureATime\":0,\"swapFee\":\"1000000\",\"adminFee\":\"2000000000\",\"oraclePrices\":[999360000000000000,999360000000000000],\"priceDiffThreshold\":[50000000000000000,50000000000000000]}",
+		"staticExtra":"{\"lpToken\":\"0xA7ABa0A4603d274D2536AE21cF6AbE7aa7293d9e\",\"aPrecision\":\"100\",\"precisionMultipliers\":[\"1\",\"1000000000000\"],\"rates\":[\"1000000000000000000\",\"1000000000000000000000000000000\"],\"isNativeCoins\":[false,false]}"
+	}`), &entityUSD1USDT)
+	poolUSD1USDT = lo.Must(NewPoolSimulator(entityUSD1USDT))
+)
+
+// USDC/USDT — 0x35c9a4dae1ff05788f24b5b32721d89340cbb636 on Ethereum
+// token[0] = USDC (6-dec), token[1] = USDT (6-dec); imbalanced 85k/324k
+// on-chain get_dy(0,1,100e6)=100025525  get_dy(1,0,100e6)=99972414
+// This pool was falsely rejected before the XP→raw fix in getDyWithoutFee.
+var (
+	entityUSDCUSDT entity.Pool
+	_              = json.Unmarshal([]byte(`{
+		"address":"0x35c9a4dae1ff05788f24b5b32721d89340cbb636",
+		"exchange":"lista-stable",
+		"type":"lista-stable",
+		"reserves":["85777228845","324257429898","410020487529258290804668"],
+		"tokens":[
+			{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","symbol":"USDC","decimals":6,"swappable":true},
+			{"address":"0xdac17f958d2ee523a2206206994597c13d831ec7","symbol":"USDT","decimals":6,"swappable":true}
+		],
+		"extra":"{\"initialA\":\"472311\",\"futureA\":\"1000000\",\"initialATime\":1780282307,\"futureATime\":1780386578,\"swapFee\":\"100000\",\"adminFee\":\"2000000000\",\"oraclePrices\":[999690000000000000,999360000000000000],\"priceDiffThreshold\":[50000000000000000,50000000000000000]}",
+		"staticExtra":"{\"lpToken\":\"0x923C67CeD114dd7341e65C0e2be47f3b0927d667\",\"aPrecision\":\"100\",\"precisionMultipliers\":[\"1000000000000\",\"1000000000000\"],\"rates\":[\"1000000000000000000000000000000\",\"1000000000000000000000000000000\"],\"isNativeCoins\":[false,false]}"
+	}`), &entityUSDCUSDT)
+	poolUSDCUSDT = lo.Must(NewPoolSimulator(entityUSDCUSDT))
+)
+
+// WBTC/cbBTC — 0x94e4a9f24a954047adb3ad4434bf1174f6824e16 on Ethereum
+// token[0] = WBTC (8-dec), token[1] = cbBTC (8-dec); tiny pool ~$77 each
+// checkPriceDiff() already fails on-chain: the $100 test trade (≈157k sat) exceeds the
+// entire pool balance (≈122k sat), so any swap must return ErrPriceDiffToken0.
+var (
+	entityWBTCcbBTC entity.Pool
+	_               = json.Unmarshal([]byte(`{
+		"address":"0x94e4a9f24a954047adb3ad4434bf1174f6824e16",
+		"exchange":"lista-stable",
+		"type":"lista-stable",
+		"reserves":["122149","122167","2443141304770259"],
+		"tokens":[
+			{"address":"0x2260fac5e5542a773aa44fbcfedf7c193bc2c599","symbol":"WBTC","decimals":8,"swappable":true},
+			{"address":"0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf","symbol":"cbBTC","decimals":8,"swappable":true}
+		],
+		"extra":"{\"initialA\":\"500000\",\"futureA\":\"500000\",\"initialATime\":0,\"futureATime\":0,\"swapFee\":\"1000000\",\"adminFee\":\"2000000000\",\"oraclePrices\":[63550923360000000000000,63578037764550000000000],\"priceDiffThreshold\":[50000000000000000,50000000000000000]}",
+		"staticExtra":"{\"lpToken\":\"0x6Ee2d8B77f5559d88057738821951a855EB5F123\",\"aPrecision\":\"100\",\"precisionMultipliers\":[\"10000000000\",\"10000000000\"],\"rates\":[\"10000000000000000000000000000\",\"10000000000000000000000000000\"],\"isNativeCoins\":[false,false]}"
+	}`), &entityWBTCcbBTC)
+	poolWBTCcbBTC = lo.Must(NewPoolSimulator(entityWBTCcbBTC))
+)
+
+// TestPoolSimulator_CalcAmountOut_USD1USDT: 18-dec/6-dec balanced pool, both directions succeed.
+// Pool is tiny (~$202 total), so amounts are capped at 1 token to keep the post-swap state
+// stable enough for checkPriceDiff's internal $100 test trade to pass.
+// on-chain: get_dy(0,1,1e18)=999899  get_dy(1,0,1e6)=999898024016224198
+func TestPoolSimulator_CalcAmountOut_USD1USDT(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountOut(t, poolUSD1USDT, map[int]map[int]map[string]string{
+		0: {1: {"1000000000000000000": "999898"}},
+		1: {0: {"1000000": "999898024016224198"}},
+	})
+}
+
+// TestPoolSimulator_CalcAmountOut_USDCUSDT: 6-dec/6-dec imbalanced pool.
+// Both directions must succeed — this pool was falsely rejected before the XP→raw fix.
+// on-chain: get_dy(0,1,100e6)=100025525  get_dy(1,0,100e6)=99972414 (simulator rounds to 99972413)
+func TestPoolSimulator_CalcAmountOut_USDCUSDT(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountOut(t, poolUSDCUSDT, map[int]map[int]map[string]string{
+		0: {1: {"100000000": "100025525"}},
+		1: {0: {"100000000": "99972413"}},
+	})
+}
+
+// TestPoolSimulator_CalcAmountOut_WBTCcbBTC: tiny pool where checkPriceDiff legitimately fails.
+// The $100 test trade (≈157k sat) exceeds pool balance (≈122k sat), so any swap errors.
+func TestPoolSimulator_CalcAmountOut_WBTCcbBTC(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountOut(t, poolWBTCcbBTC, map[int]map[int]map[string]string{
+		0: {1: {"1000": ErrPriceDiffToken0.Error()}},
+		1: {0: {"1000": ErrPriceDiffToken0.Error()}},
+	})
 }


### PR DESCRIPTION
getDyWithoutFee returned XP-scaled units (raw × Rates/PRECISION) but the
on-chain get_dy_without_fee returns raw token units.  For 18-dec tokens
Rates == PRECISION so there is no difference, but for 6-dec tokens
Rates = 1e30 so the XP value is 1e12× larger.  checkPriceDiff's price
formula uses dy in the denominator, so an 1e12× inflated dy collapses the
computed price to near-zero and the priceDiff check always fires.

Fix: add `* PRECISION / Rates[j]` at the end of getDyWithoutFee to
convert from XP to raw, matching the on-chain formula exactly.

Also: convert oraclePrices/priceDiffThreshold storage and checkPriceDiff/
prepareUpdateBalance arithmetic to uint256 with big256.MulDivDown and
variable reuse; remove stale Precision/FeeDenominator package vars; add
testutil tests covering USD1/USDT (18/6-dec), USDC/USDT (6/6-dec, the
bug pool), and WBTC/cbBTC (legitimate pool-too-small rejection).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
