### PR TITLE
perf: convert ambient to using uint256

### DIFF
--- a/pkg/liquidity-source/ambient/assimilate.go
+++ b/pkg/liquidity-source/ambient/assimilate.go
@@ -1,68 +1,79 @@
 package ambient
 
 import (
-	"math/big"
+	"github.com/holiman/uint256"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
-func AssimilateLiq(curve *CurveState, feesPaid *big.Int, isSwapInBase bool) {
-	liq := ActiveLiquidity(curve)
-	if liq.Sign() == 0 {
+func AssimilateLiq(curve *CurveState, feesPaid *uint256.Int, isSwapInBase bool) {
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
+	if liq.IsZero() {
 		return
 	}
 	feesInBase := !isSwapInBase
-	feesToLiq := shaveForPrecision(liq, curve.PriceRoot, feesPaid, feesInBase)
-	if feesToLiq.Sign() == 0 {
+
+	var feesToLiq uint256.Int
+	shaveForPrecision(&feesToLiq, &liq, &curve.PriceRoot, feesPaid, feesInBase)
+	if feesToLiq.IsZero() {
 		return
 	}
-	inflator := calcLiqInflator(liq, curve.PriceRoot, feesToLiq, feesInBase)
+	inflator := calcLiqInflator(&liq, &curve.PriceRoot, &feesToLiq, feesInBase)
 	if inflator > 0 {
 		stepToLiquidity(curve, inflator, feesInBase)
 	}
 }
 
-func calcLiqInflator(liq, price, feesPaid *big.Int, inBaseQty bool) uint64 {
-	reserve := ReserveAtPrice(liq, price, inBaseQty)
-	return calcReserveInflator(reserve, feesPaid)
+func calcLiqInflator(liq, price, feesPaid *uint256.Int, inBaseQty bool) uint64 {
+	var reserve uint256.Int
+	ReserveAtPrice(&reserve, liq, price, inBaseQty)
+	return calcReserveInflator(&reserve, feesPaid)
 }
 
-func calcReserveInflator(reserve, feesPaid *big.Int) uint64 {
-	if reserve.Sign() == 0 || feesPaid.Cmp(reserve) > 0 {
+func calcReserveInflator(reserve, feesPaid *uint256.Int) uint64 {
+	if reserve.IsZero() || feesPaid.Gt(reserve) {
 		return 0
 	}
-	nextReserve := new(big.Int).Add(reserve, feesPaid)
-	inflatorRoot := CompoundDivide(nextReserve, reserve)
+	var nextReserve uint256.Int
+	nextReserve.Add(reserve, feesPaid)
+	inflatorRoot := CompoundDivide(&nextReserve, reserve)
 	return ApproxSqrtCompound(inflatorRoot)
 }
 
-func shaveForPrecision(liq, price, feesPaid *big.Int, isFeesInBase bool) *big.Int {
-	maxLiqExpansion := bignum.Two
-	bufferTokens := new(big.Int).Mul(maxLiqExpansion, PriceToTokenPrecision(liq, price, isFeesInBase))
-	if feesPaid.Cmp(bufferTokens) <= 0 {
-		return new(big.Int)
+func shaveForPrecision(dst, liq, price, feesPaid *uint256.Int, isFeesInBase bool) *uint256.Int {
+	var precision uint256.Int
+	PriceToTokenPrecision(&precision, liq, price, isFeesInBase)
+	// bufferTokens = 2 * precision
+	precision.Lsh(&precision, 1)
+	if !feesPaid.Gt(&precision) {
+		dst.Clear()
+		return dst
 	}
-	return new(big.Int).Sub(feesPaid, bufferTokens)
+	dst.Sub(feesPaid, &precision)
+	return dst
 }
 
 func stepToLiquidity(curve *CurveState, inflator uint64, feesInBase bool) {
-	curve.PriceRoot = CompoundPrice(curve.PriceRoot, inflator, feesInBase)
+	CompoundPrice(&curve.PriceRoot, &curve.PriceRoot, inflator, feesInBase)
 	curve.SeedDeflator = CompoundStack(curve.SeedDeflator, inflator)
 
 	concRewards := CompoundShrink(inflator, curve.SeedDeflator)
 
-	newAmbientSeeds := MulQ48(curve.ConcLiq, concRewards)
+	var newAmbientSeeds uint256.Int
+	MulQ48(&newAmbientSeeds, &curve.ConcLiq, concRewards)
 
-	curve.ConcGrowth += roundDownConcRewards(concRewards, newAmbientSeeds)
-	curve.AmbientSeeds = new(big.Int).Add(curve.AmbientSeeds, newAmbientSeeds)
+	curve.ConcGrowth += roundDownConcRewards(concRewards, &newAmbientSeeds)
+	curve.AmbientSeeds.Add(&curve.AmbientSeeds, &newAmbientSeeds)
 }
 
-func roundDownConcRewards(concInflator uint64, newAmbientSeeds *big.Int) uint64 {
-	if newAmbientSeeds.Sign() <= 0 {
+func roundDownConcRewards(concInflator uint64, newAmbientSeeds *uint256.Int) uint64 {
+	if newAmbientSeeds.IsZero() {
 		return 0
 	}
-	num := new(big.Int).SetUint64(concInflator)
-	num.Mul(num, newAmbientSeeds)
-	denom := new(big.Int).Add(newAmbientSeeds, bignum.One)
-	return num.Div(num, denom).Uint64()
+	var num, denom uint256.Int
+	num.SetUint64(concInflator)
+	num.Mul(&num, newAmbientSeeds)
+	denom.Add(newAmbientSeeds, u256.U1)
+	return num.Div(&num, &denom).Uint64()
 }

--- a/pkg/liquidity-source/ambient/bitmap_view.go
+++ b/pkg/liquidity-source/ambient/bitmap_view.go
@@ -7,21 +7,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/holiman/uint256"
 )
 
-// mask96 is (1 << 96) - 1 — used to extract 96-bit lot fields from a uint256
-// storage slot. Hoisted so QueryLevel doesn't allocate on each call.
-var mask96 = func() *big.Int {
-	m := new(big.Int).Lsh(bignum.One, 96)
-	return m.Sub(m, bignum.One)
-}()
-
-// ChainBitmapView reads CrocSwapDex storage (mezzanine/terminus/levels) at a
-// pinned block; mirrors CrocImpact.sol pinBitmap/seekMezzSpill/queryLevel.
-// readSlot errors are captured and surfaced via Err(); later reads
-// short-circuit so the caller must check Err() after SweepSwap.
+// ChainBitmapView reads CrocSwapDex storage at a pinned block.
+// readSlot errors are captured; callers must check Err() after SweepSwap.
 type ChainBitmapView struct {
 	Ctx      context.Context
 	Client   *ethclient.Client
@@ -32,7 +22,6 @@ type ChainBitmapView struct {
 	err error
 }
 
-// Err returns the first readSlot error encountered, or nil if none.
 func (v *ChainBitmapView) Err() error { return v.err }
 
 func (v *ChainBitmapView) readSlot(slot common.Hash) *big.Int {
@@ -55,7 +44,6 @@ func (v *ChainBitmapView) ctx() context.Context {
 	return context.Background()
 }
 
-// PinBitmap mirrors CrocImpact.sol pinBitmap → pinTermMezz.
 func (v *ChainBitmapView) PinBitmap(isBuy bool, startTick int32) (int32, bool) {
 	termBitmap := v.readSlot(TerminusSlot(v.PoolHash, startTick))
 	shiftTerm := uint(TermBump(startTick, isBuy))
@@ -69,8 +57,6 @@ func (v *ChainBitmapView) PinBitmap(isBuy bool, startTick int32) (int32, bool) {
 	return WeldMezzTerm(tickMezz, nextTerm), false
 }
 
-// doesSpillBit mirrors CrocImpact.sol: sell-side bit 0 already set means
-// we're AT a bump, so don't spill.
 func doesSpillBit(isBuy bool, spillTrunc bool, termBitmap *big.Int) bool {
 	if isBuy {
 		return spillTrunc
@@ -81,7 +67,6 @@ func doesSpillBit(isBuy bool, spillTrunc bool, termBitmap *big.Int) bool {
 	return spillTrunc
 }
 
-// chainSpillOverPin mirrors CrocImpact.sol spillOverPin.
 func chainSpillOverPin(isBuy bool, tickMezz int16) int32 {
 	if isBuy {
 		if tickMezz == math.MaxInt16 {
@@ -99,8 +84,6 @@ func zeroTerm(isUpper bool) uint8 {
 	return 0
 }
 
-// SeekMezzSpill mirrors CrocImpact.sol seekMezzSpill → seekAtTerm/seekAtMezz/
-// seekOverLobby.
 func (v *ChainBitmapView) SeekMezzSpill(borderTick int32, isBuy bool) int32 {
 	lobbyBorder, mezzBorder := rootsForBorder(borderTick, isBuy)
 
@@ -139,7 +122,6 @@ func (v *ChainBitmapView) seekAtMezz(lobbyBit, mezzBorder uint8, isBuy bool) (in
 
 func (v *ChainBitmapView) seekOverLobby(lobbyBit uint8, isBuy bool) int32 {
 	if isBuy {
-		// Walk up through adjacent lobby words; wrap-around terminates.
 		for i := uint16(lobbyBit) + 1; i < 256; i++ {
 			if pin, ok := v.seekAtMezz(uint8(i), 0, true); ok {
 				return pin
@@ -147,7 +129,6 @@ func (v *ChainBitmapView) seekOverLobby(lobbyBit uint8, isBuy bool) int32 {
 		}
 		return zeroTick(true)
 	}
-	// sell: walk down through adjacent lobby words.
 	for i := int16(lobbyBit) - 1; i >= 0; i-- {
 		if pin, ok := v.seekAtMezz(uint8(i), 255, false); ok {
 			return pin
@@ -156,7 +137,6 @@ func (v *ChainBitmapView) seekOverLobby(lobbyBit uint8, isBuy bool) int32 {
 	return zeroTick(false)
 }
 
-// rootsForBorder mirrors CrocImpact.sol rootsForBorder.
 func rootsForBorder(borderTick int32, isBuy bool) (lobbyBit, mezzBit uint8) {
 	pinTick := borderTick
 	if !isBuy {
@@ -172,10 +152,15 @@ func weldLobbyPosMezzTerm(lobbyWord, mezzBit, termBit uint8) int32 {
 }
 
 // QueryLevel reads (bidLots, askLots) from levels_[poolHash, tick].
-// Layout: bidLots = bits [0,95], askLots = bits [96,191].
-func (v *ChainBitmapView) QueryLevel(tick int32) (bidLots, askLots *big.Int) {
+func (v *ChainBitmapView) QueryLevel(tick int32) (bidLots, askLots uint256.Int) {
 	val := v.readSlot(LevelSlot(v.PoolHash, tick))
-	bidLots = new(big.Int).And(val, mask96)
-	askLots = new(big.Int).And(new(big.Int).Rsh(val, 96), mask96)
+	var valU uint256.Int
+	var buf [32]byte
+	val.FillBytes(buf[:])
+	valU.SetBytes(buf[:])
+	bidLots.And(&valU, maskU96)
+	var tmp uint256.Int
+	tmp.Rsh(&valU, 96)
+	askLots.And(&tmp, maskU96)
 	return
 }

--- a/pkg/liquidity-source/ambient/compound.go
+++ b/pkg/liquidity-source/ambient/compound.go
@@ -1,10 +1,11 @@
 package ambient
 
 import (
-	"math/big"
 	"math/bits"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/holiman/uint256"
+
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 const q48u64 = uint64(1) << 48
@@ -14,7 +15,7 @@ func ApproxSqrtCompound(x64 uint64) uint64 {
 		x64 = q48u64 - 1
 	}
 	hi, lo := bits.Mul64(x64, x64)
-	xSq := (hi << 16) | (lo >> 48) // (x*x) >> 48, x < 2^48 so product < 2^96, fits 64b.
+	xSq := (hi << 16) | (lo >> 48)
 	linear := x64 >> 1
 	quad := xSq >> 3
 	return linear - quad
@@ -24,8 +25,6 @@ func CompoundStack(x, y uint64) uint64 {
 	a := q48u64 + x
 	b := q48u64 + y
 	hi, lo := bits.Mul64(a, b)
-	// term = (a*b) >> 48; if hi occupies more than 48 bits the result would
-	// overflow uint64 after the minus-Q48 step, saturate at max.
 	if hi>>48 != 0 {
 		return ^uint64(0)
 	}
@@ -34,40 +33,47 @@ func CompoundStack(x, y uint64) uint64 {
 }
 
 func CompoundShrink(val, deflator uint64) uint64 {
-	// (val << 48) / (Q48 + deflator). val * 2^48 fits in 128 bits.
 	q, _ := bits.Div64(val>>16, val<<48, q48u64+deflator)
 	return q
 }
 
-func CompoundDivide(inflated, seed *big.Int) uint64 {
-	num := new(big.Int).Lsh(inflated, 48)
-	z := num.Div(num, seed)
-	z.Sub(z, Q48)
-	if z.Cmp(Q48) >= 0 {
-		return Q48.Uint64()
+// CompoundDivide computes floor(inflated * 2^48 / seed) - 2^48, capped at 2^48.
+func CompoundDivide(inflated, seed *uint256.Int) uint64 {
+	var num uint256.Int
+	num.Lsh(inflated, 48)
+	num.Div(&num, seed)
+	num.Sub(&num, uQ48)
+	if num.Gt(uQ48) {
+		return uQ48.Uint64()
 	}
-	return z.Uint64()
+	return num.Uint64()
 }
 
-func CompoundPrice(price *big.Int, growth uint64, shiftUp bool) *big.Int {
-	multFactor := new(big.Int).SetUint64(growth)
-	multFactor.Add(multFactor, Q48)
+// CompoundPrice applies compound growth to a Q64 sqrt price.
+// shiftUp=true:  dst = price * (Q48+growth) >> 48 + 1
+// shiftUp=false: dst = price << 48 / (Q48+growth)
+func CompoundPrice(dst, price *uint256.Int, growth uint64, shiftUp bool) *uint256.Int {
+	var multFactor uint256.Int
+	multFactor.SetUint64(growth)
+	multFactor.Add(&multFactor, uQ48)
 	if shiftUp {
-		z := new(big.Int).Mul(price, multFactor)
-		z.Rsh(z, 48)
-		return z.Add(z, bignum.One)
+		dst.Mul(price, &multFactor)
+		dst.Rsh(dst, 48)
+		return dst.Add(dst, u256.U1)
 	}
-	z := new(big.Int).Lsh(price, 48)
-	return z.Div(z, multFactor)
+	dst.Lsh(price, 48)
+	return dst.Div(dst, &multFactor)
 }
 
-func InflateLiqSeed(seed *big.Int, growth uint64) *big.Int {
-	multFactor := new(big.Int).SetUint64(growth)
-	multFactor.Add(multFactor, Q48)
-	inflated := multFactor.Mul(seed, multFactor)
-	inflated.Rsh(inflated, 48)
-	if inflated.Cmp(mask128) > 0 {
-		return new(big.Int).Set(mask128)
+// InflateLiqSeed sets dst = floor(seed * (Q48+growth) / Q48), capped at 2^128-1.
+func InflateLiqSeed(dst, seed *uint256.Int, growth uint64) *uint256.Int {
+	var multFactor uint256.Int
+	multFactor.SetUint64(growth)
+	multFactor.Add(&multFactor, uQ48)
+	dst.Mul(seed, &multFactor)
+	dst.Rsh(dst, 48)
+	if dst.Gt(u256.UMaxU128) {
+		dst.Set(u256.UMaxU128)
 	}
-	return inflated
+	return dst
 }

--- a/pkg/liquidity-source/ambient/constant.go
+++ b/pkg/liquidity-source/ambient/constant.go
@@ -23,6 +23,7 @@ var (
 	ErrPairNotFound      = errors.New("pair not found")
 	ErrNoTrackedPairs    = errors.New("no tracked pairs")
 	ErrZeroAmount        = errors.New("zero amount")
+	ErrOverflow          = errors.New("bigInt overflow uint256")
 	ErrInsufficientFund  = errors.New("insufficient reserve")
 	ErrTickRangeExceeded = errors.New("swap exceeds fetched tick range")
 )

--- a/pkg/liquidity-source/ambient/curveroll.go
+++ b/pkg/liquidity-source/ambient/curveroll.go
@@ -4,15 +4,18 @@ import (
 	"errors"
 	"math/big"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/holiman/uint256"
+
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
-var roundPrecisionWei = bignum.Four
+// roundPrecisionWei is added to counter-flows to buffer rounding at tick boundaries.
+var roundPrecisionWei = uint256.NewInt(4)
 
 type SwapAccum struct {
-	BaseFlow  *big.Int
-	QuoteFlow *big.Int
-	ProtoFees *big.Int
+	BaseFlow  uint256.Int // signed two's complement
+	QuoteFlow uint256.Int // signed two's complement
+	ProtoFees uint256.Int // signed two's complement
 
 	CrossInitTickLoops int
 	PinSpillLoops      int
@@ -20,208 +23,219 @@ type SwapAccum struct {
 }
 
 func NewSwapAccum() *SwapAccum {
-	return &SwapAccum{
-		BaseFlow:  new(big.Int),
-		QuoteFlow: new(big.Int),
-		ProtoFees: new(big.Int),
-	}
+	return &SwapAccum{}
 }
 
-func (a *SwapAccum) Accumulate(baseFlow, quoteFlow, protoFees *big.Int) {
-	a.BaseFlow.Add(a.BaseFlow, baseFlow)
-	a.QuoteFlow.Add(a.QuoteFlow, quoteFlow)
-	a.ProtoFees.Add(a.ProtoFees, protoFees)
+func (a *SwapAccum) Accumulate(baseFlow, quoteFlow, protoFees uint256.Int) {
+	a.BaseFlow.Add(&a.BaseFlow, &baseFlow)
+	a.QuoteFlow.Add(&a.QuoteFlow, &quoteFlow)
+	a.ProtoFees.Add(&a.ProtoFees, &protoFees)
 }
 
-func RollFlow(curve *CurveState, flow *big.Int, inBaseQty, isBuy bool, swapQty *big.Int) (paidBase, paidQuote, qtyLeft *big.Int) {
+func RollFlow(curve *CurveState, flow uint256.Int, inBaseQty, isBuy bool, swapQty uint256.Int) (paidBase, paidQuote uint256.Int, qtyLeft uint256.Int) {
 	counterFlow, nextPrice := DeriveImpact(curve, flow, inBaseQty, isBuy)
 	paidFlow, paidCounter := signFlow(flow, counterFlow, inBaseQty, isBuy)
 	return setCurvePos(curve, inBaseQty, isBuy, swapQty, nextPrice, paidFlow, paidCounter)
 }
 
-func RollPrice(curve *CurveState, price *big.Int, inBaseQty, isBuy bool, swapQty *big.Int) (paidBase, paidQuote, qtyLeft *big.Int) {
+func RollPrice(curve *CurveState, price uint256.Int, inBaseQty, isBuy bool, swapQty uint256.Int) (paidBase, paidQuote uint256.Int, qtyLeft uint256.Int) {
 	flow, counterFlow := deriveDemand(curve, price, inBaseQty)
 	paidFlow, paidCounter := signFixed(flow, counterFlow, inBaseQty, isBuy)
 	return setCurvePos(curve, inBaseQty, isBuy, swapQty, price, paidFlow, paidCounter)
 }
 
-func DeriveImpact(curve *CurveState, flow *big.Int, inBaseQty, isBuy bool) (counterFlow, nextPrice *big.Int) {
-	liq := ActiveLiquidity(curve)
+func DeriveImpact(curve *CurveState, flow uint256.Int, inBaseQty, isBuy bool) (counterFlow uint256.Int, nextPrice uint256.Int) {
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
 	nextPrice = deriveFlowPrice(curve.PriceRoot, liq, flow, inBaseQty, isBuy)
 	if !inBaseQty {
-		counterFlow = DeltaBase(liq, curve.PriceRoot, nextPrice)
+		DeltaBase(&counterFlow, &liq, &curve.PriceRoot, &nextPrice)
 	} else {
-		counterFlow = DeltaQuote(liq, curve.PriceRoot, nextPrice)
+		DeltaQuote(&counterFlow, &liq, &curve.PriceRoot, &nextPrice)
 	}
 	return
 }
 
-func deriveDemand(curve *CurveState, price *big.Int, inBaseQty bool) (flow, counterFlow *big.Int) {
-	liq := ActiveLiquidity(curve)
-	baseFlow := DeltaBase(liq, curve.PriceRoot, price)
-	quoteFlow := DeltaQuote(liq, curve.PriceRoot, price)
+func deriveDemand(curve *CurveState, price uint256.Int, inBaseQty bool) (flow, counterFlow uint256.Int) {
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
+	var baseFlow, quoteFlow uint256.Int
+	DeltaBase(&baseFlow, &liq, &curve.PriceRoot, &price)
+	DeltaQuote(&quoteFlow, &liq, &curve.PriceRoot, &price)
 	if inBaseQty {
 		return baseFlow, quoteFlow
 	}
 	return quoteFlow, baseFlow
 }
 
-func deriveFlowPrice(price, liq, flow *big.Int, inBaseQty, isBuy bool) *big.Int {
-	var curvePrice *big.Int
+func deriveFlowPrice(price, liq, flow uint256.Int, inBaseQty, isBuy bool) uint256.Int {
+	var curvePrice uint256.Int
 	if inBaseQty {
 		curvePrice = calcBaseFlowPrice(price, liq, flow, isBuy)
 	} else {
 		curvePrice = calcQuoteFlowPrice(price, liq, flow, isBuy)
 	}
-	if curvePrice.Cmp(MaxSqrtRatio) >= 0 {
-		return new(big.Int).Set(MaxSqrtRatioMinus1)
+	if curvePrice.Cmp(&uMaxSqrtRatio) >= 0 {
+		return uMaxSqrtRatioMinus1
 	}
-	if curvePrice.Cmp(MinSqrtRatio) < 0 {
-		return new(big.Int).Set(MinSqrtRatio)
+	if curvePrice.Lt(&uMinSqrtRatio) {
+		return uMinSqrtRatio
 	}
 	return curvePrice
 }
 
-func calcBaseFlowPrice(price, liq, flow *big.Int, isBuy bool) *big.Int {
-	if liq.Sign() == 0 {
-		return new(big.Int).Set(mask128)
+func calcBaseFlowPrice(price, liq, flow uint256.Int, isBuy bool) uint256.Int {
+	if liq.IsZero() {
+		return uMaxSqrtRatioMinus1
 	}
-	deltaCalc := DivQ64(flow, liq)
-	if deltaCalc.Cmp(mask128) > 0 {
-		return new(big.Int).Set(mask128)
+	var deltaCalc uint256.Int
+	DivQ64(&deltaCalc, &flow, &liq)
+	if deltaCalc.Gt(u256.UMaxU128) {
+		return uMaxSqrtRatioMinus1
 	}
 	if isBuy {
-		return new(big.Int).Add(price, deltaCalc)
+		var result uint256.Int
+		result.Add(&price, &deltaCalc)
+		return result
 	}
-	if deltaCalc.Cmp(price) >= 0 {
-		return new(big.Int)
+	if deltaCalc.Cmp(&price) >= 0 {
+		var zero uint256.Int
+		return zero
 	}
-	result := new(big.Int).Sub(price, deltaCalc)
-	result.Sub(result, bignum.One)
+	var result uint256.Int
+	result.Sub(&price, &deltaCalc)
+	result.Sub(&result, u256.U1)
 	return result
 }
 
-func calcQuoteFlowPrice(price, liq, flow *big.Int, isBuy bool) *big.Int {
-	invPrice := RecipQ64(price)
+func calcQuoteFlowPrice(price, liq, flow uint256.Int, isBuy bool) uint256.Int {
+	var invPrice uint256.Int
+	RecipQ64(&invPrice, &price)
 	invNext := calcBaseFlowPrice(invPrice, liq, flow, !isBuy)
-	if invNext.Sign() == 0 {
-		return new(big.Int).Set(MaxSqrtRatio)
+	if invNext.IsZero() {
+		return uMaxSqrtRatio
 	}
-	result := RecipQ64(invNext)
-	result.Add(result, bignum.One)
+	var result uint256.Int
+	RecipQ64(&result, &invNext)
+	result.Add(&result, u256.U1)
 	return result
 }
 
-func signFlow(flowMagn, counterMagn *big.Int, inBaseQty, isBuy bool) (flow, counter *big.Int) {
+// signFlow applies sign to (flowMagn, counterMagn) based on direction, then adds
+// roundPrecisionWei to the counter to buffer rounding.
+func signFlow(flowMagn, counterMagn uint256.Int, inBaseQty, isBuy bool) (flow, counter uint256.Int) {
 	flow, counter = signMagn(flowMagn, counterMagn, inBaseQty, isBuy)
-	counter.Add(counter, roundPrecisionWei)
+	counter.Add(&counter, roundPrecisionWei)
 	return
 }
 
-func signFixed(flowMagn, counterMagn *big.Int, inBaseQty, isBuy bool) (flow, counter *big.Int) {
+func signFixed(flowMagn, counterMagn uint256.Int, inBaseQty, isBuy bool) (flow, counter uint256.Int) {
 	flow, counter = signMagn(flowMagn, counterMagn, inBaseQty, isBuy)
-	flow.Add(flow, roundPrecisionWei)
-	counter.Add(counter, roundPrecisionWei)
+	flow.Add(&flow, roundPrecisionWei)
+	counter.Add(&counter, roundPrecisionWei)
 	return
 }
 
-func signMagn(flowMagn, counterMagn *big.Int, inBaseQty, isBuy bool) (flow, counter *big.Int) {
+// signMagn assigns signs: the "paid" direction is positive, the "received" direction is negative.
+func signMagn(flowMagn, counterMagn uint256.Int, inBaseQty, isBuy bool) (flow, counter uint256.Int) {
 	if inBaseQty == isBuy {
-		flow = new(big.Int).Set(flowMagn)
-		counter = new(big.Int).Neg(counterMagn)
+		// flow is positive (user pays), counter is negative (user receives)
+		flow.Set(&flowMagn)
+		counter.Neg(&counterMagn)
 	} else {
-		flow = new(big.Int).Neg(flowMagn)
-		counter = new(big.Int).Set(counterMagn)
+		// flow is negative (user receives), counter is positive (user pays)
+		flow.Neg(&flowMagn)
+		counter.Set(&counterMagn)
 	}
 	return
 }
 
-func setCurvePos(curve *CurveState, inBaseQty, isBuy bool, swapQty, price, paidFlow, paidCounter *big.Int) (paidBase, paidQuote, qtyLeft *big.Int) {
+func setCurvePos(curve *CurveState, inBaseQty, isBuy bool, swapQty, price uint256.Int, paidFlow, paidCounter uint256.Int) (paidBase, paidQuote uint256.Int, qtyLeft uint256.Int) {
 	spent := flowToSpent(paidFlow, inBaseQty, isBuy)
-	if spent.Cmp(swapQty) >= 0 {
-		qtyLeft = new(big.Int)
-	} else {
-		qtyLeft = new(big.Int).Sub(swapQty, spent)
+	if spent.Cmp(&swapQty) < 0 {
+		qtyLeft.Sub(&swapQty, &spent)
 	}
 	if inBaseQty {
 		paidBase, paidQuote = paidFlow, paidCounter
 	} else {
 		paidBase, paidQuote = paidCounter, paidFlow
 	}
-	curve.PriceRoot = new(big.Int).Set(price)
+	curve.PriceRoot.Set(&price)
 	return
 }
 
-func flowToSpent(paidFlow *big.Int, inBaseQty, isBuy bool) *big.Int {
-	if inBaseQty == isBuy {
+func flowToSpent(paidFlow uint256.Int, inBaseQty, isBuy bool) uint256.Int {
+	// The "spent" side is whichever flow is positive (user pays).
+	if (inBaseQty == isBuy) == (paidFlow.Sign() > 0) {
+		var abs uint256.Int
 		if paidFlow.Sign() < 0 {
-			return new(big.Int)
+			abs.Neg(&paidFlow)
+		} else {
+			abs.Set(&paidFlow)
 		}
-		return paidFlow
+		return abs
 	}
-	spent := new(big.Int).Neg(paidFlow)
-	if spent.Sign() < 0 {
-		return new(big.Int)
-	}
-	return spent
+	return uint256.Int{}
 }
 
-func PriceToTokenPrecision(liq, price *big.Int, inBase bool) *big.Int {
+// PriceToTokenPrecision computes the minimum token precision buffer at the current price/liq.
+func PriceToTokenPrecision(dst, liq, price *uint256.Int, inBase bool) *uint256.Int {
 	if inBase {
-		result := new(big.Int).Rsh(liq, 64)
-		result.Add(result, bignum.One)
-		return result
+		dst.Rsh(liq, 64)
+		return dst.Add(dst, u256.U1)
 	}
-	priceMinus1 := new(big.Int).Sub(price, bignum.One)
-	step := DivQ64(liq, priceMinus1)
-	start := DivQ64(liq, price)
-	delta := new(big.Int).Sub(step, start)
-	delta.Add(delta, bignum.One)
-	return delta
+	var priceMinus1, step, start uint256.Int
+	priceMinus1.Sub(price, u256.U1)
+	DivQ64(&step, liq, &priceMinus1)
+	DivQ64(&start, liq, price)
+	dst.Sub(&step, &start)
+	return dst.Add(dst, u256.U1)
 }
 
-// ErrShaveBurnDown mirrors Solidity's require(swapLeft > burnDown).
-// In practice unreachable; kept as error (not panic) for safety.
 var ErrShaveBurnDown = errors.New("shave-at-bump: swapLeft <= burnDown")
 
-func ShaveAtBump(curve *CurveState, inBaseQty, isBuy bool, swapLeft *big.Int) (paidBase, paidQuote, burnSwap *big.Int, err error) {
-	liq := ActiveLiquidity(curve)
-	burnDown := PriceToTokenPrecision(liq, curve.PriceRoot, inBaseQty)
-	if swapLeft.Cmp(burnDown) <= 0 {
-		return nil, nil, nil, ErrShaveBurnDown
+func ShaveAtBump(curve *CurveState, inBaseQty, isBuy bool, swapLeft uint256.Int) (paidBase, paidQuote uint256.Int, burnSwap uint256.Int, err error) {
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
+	var burnDown uint256.Int
+	PriceToTokenPrecision(&burnDown, &liq, &curve.PriceRoot, inBaseQty)
+	if !swapLeft.Gt(&burnDown) {
+		return paidBase, paidQuote, burnSwap, ErrShaveBurnDown
 	}
 	if isBuy {
 		paidBase, paidQuote, burnSwap = setShaveUp(curve, inBaseQty, burnDown)
-		return paidBase, paidQuote, burnSwap, nil
+	} else {
+		paidBase, paidQuote, burnSwap = setShaveDown(curve, inBaseQty, burnDown)
 	}
-	paidBase, paidQuote, burnSwap = setShaveDown(curve, inBaseQty, burnDown)
 	return paidBase, paidQuote, burnSwap, nil
 }
 
-func setShaveDown(curve *CurveState, inBaseQty bool, burnDown *big.Int) (paidBase, paidQuote, burnSwap *big.Int) {
-	if curve.PriceRoot.Cmp(MinSqrtRatio) > 0 {
-		curve.PriceRoot = new(big.Int).Sub(curve.PriceRoot, bignum.One)
+func setShaveDown(curve *CurveState, inBaseQty bool, burnDown uint256.Int) (paidBase, paidQuote uint256.Int, burnSwap uint256.Int) {
+	if curve.PriceRoot.Gt(&uMinSqrtRatio) {
+		curve.PriceRoot.Sub(&curve.PriceRoot, u256.U1)
 	}
-	paidBase = new(big.Int)
-	paidQuote = new(big.Int).Set(burnDown)
-	if inBaseQty {
-		burnSwap = new(big.Int)
-	} else {
-		burnSwap = new(big.Int).Set(burnDown)
+	// paidBase = 0 (zero value), paidQuote = burnDown
+	paidQuote.Set(&burnDown)
+	if !inBaseQty {
+		burnSwap = burnDown
 	}
 	return
 }
 
-func setShaveUp(curve *CurveState, inBaseQty bool, burnDown *big.Int) (paidBase, paidQuote, burnSwap *big.Int) {
-	if curve.PriceRoot.Cmp(MaxSqrtRatioMinus1) < 0 {
-		curve.PriceRoot = new(big.Int).Add(curve.PriceRoot, bignum.One)
+func setShaveUp(curve *CurveState, inBaseQty bool, burnDown uint256.Int) (paidBase, paidQuote uint256.Int, burnSwap uint256.Int) {
+	if curve.PriceRoot.Lt(&uMaxSqrtRatioMinus1) {
+		curve.PriceRoot.Add(&curve.PriceRoot, u256.U1)
 	}
-	paidQuote = new(big.Int)
-	paidBase = new(big.Int).Set(burnDown)
+	// paidQuote = 0 (zero value), paidBase = burnDown
+	paidBase.Set(&burnDown)
 	if inBaseQty {
-		burnSwap = new(big.Int).Set(burnDown)
-	} else {
-		burnSwap = new(big.Int)
+		burnSwap = burnDown
 	}
 	return
+}
+
+// FlowToBig converts a signed two's-complement uint256 to *big.Int.
+// f is passed by value so &f is a safe local pointer for big256.ToBig.
+func FlowToBig(f uint256.Int) *big.Int {
+	return u256.ToBig(&f)
 }

--- a/pkg/liquidity-source/ambient/decode.go
+++ b/pkg/liquidity-source/ambient/decode.go
@@ -1,32 +1,24 @@
 package ambient
 
 import (
-	"math/big"
+	"github.com/holiman/uint256"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 type CurveState struct {
-	PriceRoot    *big.Int // uint128 — Q64.64 sqrt price
-	AmbientSeeds *big.Int // uint128
-	ConcLiq      *big.Int // uint128
+	PriceRoot    uint256.Int // uint128 — Q64.64 sqrt price
+	AmbientSeeds uint256.Int // uint128
+	ConcLiq      uint256.Int // uint128 (on-chain int128, always ≥ 0 in valid state)
 	SeedDeflator uint64
 	ConcGrowth   uint64
 }
 
-func (c CurveState) Clone() CurveState {
-	return CurveState{
-		PriceRoot:    new(big.Int).Set(c.PriceRoot),
-		AmbientSeeds: new(big.Int).Set(c.AmbientSeeds),
-		ConcLiq:      new(big.Int).Set(c.ConcLiq),
-		SeedDeflator: c.SeedDeflator,
-		ConcGrowth:   c.ConcGrowth,
-	}
-}
+func (c CurveState) Clone() CurveState { return c } // value copy; all fields are value types
 
 type BookLevel struct {
-	BidLots     *big.Int // uint96
-	AskLots     *big.Int // uint96
+	BidLots     uint256.Int // uint96
+	AskLots     uint256.Int // uint96
 	FeeOdometer uint64
 }
 
@@ -41,60 +33,64 @@ type PoolSpec struct {
 }
 
 var (
-	maskU64  = new(big.Int).SetUint64(^uint64(0))
-	maskU96  = new(big.Int).Sub(new(big.Int).Lsh(bignum.One, 96), bignum.One)
-	maskU128 = bignum.MaxUint128
-	maskU16  = big.NewInt(0xffff)
-	maskU8   = big.NewInt(0xff)
+	maskU64  = new(uint256.Int).SetUint64(^uint64(0))
+	maskU96  = func() *uint256.Int { v := new(uint256.Int).Lsh(u256.U1, 96); return v.Sub(v, u256.U1) }()
+	maskU128 = u256.UMaxU128
+	maskU16  = new(uint256.Int).SetUint64(0xffff)
+	maskU8   = new(uint256.Int).SetUint64(0xff)
 )
 
-func slotToBig(slot [32]byte) *big.Int {
-	return new(big.Int).SetBytes(slot[:])
-}
-
 func DecodeCurve(slot0, slot1 [32]byte) CurveState {
-	v0 := slotToBig(slot0)
-	v1 := slotToBig(slot1)
+	s0 := new(uint256.Int).SetBytes(slot0[:])
+	s1 := new(uint256.Int).SetBytes(slot1[:])
 
-	priceRoot := new(big.Int).And(v0, maskU128)
-	ambientSeeds := new(big.Int).Rsh(v0, 128)
+	var c CurveState
+	c.PriceRoot.And(s0, maskU128)
+	c.AmbientSeeds.Rsh(s0, 128)
 
-	concLiq := new(big.Int).And(v1, maskU128)
-	seedDeflator := new(big.Int).And(new(big.Int).Rsh(v1, 128), maskU64).Uint64()
-	concGrowth := new(big.Int).Rsh(v1, 192).Uint64()
+	c.ConcLiq.And(s1, maskU128)
+	var tmp uint256.Int
+	tmp.Rsh(s1, 128)
+	tmp.And(&tmp, maskU64)
+	c.SeedDeflator = tmp.Uint64()
+	tmp.Rsh(s1, 192)
+	c.ConcGrowth = tmp.Uint64()
 
-	return CurveState{
-		PriceRoot:    priceRoot,
-		AmbientSeeds: ambientSeeds,
-		ConcLiq:      concLiq,
-		SeedDeflator: seedDeflator,
-		ConcGrowth:   concGrowth,
-	}
+	return c
 }
 
 func DecodeBookLevel(slot [32]byte) BookLevel {
-	v := slotToBig(slot)
+	v := new(uint256.Int).SetBytes(slot[:])
 
-	bidLots := new(big.Int).And(v, maskU96)
-	askLots := new(big.Int).And(new(big.Int).Rsh(v, 96), maskU96)
-	feeOdometer := new(big.Int).And(new(big.Int).Rsh(v, 192), maskU64).Uint64()
+	var bl BookLevel
+	bl.BidLots.And(v, maskU96)
 
-	return BookLevel{
-		BidLots:     bidLots,
-		AskLots:     askLots,
-		FeeOdometer: feeOdometer,
-	}
+	var tmp uint256.Int
+	tmp.Rsh(v, 96)
+	bl.AskLots.And(&tmp, maskU96)
+
+	tmp.Rsh(v, 192)
+	tmp.And(&tmp, maskU64)
+	bl.FeeOdometer = tmp.Uint64()
+
+	return bl
 }
 
 func DecodePoolSpec(slot [32]byte) PoolSpec {
-	v := slotToBig(slot)
+	v := new(uint256.Int).SetBytes(slot[:])
+	var tmp uint256.Int
+	field := func(rsh uint, mask *uint256.Int) uint64 {
+		tmp.Rsh(v, rsh)
+		tmp.And(&tmp, mask)
+		return tmp.Uint64()
+	}
 	return PoolSpec{
-		Schema:       uint8(new(big.Int).And(v, maskU8).Uint64()),
-		FeeRate:      uint16(new(big.Int).And(new(big.Int).Rsh(v, 8), maskU16).Uint64()),
-		ProtocolTake: uint8(new(big.Int).And(new(big.Int).Rsh(v, 24), maskU8).Uint64()),
-		TickSize:     uint16(new(big.Int).And(new(big.Int).Rsh(v, 32), maskU16).Uint64()),
-		JitThresh:    uint8(new(big.Int).And(new(big.Int).Rsh(v, 48), maskU8).Uint64()),
-		KnockoutBits: uint8(new(big.Int).And(new(big.Int).Rsh(v, 56), maskU8).Uint64()),
-		OracleFlags:  uint8(new(big.Int).And(new(big.Int).Rsh(v, 64), maskU8).Uint64()),
+		Schema:       uint8(field(0, maskU8)),
+		FeeRate:      uint16(field(8, maskU16)),
+		ProtocolTake: uint8(field(24, maskU8)),
+		TickSize:     uint16(field(32, maskU16)),
+		JitThresh:    uint8(field(48, maskU8)),
+		KnockoutBits: uint8(field(56, maskU8)),
+		OracleFlags:  uint8(field(64, maskU8)),
 	}
 }

--- a/pkg/liquidity-source/ambient/fixedpoint.go
+++ b/pkg/liquidity-source/ambient/fixedpoint.go
@@ -1,33 +1,38 @@
 package ambient
 
 import (
-	"math/big"
+	"github.com/holiman/uint256"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 var (
-	Q48  = new(big.Int).Lsh(bignum.One, 48)
-	Q128 = bignum.B2Pow128
-
-	mask128 = bignum.MaxUint128
+	// uQ48 = 2^48, uQ128 = 2^128.
+	uQ48  = new(uint256.Int).Lsh(u256.U1, 48)
+	uQ128 = u256.U2Pow128
 )
 
-func MulQ64(x, y *big.Int) *big.Int {
-	result := new(big.Int).Mul(x, y)
-	return result.Rsh(result, 64)
+// MulQ64 sets dst = floor(x * y / 2^64) and returns dst.
+func MulQ64(dst, x, y *uint256.Int) *uint256.Int {
+	dst.Mul(x, y)
+	return dst.Rsh(dst, 64)
 }
 
-func DivQ64(x, y *big.Int) *big.Int {
-	num := new(big.Int).Lsh(x, 64)
-	return num.Div(num, y)
+// DivQ64 sets dst = floor(x * 2^64 / y) and returns dst.
+func DivQ64(dst, x, y *uint256.Int) *uint256.Int {
+	dst.Lsh(x, 64)
+	return dst.Div(dst, y)
 }
 
-func MulQ48(x *big.Int, y uint64) *big.Int {
-	result := new(big.Int).Mul(x, new(big.Int).SetUint64(y))
-	return result.Rsh(result, 48)
+// MulQ48 sets dst = floor(x * y / 2^48) and returns dst (y is uint64).
+func MulQ48(dst, x *uint256.Int, y uint64) *uint256.Int {
+	var tmp uint256.Int
+	tmp.SetUint64(y)
+	dst.Mul(x, &tmp)
+	return dst.Rsh(dst, 48)
 }
 
-func RecipQ64(x *big.Int) *big.Int {
-	return new(big.Int).Div(Q128, x)
+// RecipQ64 sets dst = floor(2^128 / x) and returns dst.
+func RecipQ64(dst, x *uint256.Int) *uint256.Int {
+	return dst.Div(uQ128, x)
 }

--- a/pkg/liquidity-source/ambient/liquidity.go
+++ b/pkg/liquidity-source/ambient/liquidity.go
@@ -1,55 +1,60 @@
 package ambient
 
-import "math/big"
+import "github.com/holiman/uint256"
 
-const (
-	LotSizeBits = 10
-)
+const LotSizeBits = 10
 
-var (
-	knockoutFlagMask = big.NewInt(0x1)
-)
-
-func LotsToLiquidity(lots *big.Int) *big.Int {
-	result := new(big.Int).AndNot(lots, knockoutFlagMask)
-	return result.Lsh(result, LotSizeBits)
+// LotsToLiquidity sets dst = (lots & ^1) << LotSizeBits and returns dst.
+func LotsToLiquidity(dst, lots *uint256.Int) *uint256.Int {
+	dst.And(lots, uKnockoutClearMask)
+	return dst.Lsh(dst, LotSizeBits)
 }
 
-func HasKnockoutLiq(lots *big.Int) bool {
-	return lots != nil && lots.Bit(0) == 1
+// HasKnockoutLiq returns true when bit 0 of lots is set (knockout flag).
+func HasKnockoutLiq(lots *uint256.Int) bool {
+	return lots != nil && lots[0]&1 == 1
 }
 
-func ActiveLiquidity(curve *CurveState) *big.Int {
-	ambient := InflateLiqSeed(curve.AmbientSeeds, curve.SeedDeflator)
-	return ambient.Add(ambient, curve.ConcLiq)
+// ActiveLiquidity sets dst = InflateLiqSeed(ambientSeeds, deflator) + concLiq.
+func ActiveLiquidity(dst *uint256.Int, curve *CurveState) *uint256.Int {
+	InflateLiqSeed(dst, &curve.AmbientSeeds, curve.SeedDeflator)
+	return dst.Add(dst, &curve.ConcLiq)
 }
 
-func DeltaBase(liq, priceX, priceY *big.Int) *big.Int {
-	priceDelta := new(big.Int).Sub(priceX, priceY)
-	if priceDelta.Sign() < 0 {
-		priceDelta.Neg(priceDelta)
+// DeltaBase sets dst = MulQ64(liq, |priceX - priceY|).
+func DeltaBase(dst, liq, priceX, priceY *uint256.Int) *uint256.Int {
+	var delta uint256.Int
+	if priceX.Gt(priceY) {
+		delta.Sub(priceX, priceY)
+	} else {
+		delta.Sub(priceY, priceX)
 	}
-	return ReserveAtPrice(liq, priceDelta, true)
+	return MulQ64(dst, liq, &delta)
 }
 
-func DeltaQuote(liq, price, limitPrice *big.Int) *big.Int {
-	if limitPrice.Cmp(price) > 0 {
-		return calcQuoteDelta(liq, limitPrice, price)
+// DeltaQuote sets dst = delta(liq, price, limitPrice) (Q64 reserve difference).
+func DeltaQuote(dst, liq, price, limitPrice *uint256.Int) *uint256.Int {
+	if limitPrice.Gt(price) {
+		return calcQuoteDelta(dst, liq, limitPrice, price)
 	}
-	return calcQuoteDelta(liq, price, limitPrice)
+	return calcQuoteDelta(dst, liq, price, limitPrice)
 }
 
-func calcQuoteDelta(liq, priceBig, priceSmall *big.Int) *big.Int {
-	priceDelta := new(big.Int).Sub(priceBig, priceSmall)
-	termOne := DivQ64(liq, priceSmall)
-	termTwo := new(big.Int).Mul(termOne, priceDelta)
-	termTwo.Div(termTwo, priceBig)
-	return termTwo
+func calcQuoteDelta(dst, liq, priceBig, priceSmall *uint256.Int) *uint256.Int {
+	var termOne, delta uint256.Int
+	DivQ64(&termOne, liq, priceSmall)
+	delta.Sub(priceBig, priceSmall)
+	dst.Mul(&termOne, &delta)
+	return dst.Div(dst, priceBig)
 }
 
-func ReserveAtPrice(liq, price *big.Int, inBaseQty bool) *big.Int {
+// ReserveAtPrice sets dst = MulQ64(liq, price) for base, DivQ64(liq, price) for quote.
+func ReserveAtPrice(dst, liq, price *uint256.Int, inBaseQty bool) *uint256.Int {
 	if inBaseQty {
-		return MulQ64(liq, price)
+		return MulQ64(dst, liq, price)
 	}
-	return DivQ64(liq, price)
+	return DivQ64(dst, liq, price)
 }
+
+// uKnockoutClearMask is ^uint256(1), used in LotsToLiquidity.
+var uKnockoutClearMask = new(uint256.Int).Not(new(uint256.Int).SetUint64(1))

--- a/pkg/liquidity-source/ambient/pool_lister_tracker_test.go
+++ b/pkg/liquidity-source/ambient/pool_lister_tracker_test.go
@@ -137,10 +137,9 @@ func TestPoolTracker(t *testing.T) {
 	var trackedExtra Extra
 	require.NoError(t, json.Unmarshal([]byte(tracked.Extra), &trackedExtra))
 	require.NotNil(t, trackedExtra.State)
-	require.NotNil(t, trackedExtra.State.Curve.PriceRoot)
-	require.Equal(t, 1, trackedExtra.State.Curve.PriceRoot.Sign())
+	require.False(t, trackedExtra.State.Curve.PriceRoot.IsZero())
 	t.Logf("tracked ticks=%d sqrtPrice=%s",
-		len(trackedExtra.State.ActiveTicks), trackedExtra.State.Curve.PriceRoot)
+		len(trackedExtra.State.ActiveTicks), trackedExtra.State.Curve.PriceRoot.ToBig())
 
 	// --- Verify simulator can be built from tracked state ---
 	sim, err := NewPoolSimulator(tracked)

--- a/pkg/liquidity-source/ambient/pool_simulator.go
+++ b/pkg/liquidity-source/ambient/pool_simulator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/KyberNetwork/logger"
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 	"github.com/samber/lo"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
@@ -45,9 +46,7 @@ func NewPoolSimulator(ep entity.Pool) (*PoolSimulator, error) {
 	if err := json.Unmarshal([]byte(ep.Extra), &extra); err != nil {
 		return nil, err
 	}
-	if extra.State == nil ||
-		extra.State.Curve.PriceRoot == nil ||
-		extra.State.Curve.PriceRoot.Sign() == 0 {
+	if extra.State == nil || extra.State.Curve.PriceRoot.IsZero() {
 		return nil, ErrNoTrackedPairs
 	}
 
@@ -78,19 +77,21 @@ func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	isBuy := inBaseQty
 
 	curve := p.state.Curve
-	swap := &SwapDirective{
-		Qty:        new(big.Int).Set(params.TokenAmountIn.Amount),
-		InBaseQty:  inBaseQty,
-		IsBuy:      isBuy,
-		LimitPrice: defaultLimitPrice(isBuy),
+	var swap SwapDirective
+	swap.InBaseQty = inBaseQty
+	swap.IsBuy = isBuy
+	if overflow := swap.Qty.SetFromBig(params.TokenAmountIn.Amount); overflow {
+		return nil, ErrZeroAmount
 	}
+	swap.LimitPrice = defaultLimitPrice(isBuy)
+
 	bmpView := NewSnapshotBitmapView(p.state)
-	accum, err := SweepSwap(&curve, swap, &p.state.PoolParams, bmpView)
+	accum, err := SweepSwap(&curve, &swap, &p.state.PoolParams, bmpView)
 	if err != nil {
 		return nil, err
 	}
 
-	if bmpView.BoundaryExceeded() && swap.Qty.Sign() > 0 {
+	if bmpView.BoundaryExceeded() && !swap.Qty.IsZero() {
 		return nil, ErrTickRangeExceeded
 	}
 
@@ -114,7 +115,7 @@ func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		}
 	}
 
-	remainingAmountIn := new(big.Int).Set(swap.Qty)
+	remainingAmountIn := swap.Qty.ToBig()
 	return &pool.CalcAmountOutResult{
 		TokenAmountOut: &pool.TokenAmount{
 			Token:  params.TokenOut,
@@ -168,7 +169,7 @@ func (p *PoolSimulator) CloneState() pool.IPoolSimulator {
 
 func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 	swapInfo, ok := params.SwapInfo.(SwapInfo)
-	if !ok || swapInfo.nextCurve.PriceRoot == nil {
+	if !ok || swapInfo.nextCurve.PriceRoot.IsZero() {
 		return
 	}
 
@@ -202,7 +203,6 @@ func (p *PoolSimulator) GetApprovalAddress(tokenIn, _ string) string {
 	if !valueobject.IsZero(lo.Ternary(tokenInIndex == 0, p.base, p.quote)) {
 		return p.swapDex
 	}
-
 	return ""
 }
 
@@ -217,15 +217,18 @@ func (s *PoolSimulator) SwapReturnNativeOut(tokenIn, tokenOut string, chainId va
 }
 
 func outputAmount(accum *SwapAccum, inBaseQty bool) *big.Int {
+	// The output token's flow is negative (user receives). Negate to get positive amount.
 	if inBaseQty {
-		return new(big.Int).Neg(accum.QuoteFlow)
+		b := FlowToBig(accum.QuoteFlow)
+		return b.Neg(b)
 	}
-	return new(big.Int).Neg(accum.BaseFlow)
+	b := FlowToBig(accum.BaseFlow)
+	return b.Neg(b)
 }
 
-func defaultLimitPrice(isBuy bool) *big.Int {
+func defaultLimitPrice(isBuy bool) uint256.Int {
 	if isBuy {
-		return new(big.Int).Set(MaxSqrtRatioMinus1)
+		return uMaxSqrtRatioMinus1
 	}
-	return new(big.Int).Set(MinSqrtRatio)
+	return uMinSqrtRatio
 }

--- a/pkg/liquidity-source/ambient/pool_simulator.go
+++ b/pkg/liquidity-source/ambient/pool_simulator.go
@@ -81,7 +81,7 @@ func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	swap.InBaseQty = inBaseQty
 	swap.IsBuy = isBuy
 	if overflow := swap.Qty.SetFromBig(params.TokenAmountIn.Amount); overflow {
-		return nil, ErrZeroAmount
+		return nil, ErrOverflow
 	}
 	swap.LimitPrice = defaultLimitPrice(isBuy)
 

--- a/pkg/liquidity-source/ambient/pool_simulator_test.go
+++ b/pkg/liquidity-source/ambient/pool_simulator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
@@ -79,11 +80,9 @@ func TestPoolSimulatorCloneStateIsolatesPairState(t *testing.T) {
 	sim := newTestPoolSimulator(t)
 	cloned := sim.CloneState().(*PoolSimulator)
 
-	// Production never mutates Curve's big.Ints in place — SweepSwap always
-	// reassigns the fields via new(big.Int). Follow that invariant here and
-	// verify the clone's state pointer is independent of the original.
-	cloned.state.Curve.PriceRoot = new(big.Int).Add(cloned.state.Curve.PriceRoot, big.NewInt(1))
-	require.NotEqual(t, 0, cloned.state.Curve.PriceRoot.Cmp(sim.state.Curve.PriceRoot))
+	// PriceRoot is uint256.Int (value type); mutating cloned must not affect original.
+	cloned.state.Curve.PriceRoot.Add(&cloned.state.Curve.PriceRoot, uint256.NewInt(1))
+	require.NotEqual(t, 0, cloned.state.Curve.PriceRoot.Cmp(&sim.state.Curve.PriceRoot))
 }
 
 func newTestPoolSimulator(t *testing.T) *PoolSimulator {
@@ -102,6 +101,13 @@ func newTestPoolSimulator(t *testing.T) *PoolSimulator {
 	})
 	require.NoError(t, err)
 
+	var seeds, concLiq uint256.Int
+	seeds.SetUint64(1_000_000_000)
+	concLiq.SetUint64(500_000_000)
+	var bidLots100, askLots100 uint256.Int
+	askLots100.SetUint64(100)
+	bidLots100.SetUint64(100)
+
 	state := &TrackerExtra{
 		Base:     base,
 		Quote:    quote,
@@ -109,8 +115,8 @@ func newTestPoolSimulator(t *testing.T) *PoolSimulator {
 		PoolHash: poolHash,
 		Curve: CurveState{
 			PriceRoot:    GetSqrtRatioAtTick(0),
-			AmbientSeeds: big.NewInt(1_000_000_000),
-			ConcLiq:      big.NewInt(500_000_000),
+			AmbientSeeds: seeds,
+			ConcLiq:      concLiq,
 			SeedDeflator: 0,
 			ConcGrowth:   0,
 		},
@@ -118,8 +124,8 @@ func newTestPoolSimulator(t *testing.T) *PoolSimulator {
 		PoolParams:  PoolParams{FeeRate: 2500, ProtocolTake: 0, TickSize: 16},
 		ActiveTicks: []int32{-256, 256},
 		Levels: []TrackedLevel{
-			{Tick: -256, Level: BookLevel{BidLots: big.NewInt(0), AskLots: big.NewInt(100)}},
-			{Tick: 256, Level: BookLevel{BidLots: big.NewInt(100), AskLots: big.NewInt(0)}},
+			{Tick: -256, Level: BookLevel{AskLots: askLots100}},
+			{Tick: 256, Level: BookLevel{BidLots: bidLots100}},
 		},
 	}
 

--- a/pkg/liquidity-source/ambient/pool_simulator_testutil_test.go
+++ b/pkg/liquidity-source/ambient/pool_simulator_testutil_test.go
@@ -1,0 +1,125 @@
+package ambient
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+)
+
+// pool fetched with: pools u ethereum ambient (block 25339274)
+const pepePepePoolJSON = `{
+	"address": "0x8e008cd78b86e502a7f5daf71ca8efff2f0a6020101553ebdbd1fb8b01f129ca",
+	"exchange": "ambient",
+	"type":     "ambient",
+	"reserves": ["62802594184157341831","7702999369001304682216852"],
+	"tokens": [
+		{"address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","symbol":"WETH","decimals":18,"swappable":true},
+		{"address":"0x6982508145454ce325ddbe47a25d4ec3d2311933","symbol":"PEPE","decimals":18,"swappable":true}
+	],
+	"extra": "{\"state\":{\"Base\":\"0x0000000000000000000000000000000000000000\",\"Quote\":\"0x6982508145454ce325ddbe47a25d4ec3d2311933\",\"PoolIdx\":420,\"PoolHash\":\"0x8e008cd78b86e502a7f5daf71ca8efff2f0a6020101553ebdbd1fb8b01f129ca\",\"Curve\":{\"PriceRoot\":767249695060131,\"AmbientSeeds\":287900299556547505950,\"ConcLiq\":0,\"SeedDeflator\":4951228715665,\"ConcGrowth\":3840188497074},\"PoolSpec\":{\"Schema\":1,\"FeeRate\":2700,\"ProtocolTake\":0,\"TickSize\":16,\"JitThresh\":3,\"KnockoutBits\":36,\"OracleFlags\":0},\"PoolParams\":{\"FeeRate\":2700,\"ProtocolTake\":0,\"TickSize\":16},\"ActiveTicks\":[-214608,-214416,-211120,-211024,-209104,-209008,-206592,-204400,-196944,-194736],\"Levels\":[{\"Tick\":-214608,\"Level\":{\"BidLots\":22030383990457222,\"AskLots\":0,\"FeeOdometer\":517895040700}},{\"Tick\":-214416,\"Level\":{\"BidLots\":356466428453858906,\"AskLots\":0,\"FeeOdometer\":539798191040}},{\"Tick\":-211120,\"Level\":{\"BidLots\":72426694961268976,\"AskLots\":0,\"FeeOdometer\":1107318714187}},{\"Tick\":-211024,\"Level\":{\"BidLots\":275074792625484608,\"AskLots\":0,\"FeeOdometer\":1114583527272}},{\"Tick\":-209104,\"Level\":{\"BidLots\":0,\"AskLots\":72426694961268976,\"FeeOdometer\":1307501876939}},{\"Tick\":-209008,\"Level\":{\"BidLots\":0,\"AskLots\":275074792625484608,\"FeeOdometer\":1313346280682}},{\"Tick\":-206592,\"Level\":{\"BidLots\":0,\"AskLots\":22030383990457222,\"FeeOdometer\":1426626934481}},{\"Tick\":-204400,\"Level\":{\"BidLots\":0,\"AskLots\":356466428453858906,\"FeeOdometer\":1340180871052}},{\"Tick\":-196944,\"Level\":{\"BidLots\":325710782961597566,\"AskLots\":0,\"FeeOdometer\":3826755276771}},{\"Tick\":-194736,\"Level\":{\"BidLots\":0,\"AskLots\":325710782961597566,\"FeeOdometer\":3263114987145}}],\"minTick\":-221762,\"maxTick\":-181762}}",
+	"staticExtra": "{\"nT\":\"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\"pI\":420,\"sD\":\"0xaaaaaaaaa24eeeb8d57d431224f73832bc34f688\",\"b\":\"0x0000000000000000000000000000000000000000\",\"q\":\"0x6982508145454ce325ddbe47a25d4ec3d2311933\"}"
+}`
+
+func TestCalcAmountOut_WETH_PEPE(t *testing.T) {
+	t.Parallel()
+
+	var ep entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(pepePepePoolJSON), &ep))
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	// tokens[0]=WETH tokens[1]=PEPE
+	// idx 0→1: buy PEPE with WETH (inBaseQty=true, isBuy=true)
+	// idx 1→0: sell PEPE for WETH (inBaseQty=false, isBuy=false)
+	testutil.TestCalcAmountOut(t, sim, map[int]map[int]map[string]string{
+		0: {1: {
+			// dust
+			"1000000000000": "576442870012802354608",
+			// small — linear region
+			"100000000000000":  "57180844910767991763488",
+			"1000000000000000": "532874702733362709783030",
+			// mid — starts crossing concentrated-liq ticks
+			"10000000000000000":  "3430948441567559587480289",
+			"100000000000000000": "6920286647218451536522758",
+			// large — exhausts most concentrated liq, runs on ambient
+			"1000000000000000000":  "7617075642681900846090866",
+			"10000000000000000000": "7693764345863403104012500",
+		}},
+		1: {0: {
+			// dust
+			"1000000000000": "1707",
+			// small — linear region
+			"100000000000000":  "172511",
+			"1000000000000000": "1725265",
+			// mid
+			"10000000000000000":  "17252793",
+			"100000000000000000": "172528074",
+			// large — crossing ticks
+			"1000000000000000000":    "1725280679",
+			"1000000000000000000000": "1725036690819",
+			// very large — deep into ambient
+			"1000000000000000000000000": "1511268015700814",
+		}},
+	})
+}
+
+func TestCalcAmountOutWithUpdateBalance_WETH_PEPE(t *testing.T) {
+	t.Parallel()
+
+	var ep entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(pepePepePoolJSON), &ep))
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	testutil.TestCalcAmountOutWithUpdateBalance(t, sim, map[int]map[int][][][2]string{
+		0: {1: {
+			// three successive 1 ETH buys move price up; 10 wei then rounds to zero output
+			{
+				{"1000000000000000000", "7617075642681900846090866"},
+				{"1000000000000000000", "42375677572960160303268"},
+				{"1000000000000000000", "14232917791043158912132"},
+				{"10", "zero amount"},
+			},
+		}},
+		1: {0: {
+			// three successive 1B PEPE sells: price moves down each time
+			{
+				{"1000000000000000000000000000", "18570677112940530"},
+				{"1000000000000000000000000000", "43199398599336"},
+				{"1000000000000000000000000000", "14401802524962"},
+			},
+		}},
+	})
+}
+
+func TestCloneState_WETH_PEPE(t *testing.T) {
+	t.Parallel()
+
+	var ep entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(pepePepePoolJSON), &ep))
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	tokens := sim.GetTokens()
+	testutil.TestCloneState(t, sim, calcParams(tokens[0], tokens[1], bignum.NewBig10("10000000000000000")), nil)
+}
+
+func TestCalcAmountOut_WETH_PEPE_ConcurrentSafe(t *testing.T) {
+	t.Parallel()
+
+	var ep entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(pepePepePoolJSON), &ep))
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	tokens := sim.GetTokens()
+	_, err = testutil.MustConcurrentSafe(t, func() (any, error) {
+		return sim.CalcAmountOut(calcParams(tokens[0], tokens[1], bignum.NewBig10("10000000000000000")))
+	})
+	require.NoError(t, err)
+}

--- a/pkg/liquidity-source/ambient/pool_tracker.go
+++ b/pkg/liquidity-source/ambient/pool_tracker.go
@@ -141,7 +141,7 @@ func (t *PoolTracker) tickWindow(prevCurve *CurveState) TickWindow {
 	if t.cfg.TickRange <= 0 {
 		return FullTickWindow
 	}
-	if prevCurve == nil || prevCurve.PriceRoot == nil || prevCurve.PriceRoot.Sign() == 0 {
+	if prevCurve == nil || prevCurve.PriceRoot.IsZero() {
 		return FullTickWindow
 	}
 

--- a/pkg/liquidity-source/ambient/snapshot_bitmap_view.go
+++ b/pkg/liquidity-source/ambient/snapshot_bitmap_view.go
@@ -1,19 +1,12 @@
 package ambient
 
 import (
-	"math/big"
 	"sort"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/holiman/uint256"
 )
 
-// SnapshotBitmapView is an in-memory implementation of BitmapView backed by a
-// tracked pool snapshot. It avoids rebuilding the full on-chain bitmap words
-// while preserving the bump-selection behavior that SweepSwap needs.
-//
-// When MinTick/MaxTick are narrower than the full int24 range, the view
-// reports boundary-exceeded via BoundaryExceeded after any PinBitmap or
-// SeekMezzSpill call that would have returned a tick outside the window.
+// SnapshotBitmapView is an in-memory BitmapView backed by a tracked pool snapshot.
 type SnapshotBitmapView struct {
 	activeTicks      []int32
 	levels           map[int32]BookLevel
@@ -21,9 +14,6 @@ type SnapshotBitmapView struct {
 	boundaryExceeded bool
 }
 
-// NewSnapshotBitmapView builds a read-only view over state. Callers must not
-// mutate state.ActiveTicks or state.Levels for the lifetime of the view; the
-// view borrows them without copying.
 func NewSnapshotBitmapView(state *TrackerExtra) *SnapshotBitmapView {
 	levels := make(map[int32]BookLevel, len(state.Levels))
 	for _, level := range state.Levels {
@@ -45,9 +35,7 @@ func NewSnapshotBitmapView(state *TrackerExtra) *SnapshotBitmapView {
 	}
 }
 
-func (v *SnapshotBitmapView) BoundaryExceeded() bool {
-	return v.boundaryExceeded
-}
+func (v *SnapshotBitmapView) BoundaryExceeded() bool { return v.boundaryExceeded }
 
 func (v *SnapshotBitmapView) PinBitmap(isBuy bool, startTick int32) (int32, bool) {
 	tickMezz := MezzKey(startTick)
@@ -94,13 +82,11 @@ func (v *SnapshotBitmapView) SeekMezzSpill(borderTick int32, isBuy bool) int32 {
 	return zeroTick(false)
 }
 
-// QueryLevel returns bid/ask lots for tick. Callers must treat the returned
-// *big.Int as read-only; misses share bignum.ZeroBI, hits share the level's
-// own pointers.
-func (v *SnapshotBitmapView) QueryLevel(tick int32) (bidLots, askLots *big.Int) {
+// QueryLevel returns bidLots/askLots for tick as value copies (zero if tick absent).
+func (v *SnapshotBitmapView) QueryLevel(tick int32) (bidLots, askLots uint256.Int) {
 	level, ok := v.levels[tick]
 	if !ok {
-		return bignum.ZeroBI, bignum.ZeroBI
+		return
 	}
 	return level.BidLots, level.AskLots
 }

--- a/pkg/liquidity-source/ambient/swapcurve.go
+++ b/pkg/liquidity-source/ambient/swapcurve.go
@@ -1,16 +1,16 @@
 package ambient
 
 import (
-	"math/big"
+	"github.com/holiman/uint256"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 type SwapDirective struct {
-	Qty        *big.Int
+	Qty        uint256.Int
 	InBaseQty  bool
 	IsBuy      bool
-	LimitPrice *big.Int
+	LimitPrice uint256.Int
 }
 
 type PoolParams struct {
@@ -22,65 +22,77 @@ type PoolParams struct {
 func SwapToLimit(curve *CurveState, accum *SwapAccum, swap *SwapDirective, pool *PoolParams, bumpTick int32) {
 	limitPrice := determineLimit(bumpTick, swap.LimitPrice, swap.IsBuy)
 
-	paidBase, paidQuote, paidProto := bookExchFees(curve, swap.Qty, pool, swap.InBaseQty, limitPrice)
+	paidBase, paidQuote, paidProto := bookExchFees(curve, &swap.Qty, pool, swap.InBaseQty, limitPrice)
 	accum.Accumulate(paidBase, paidQuote, paidProto)
 
 	paidBase, paidQuote, swap.Qty = swapOverCurve(curve, swap.InBaseQty, swap.IsBuy, swap.Qty, limitPrice)
-	accum.Accumulate(paidBase, paidQuote, bignum.ZeroBI)
+	accum.Accumulate(paidBase, paidQuote, uint256.Int{})
 }
 
-func CalcLimitFlows(curve *CurveState, swapQty *big.Int, inBaseQty bool, limitPrice *big.Int) *big.Int {
+func CalcLimitFlows(curve *CurveState, swapQty *uint256.Int, inBaseQty bool, limitPrice uint256.Int) uint256.Int {
 	limitFlow := calcLimitFlowsUncapped(curve, inBaseQty, limitPrice)
-	if limitFlow.Cmp(swapQty) > 0 {
-		return new(big.Int).Set(swapQty)
+	if limitFlow.Gt(swapQty) {
+		return *swapQty
 	}
 	return limitFlow
 }
 
-func calcLimitFlowsUncapped(curve *CurveState, inBaseQty bool, limitPrice *big.Int) *big.Int {
-	liq := ActiveLiquidity(curve)
+func calcLimitFlowsUncapped(curve *CurveState, inBaseQty bool, limitPrice uint256.Int) uint256.Int {
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
+	var result uint256.Int
 	if inBaseQty {
-		return DeltaBase(liq, curve.PriceRoot, limitPrice)
-	}
-	return DeltaQuote(liq, curve.PriceRoot, limitPrice)
-}
-
-func CalcLimitCounter(curve *CurveState, swapQty *big.Int, inBaseQty bool, limitPrice *big.Int) *big.Int {
-	isBuy := limitPrice.Cmp(curve.PriceRoot) > 0
-	denomFlow := CalcLimitFlows(curve, swapQty, inBaseQty, limitPrice)
-	return invertFlow(ActiveLiquidity(curve), curve.PriceRoot, denomFlow, isBuy, inBaseQty)
-}
-
-func invertFlow(liq, price, denomFlow *big.Int, isBuy, inBaseQty bool) *big.Int {
-	if liq.Sign() == 0 {
-		return new(big.Int)
-	}
-	invertReserve := ReserveAtPrice(liq, price, !inBaseQty)
-	initReserve := ReserveAtPrice(liq, price, inBaseQty)
-
-	var endReserve *big.Int
-	if isBuy == inBaseQty {
-		endReserve = new(big.Int).Add(initReserve, denomFlow)
+		DeltaBase(&result, &liq, &curve.PriceRoot, &limitPrice)
 	} else {
-		endReserve = new(big.Int).Sub(initReserve, denomFlow)
+		DeltaQuote(&result, &liq, &curve.PriceRoot, &limitPrice)
 	}
-	if endReserve.Sign() == 0 {
-		return new(big.Int).Set(mask128)
+	return result
+}
+
+func CalcLimitCounter(curve *CurveState, swapQty *uint256.Int, inBaseQty bool, limitPrice uint256.Int) uint256.Int {
+	isBuy := limitPrice.Gt(&curve.PriceRoot)
+	denomFlow := CalcLimitFlows(curve, swapQty, inBaseQty, limitPrice)
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
+	return invertFlow(liq, curve.PriceRoot, denomFlow, isBuy, inBaseQty)
+}
+
+func invertFlow(liq, price, denomFlow uint256.Int, isBuy, inBaseQty bool) uint256.Int {
+	if liq.IsZero() {
+		var zero uint256.Int
+		return zero
+	}
+	var invertReserve, initReserve uint256.Int
+	ReserveAtPrice(&invertReserve, &liq, &price, !inBaseQty)
+	ReserveAtPrice(&initReserve, &liq, &price, inBaseQty)
+
+	var endReserve uint256.Int
+	if isBuy == inBaseQty {
+		endReserve.Add(&initReserve, &denomFlow)
+	} else {
+		endReserve.Sub(&initReserve, &denomFlow)
+	}
+	if endReserve.IsZero() {
+		return *u256.UMaxU128
 	}
 
-	liqSq := new(big.Int).Mul(liq, liq)
-	endInvert := new(big.Int).Div(liqSq, endReserve)
+	var liqSq uint256.Int
+	liqSq.Mul(&liq, &liq)
+	var endInvert uint256.Int
+	endInvert.Div(&liqSq, &endReserve)
 
-	diff := new(big.Int).Sub(endInvert, invertReserve)
-	if diff.Sign() < 0 {
-		diff.Neg(diff)
+	var diff uint256.Int
+	if endInvert.Gt(&invertReserve) {
+		diff.Sub(&endInvert, &invertReserve)
+	} else {
+		diff.Sub(&invertReserve, &endInvert)
 	}
 	return diff
 }
 
-func swapOverCurve(curve *CurveState, inBaseQty, isBuy bool, swapQty, limitPrice *big.Int) (paidBase, paidQuote, qtyLeft *big.Int) {
-	realFlows := CalcLimitFlows(curve, swapQty, inBaseQty, limitPrice)
-	hitsLimit := realFlows.Cmp(swapQty) < 0
+func swapOverCurve(curve *CurveState, inBaseQty, isBuy bool, swapQty, limitPrice uint256.Int) (paidBase, paidQuote uint256.Int, qtyLeft uint256.Int) {
+	realFlows := CalcLimitFlows(curve, &swapQty, inBaseQty, limitPrice)
+	hitsLimit := realFlows.Lt(&swapQty)
 
 	if hitsLimit {
 		return RollPrice(curve, limitPrice, inBaseQty, isBuy, swapQty)
@@ -88,48 +100,48 @@ func swapOverCurve(curve *CurveState, inBaseQty, isBuy bool, swapQty, limitPrice
 	return RollFlow(curve, realFlows, inBaseQty, isBuy, swapQty)
 }
 
-func determineLimit(bumpTick int32, limitPrice *big.Int, isBuy bool) *big.Int {
+func determineLimit(bumpTick int32, limitPrice uint256.Int, isBuy bool) uint256.Int {
 	bounded := boundLimit(bumpTick, limitPrice, isBuy)
-	if bounded.Cmp(MinSqrtRatio) < 0 {
-		return new(big.Int).Set(MinSqrtRatio)
+	if bounded.Lt(&uMinSqrtRatio) {
+		return uMinSqrtRatio
 	}
-	if bounded.Cmp(MaxSqrtRatio) >= 0 {
-		return new(big.Int).Set(MaxSqrtRatioMinus1)
+	if bounded.Cmp(&uMaxSqrtRatio) >= 0 {
+		return uMaxSqrtRatioMinus1
 	}
 	return bounded
 }
 
-func boundLimit(bumpTick int32, limitPrice *big.Int, isBuy bool) *big.Int {
+func boundLimit(bumpTick int32, limitPrice uint256.Int, isBuy bool) uint256.Int {
 	if bumpTick <= MinTick || bumpTick >= MaxTick {
-		return new(big.Int).Set(limitPrice)
+		return limitPrice
 	}
 	if isBuy {
-		bumpPrice := new(big.Int).Sub(GetSqrtRatioAtTick(bumpTick), bignum.One)
-		if bumpPrice.Cmp(limitPrice) < 0 {
+		bumpPrice := GetSqrtRatioAtTick(bumpTick)
+		bumpPrice.Sub(&bumpPrice, u256.U1)
+		if bumpPrice.Lt(&limitPrice) {
 			return bumpPrice
 		}
-		return new(big.Int).Set(limitPrice)
+		return limitPrice
 	}
 	bumpPrice := GetSqrtRatioAtTick(bumpTick)
-	if bumpPrice.Cmp(limitPrice) > 0 {
+	if bumpPrice.Gt(&limitPrice) {
 		return bumpPrice
 	}
-	return new(big.Int).Set(limitPrice)
+	return limitPrice
 }
 
-func bookExchFees(curve *CurveState, swapQty *big.Int, pool *PoolParams, inBaseQty bool, limitPrice *big.Int) (paidBase, paidQuote, paidProto *big.Int) {
+func bookExchFees(curve *CurveState, swapQty *uint256.Int, pool *PoolParams, inBaseQty bool, limitPrice uint256.Int) (paidBase, paidQuote, paidProto uint256.Int) {
 	flow := CalcLimitCounter(curve, swapQty, inBaseQty, limitPrice)
 	liqFees, exchFees := CalcFeeOverFlow(flow, pool.FeeRate, pool.ProtocolTake)
 
-	AssimilateLiq(curve, liqFees, inBaseQty)
+	AssimilateLiq(curve, &liqFees, inBaseQty)
 
 	return assignFees(liqFees, exchFees, inBaseQty)
 }
 
-func assignFees(liqFees, exchFees *big.Int, inBaseQty bool) (paidBase, paidQuote, paidProto *big.Int) {
-	totalFees := liqFees.Add(liqFees, exchFees)
-	paidBase = bignum.ZeroBI
-	paidQuote = bignum.ZeroBI
+func assignFees(liqFees, exchFees uint256.Int, inBaseQty bool) (paidBase, paidQuote, paidProto uint256.Int) {
+	var totalFees uint256.Int
+	totalFees.Add(&liqFees, &exchFees)
 	if inBaseQty {
 		paidQuote = totalFees
 	} else {
@@ -140,17 +152,17 @@ func assignFees(liqFees, exchFees *big.Int, inBaseQty bool) (paidBase, paidQuote
 }
 
 var (
-	feeBPMult        = big.NewInt(1_000_000)
-	protoTakeDivisor = big.NewInt(256)
+	uFeeBPMult        = *uint256.NewInt(1_000_000)
+	uProtoTakeDivisor = *uint256.NewInt(256)
 )
 
-func CalcFeeOverFlow(flow *big.Int, feeRate uint16, protoProp uint8) (liqFee, protoFee *big.Int) {
-	totalFee := new(big.Int).SetUint64(uint64(feeRate))
-	totalFee.Mul(flow, totalFee)
-	totalFee.Div(totalFee, feeBPMult)
-	protoFee = new(big.Int).SetUint64(uint64(protoProp))
-	protoFee.Mul(totalFee, protoFee)
-	protoFee.Div(protoFee, protoTakeDivisor)
-	liqFee = new(big.Int).Sub(totalFee, protoFee)
+func CalcFeeOverFlow(flow uint256.Int, feeRate uint16, protoProp uint8) (liqFee, protoFee uint256.Int) {
+	liqFee.SetUint64(uint64(feeRate))
+	liqFee.Mul(&flow, &liqFee)
+	liqFee.Div(&liqFee, &uFeeBPMult)
+	protoFee.SetUint64(uint64(protoProp))
+	protoFee.Mul(&liqFee, &protoFee)
+	protoFee.Div(&protoFee, &uProtoTakeDivisor)
+	liqFee.Sub(&liqFee, &protoFee)
 	return
 }

--- a/pkg/liquidity-source/ambient/swapcurve_test.go
+++ b/pkg/liquidity-source/ambient/swapcurve_test.go
@@ -1,68 +1,71 @@
 package ambient
 
 import (
-	"math/big"
 	"testing"
+
+	"github.com/holiman/uint256"
 )
 
 func TestSwapToLimit_SmallBuy(t *testing.T) {
-	// Simulate a small buy on a curve with known state
+	var seeds, concLiq uint256.Int
+	seeds.SetUint64(1_000_000_000)
+	concLiq.SetUint64(500_000_000)
+
 	curve := &CurveState{
-		PriceRoot:    GetSqrtRatioAtTick(0), // price = 1.0
-		AmbientSeeds: big.NewInt(1_000_000_000),
-		ConcLiq:      big.NewInt(500_000_000),
+		PriceRoot:    GetSqrtRatioAtTick(0),
+		AmbientSeeds: seeds,
+		ConcLiq:      concLiq,
 		SeedDeflator: 0,
 		ConcGrowth:   0,
 	}
-	origPrice := new(big.Int).Set(curve.PriceRoot)
+	origPrice := curve.PriceRoot // value copy
 
 	pool := &PoolParams{
-		FeeRate:      2500, // 0.25%
+		FeeRate:      2500,
 		ProtocolTake: 0,
 		TickSize:     16,
 	}
 
 	swap := &SwapDirective{
-		Qty:        big.NewInt(10_000),
 		InBaseQty:  true,
 		IsBuy:      true,
 		LimitPrice: GetSqrtRatioAtTick(MaxTick - 1),
 	}
+	swap.Qty.SetUint64(10_000)
 
 	accum := NewSwapAccum()
 	SwapToLimit(curve, accum, swap, pool, MaxTick)
 
-	// Price should increase for a buy
-	if curve.PriceRoot.Cmp(origPrice) <= 0 {
-		t.Errorf("buy should increase price: before=%s after=%s", origPrice, curve.PriceRoot)
+	if curve.PriceRoot.Cmp(&origPrice) <= 0 {
+		t.Errorf("buy should increase price: before=%s after=%s", origPrice.ToBig(), curve.PriceRoot.ToBig())
 	}
-
-	// Swap should be fully consumed
-	if swap.Qty.Sign() != 0 {
-		t.Errorf("swap should be fully consumed, got qty=%s", swap.Qty)
+	if !swap.Qty.IsZero() {
+		t.Errorf("swap should be fully consumed, got qty=%s", swap.Qty.ToBig())
 	}
-
-	// Base flow should be positive (user pays), quote flow negative (user receives)
 	if accum.BaseFlow.Sign() <= 0 {
-		t.Errorf("buy: baseFlow should be positive, got %s", accum.BaseFlow)
+		t.Errorf("buy: baseFlow should be positive, got %s", FlowToBig(accum.BaseFlow))
 	}
 	if accum.QuoteFlow.Sign() >= 0 {
-		t.Errorf("buy: quoteFlow should be negative, got %s", accum.QuoteFlow)
+		t.Errorf("buy: quoteFlow should be negative, got %s", FlowToBig(accum.QuoteFlow))
 	}
 
 	t.Logf("Swap result: price %s -> %s, baseFlow=%s, quoteFlow=%s",
-		origPrice, curve.PriceRoot, accum.BaseFlow, accum.QuoteFlow)
+		origPrice.ToBig(), curve.PriceRoot.ToBig(), FlowToBig(accum.BaseFlow), FlowToBig(accum.QuoteFlow))
 }
 
 func TestSwapToLimit_SmallSell(t *testing.T) {
+	var seeds, concLiq uint256.Int
+	seeds.SetUint64(1_000_000_000)
+	concLiq.SetUint64(500_000_000)
+
 	curve := &CurveState{
 		PriceRoot:    GetSqrtRatioAtTick(0),
-		AmbientSeeds: big.NewInt(1_000_000_000),
-		ConcLiq:      big.NewInt(500_000_000),
+		AmbientSeeds: seeds,
+		ConcLiq:      concLiq,
 		SeedDeflator: 0,
 		ConcGrowth:   0,
 	}
-	origPrice := new(big.Int).Set(curve.PriceRoot)
+	origPrice := curve.PriceRoot
 
 	pool := &PoolParams{
 		FeeRate:      2500,
@@ -71,31 +74,35 @@ func TestSwapToLimit_SmallSell(t *testing.T) {
 	}
 
 	swap := &SwapDirective{
-		Qty:        big.NewInt(10_000),
 		InBaseQty:  true,
 		IsBuy:      false,
 		LimitPrice: GetSqrtRatioAtTick(MinTick + 1),
 	}
+	swap.Qty.SetUint64(10_000)
 
 	accum := NewSwapAccum()
 	SwapToLimit(curve, accum, swap, pool, MinTick)
 
-	if curve.PriceRoot.Cmp(origPrice) >= 0 {
-		t.Errorf("sell should decrease price: before=%s after=%s", origPrice, curve.PriceRoot)
+	if curve.PriceRoot.Cmp(&origPrice) >= 0 {
+		t.Errorf("sell should decrease price: before=%s after=%s", origPrice.ToBig(), curve.PriceRoot.ToBig())
 	}
-	if swap.Qty.Sign() != 0 {
-		t.Errorf("swap should be fully consumed, got qty=%s", swap.Qty)
+	if !swap.Qty.IsZero() {
+		t.Errorf("swap should be fully consumed, got qty=%s", swap.Qty.ToBig())
 	}
 
 	t.Logf("Swap result: price %s -> %s, baseFlow=%s, quoteFlow=%s",
-		origPrice, curve.PriceRoot, accum.BaseFlow, accum.QuoteFlow)
+		origPrice.ToBig(), curve.PriceRoot.ToBig(), FlowToBig(accum.BaseFlow), FlowToBig(accum.QuoteFlow))
 }
 
 func TestSwapToLimit_HitsBump(t *testing.T) {
+	var seeds, concLiq uint256.Int
+	seeds.SetUint64(100_000)
+	concLiq.SetUint64(50_000)
+
 	curve := &CurveState{
 		PriceRoot:    GetSqrtRatioAtTick(100),
-		AmbientSeeds: big.NewInt(100_000),
-		ConcLiq:      big.NewInt(50_000),
+		AmbientSeeds: seeds,
+		ConcLiq:      concLiq,
 		SeedDeflator: 0,
 		ConcGrowth:   0,
 	}
@@ -106,55 +113,51 @@ func TestSwapToLimit_HitsBump(t *testing.T) {
 		TickSize:     16,
 	}
 
-	// Large swap that should hit the bump tick boundary
 	swap := &SwapDirective{
-		Qty:        big.NewInt(1_000_000),
 		InBaseQty:  true,
 		IsBuy:      true,
 		LimitPrice: GetSqrtRatioAtTick(MaxTick - 1),
 	}
+	swap.Qty.SetUint64(1_000_000)
 
 	bumpTick := int32(200)
-	bumpPrice := new(big.Int).Sub(GetSqrtRatioAtTick(bumpTick), big.NewInt(1))
+	bumpPrice := GetSqrtRatioAtTick(bumpTick)
+	bumpPrice.Sub(&bumpPrice, new(uint256.Int).SetUint64(1))
 
 	accum := NewSwapAccum()
 	SwapToLimit(curve, accum, swap, pool, bumpTick)
 
-	// Should stop at the bump price
-	if curve.PriceRoot.Cmp(bumpPrice) != 0 {
-		t.Errorf("should stop at bump price: got %s, want %s", curve.PriceRoot, bumpPrice)
+	if curve.PriceRoot.Cmp(&bumpPrice) != 0 {
+		t.Errorf("should stop at bump price: got %s, want %s", curve.PriceRoot.ToBig(), bumpPrice.ToBig())
 	}
-
-	// Should have remaining qty
-	if swap.Qty.Sign() == 0 {
+	if swap.Qty.IsZero() {
 		t.Error("should have remaining swap qty after hitting bump")
 	}
 
-	t.Logf("Hit bump: price=%s, remaining qty=%s", curve.PriceRoot, swap.Qty)
+	t.Logf("Hit bump: price=%s, remaining qty=%s", curve.PriceRoot.ToBig(), swap.Qty.ToBig())
 }
 
 func TestDeriveImpact_Symmetry(t *testing.T) {
+	var seeds uint256.Int
+	seeds.SetUint64(1_000_000)
+
 	curve := &CurveState{
 		PriceRoot:    GetSqrtRatioAtTick(0),
-		AmbientSeeds: big.NewInt(1_000_000),
-		ConcLiq:      big.NewInt(0),
+		AmbientSeeds: seeds,
 		SeedDeflator: 0,
 		ConcGrowth:   0,
 	}
 
-	flow := big.NewInt(1000)
+	var flow uint256.Int
+	flow.SetUint64(1000)
 
-	// Buy with base tokens
 	_, buyPrice := DeriveImpact(curve, flow, true, true)
-
-	// The resulting price should be higher (buy pushes price up)
-	if buyPrice.Cmp(curve.PriceRoot) <= 0 {
-		t.Errorf("buy should push price up: from %s to %s", curve.PriceRoot, buyPrice)
+	if buyPrice.Cmp(&curve.PriceRoot) <= 0 {
+		t.Errorf("buy should push price up: from %s to %s", curve.PriceRoot.ToBig(), buyPrice.ToBig())
 	}
 
-	// Sell with base tokens
 	_, sellPrice := DeriveImpact(curve, flow, true, false)
-	if sellPrice.Cmp(curve.PriceRoot) >= 0 {
-		t.Errorf("sell should push price down: from %s to %s", curve.PriceRoot, sellPrice)
+	if sellPrice.Cmp(&curve.PriceRoot) >= 0 {
+		t.Errorf("sell should push price down: from %s to %s", curve.PriceRoot.ToBig(), sellPrice.ToBig())
 	}
 }

--- a/pkg/liquidity-source/ambient/sweepswap.go
+++ b/pkg/liquidity-source/ambient/sweepswap.go
@@ -2,30 +2,22 @@ package ambient
 
 import (
 	"math"
-	"math/big"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/holiman/uint256"
 )
 
-// int24 sentinels used by Bitmaps.zeroTick() as "zero horizon" bump ticks.
 const (
 	TickInfinityUpper int32 = (1 << 23) - 1
 	TickInfinityLower int32 = -(1 << 23)
 )
 
-// BitmapView is the read surface SweepSwap needs. Mirrors CrocImpact.sol.
+// BitmapView is the read surface SweepSwap needs.
 type BitmapView interface {
-	// PinBitmap returns the next bump tick in the local mezz of startTick;
-	// spillsOver when no bit is found locally.
 	PinBitmap(isBuy bool, startTick int32) (bumpTick int32, spillsOver bool)
-	// SeekMezzSpill returns the next active tick across the whole bitmap,
-	// falling back to zeroTick(isBuy).
 	SeekMezzSpill(borderTick int32, isBuy bool) int32
-	// QueryLevel returns (bidLots, askLots) at tick; zeros if none.
-	QueryLevel(tick int32) (bidLots, askLots *big.Int)
+	QueryLevel(tick int32) (bidLots, askLots uint256.Int)
 }
 
-// EmptyBitmapView is the zero-liquidity implementation of BitmapView.
 type EmptyBitmapView struct{}
 
 func (EmptyBitmapView) PinBitmap(isBuy bool, startTick int32) (int32, bool) {
@@ -33,24 +25,21 @@ func (EmptyBitmapView) PinBitmap(isBuy bool, startTick int32) (int32, bool) {
 	return spillOverPin(isBuy, mezz), true
 }
 
-func (EmptyBitmapView) SeekMezzSpill(borderTick int32, isBuy bool) int32 {
+func (EmptyBitmapView) SeekMezzSpill(_ int32, isBuy bool) int32 {
 	return zeroTick(isBuy)
 }
 
-func (EmptyBitmapView) QueryLevel(tick int32) (*big.Int, *big.Int) {
-	return bignum.ZeroBI, bignum.ZeroBI
+func (EmptyBitmapView) QueryLevel(_ int32) (uint256.Int, uint256.Int) {
+	return uint256.Int{}, uint256.Int{}
 }
 
-// spillOverPin mirrors Bitmaps.spillOverPin: next mezz bucket in swap direction.
 func spillOverPin(isBuy bool, tickMezz int16) int32 {
 	if isBuy {
 		if tickMezz == math.MaxInt16 {
 			return zeroTick(true)
 		}
-		// weldMezzTerm(tickMezz+1, zeroTerm(!isBuy)=0)
 		return int32(tickMezz+1) << 8
 	}
-	// weldMezzTerm(tickMezz, 0)
 	return int32(tickMezz) << 8
 }
 
@@ -65,9 +54,6 @@ func isTickFinite(tick int32) bool {
 	return tick > TickInfinityLower && tick < TickInfinityUpper
 }
 
-// SweepSwap mirrors CrocImpact.sol sweepSwap: repeatedly SwapToLimit to the
-// next bump tick until swap exhausts or hits limit price; fees accumulate
-// segment-by-segment.
 func SweepSwap(
 	curve *CurveState,
 	swap *SwapDirective,
@@ -76,11 +62,10 @@ func SweepSwap(
 ) (*SwapAccum, error) {
 	accum := NewSwapAccum()
 
-	// Solidity short-circuit: already past limit → zero flow.
-	if swap.IsBuy && curve.PriceRoot.Cmp(swap.LimitPrice) >= 0 {
+	if swap.IsBuy && curve.PriceRoot.Cmp(&swap.LimitPrice) >= 0 {
 		return accum, nil
 	}
-	if !swap.IsBuy && curve.PriceRoot.Cmp(swap.LimitPrice) <= 0 {
+	if !swap.IsBuy && curve.PriceRoot.Cmp(&swap.LimitPrice) <= 0 {
 		return accum, nil
 	}
 
@@ -133,21 +118,18 @@ func SweepSwap(
 	return accum, nil
 }
 
-// sweepTrace is an optional debug callback for tests; nil disables tracing.
 var sweepTrace func(label string, tick int32, swap *SwapDirective, curve *CurveState)
 
 func hasSwapLeft(curve *CurveState, swap *SwapDirective) bool {
 	var inLimit bool
 	if swap.IsBuy {
-		inLimit = curve.PriceRoot.Cmp(swap.LimitPrice) < 0
+		inLimit = curve.PriceRoot.Lt(&swap.LimitPrice)
 	} else {
-		inLimit = curve.PriceRoot.Cmp(swap.LimitPrice) > 0
+		inLimit = curve.PriceRoot.Gt(&swap.LimitPrice)
 	}
-	return inLimit && swap.Qty.Sign() > 0
+	return inLimit && !swap.Qty.IsZero()
 }
 
-// adjTickLiq mirrors CrocImpact.sol adjTickLiq: on bump crossing, update
-// concLiq, shave one unit of precision, and return new midTick.
 func adjTickLiq(
 	accum *SwapAccum,
 	bumpTick int32,
@@ -164,23 +146,45 @@ func adjTickLiq(
 	if !swap.IsBuy {
 		crossedLots = bidLots
 	}
-	if HasKnockoutLiq(crossedLots) {
+	if HasKnockoutLiq(&crossedLots) {
 		accum.KnockoutCrossLoops++
 	}
 
-	// liqDelta = (int128(bid) - int128(ask)) * LOT_SIZE, negated on sell side.
-	liqDelta := new(big.Int).Sub(LotsToLiquidity(bidLots), LotsToLiquidity(askLots))
-	if !swap.IsBuy {
-		liqDelta.Neg(liqDelta)
+	// Apply liqDelta = (bidLiq - askLiq) * sign to ConcLiq (uint256 two's complement int128).
+	var bidLiq, askLiq uint256.Int
+	LotsToLiquidity(&bidLiq, &bidLots)
+	LotsToLiquidity(&askLiq, &askLots)
+
+	if swap.IsBuy {
+		// delta = bidLiq - askLiq
+		if bidLiq.Cmp(&askLiq) >= 0 {
+			var diff uint256.Int
+			diff.Sub(&bidLiq, &askLiq)
+			curve.ConcLiq.Add(&curve.ConcLiq, &diff)
+		} else {
+			var diff uint256.Int
+			diff.Sub(&askLiq, &bidLiq)
+			curve.ConcLiq.Sub(&curve.ConcLiq, &diff)
+		}
+	} else {
+		// delta = -(bidLiq - askLiq) = askLiq - bidLiq
+		if askLiq.Cmp(&bidLiq) >= 0 {
+			var diff uint256.Int
+			diff.Sub(&askLiq, &bidLiq)
+			curve.ConcLiq.Add(&curve.ConcLiq, &diff)
+		} else {
+			var diff uint256.Int
+			diff.Sub(&bidLiq, &askLiq)
+			curve.ConcLiq.Sub(&curve.ConcLiq, &diff)
+		}
 	}
-	curve.ConcLiq = liqDelta.Add(curve.ConcLiq, liqDelta)
 
 	paidBase, paidQuote, burnSwap, err := ShaveAtBump(curve, swap.InBaseQty, swap.IsBuy, swap.Qty)
 	if err != nil {
 		return 0, err
 	}
-	accum.Accumulate(paidBase, paidQuote, bignum.ZeroBI)
-	swap.Qty.Sub(swap.Qty, burnSwap)
+	accum.Accumulate(paidBase, paidQuote, uint256.Int{})
+	swap.Qty.Sub(&swap.Qty, &burnSwap)
 	accum.CrossInitTickLoops++
 
 	if swap.IsBuy {

--- a/pkg/liquidity-source/ambient/tick_range_test.go
+++ b/pkg/liquidity-source/ambient/tick_range_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
@@ -409,18 +410,9 @@ func percentile(sorted []int32, p float64) int32 {
 	return sorted[idx]
 }
 
-func absBI(x *big.Int) *big.Int {
-	if x == nil {
-		return new(big.Int)
-	}
-	if x.Sign() < 0 {
-		return new(big.Int).Neg(x)
-	}
-	return new(big.Int).Set(x)
-}
-
-func realLots(x *big.Int) *big.Int {
-	return new(big.Int).AndNot(absBI(x), knockoutFlagMask)
+func realLots(x uint256.Int) *big.Int {
+	x.And(&x, uKnockoutClearMask)
+	return x.ToBig()
 }
 
 func defaultSwapParityCases(wethAddr, usdcAddr common.Address) []swapParityCase {
@@ -457,11 +449,11 @@ func calcChainBitmapOut(
 ) (*big.Int, error) {
 	simCurve := fullState.Curve
 	simSwap := &SwapDirective{
-		Qty:        new(big.Int).Set(tc.amountIn),
 		InBaseQty:  tc.inBaseQty,
 		IsBuy:      tc.isBuy,
 		LimitPrice: defaultLimitPrice(tc.isBuy),
 	}
+	simSwap.Qty.SetFromBig(tc.amountIn)
 	chainBmp := &ChainBitmapView{
 		Ctx:      h.ctx,
 		Client:   h.client,
@@ -473,7 +465,7 @@ func calcChainBitmapOut(
 	if err != nil {
 		return nil, err
 	}
-	return deriveChainOutput(chainAccum.BaseFlow, chainAccum.QuoteFlow, tc.inBaseQty), nil
+	return deriveChainOutput(FlowToBig(chainAccum.BaseFlow), FlowToBig(chainAccum.QuoteFlow), tc.inBaseQty), nil
 }
 
 // --- indexer / on-chain helpers --------------------------------------------
@@ -582,9 +574,9 @@ func callCrocImpact(
 	isBuy, inBaseQty bool,
 	qty, blockNum *big.Int,
 ) (baseFlow, quoteFlow *big.Int, err error) {
-	limitPrice := new(big.Int).Set(MinSqrtRatio)
+	limitPrice := uMinSqrtRatio.ToBig()
 	if isBuy {
-		limitPrice = new(big.Int).Sub(MaxSqrtRatio, big.NewInt(1))
+		limitPrice = uMaxSqrtRatioMinus1.ToBig()
 	}
 	data, err := crocImpactParsedABI.Pack("calcImpact",
 		base, quote, new(big.Int).SetUint64(poolIdx),

--- a/pkg/liquidity-source/ambient/tick_range_test.go
+++ b/pkg/liquidity-source/ambient/tick_range_test.go
@@ -453,7 +453,9 @@ func calcChainBitmapOut(
 		IsBuy:      tc.isBuy,
 		LimitPrice: defaultLimitPrice(tc.isBuy),
 	}
-	simSwap.Qty.SetFromBig(tc.amountIn)
+	if overflow := simSwap.Qty.SetFromBig(tc.amountIn); overflow {
+		return nil, ErrOverflow
+	}
 	chainBmp := &ChainBitmapView{
 		Ctx:      h.ctx,
 		Client:   h.client,

--- a/pkg/liquidity-source/ambient/tickmath.go
+++ b/pkg/liquidity-source/ambient/tickmath.go
@@ -3,178 +3,177 @@ package ambient
 import (
 	"math/big"
 
-	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/holiman/uint256"
+
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
+
+func mustU256Dec(s string) uint256.Int {
+	b, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		panic("mustU256Dec: " + s)
+	}
+	v, _ := uint256.FromBig(b)
+	return *v
+}
 
 var (
 	MinTick int32 = -665454
 	MaxTick int32 = 831818
 
-	MinSqrtRatio       = big.NewInt(65538)
-	MaxSqrtRatio       = bignum.NewBig("21267430153580247136652501917186561138")
-	MaxSqrtRatioMinus1 = new(big.Int).Sub(MaxSqrtRatio, bignum.One)
+	uMinSqrtRatio       = *uint256.NewInt(65538)
+	uMaxSqrtRatio       = mustU256Dec("21267430153580247136652501917186561138")
+	uMaxSqrtRatioMinus1 = func() uint256.Int { v := uMaxSqrtRatio; v.Sub(&v, u256.U1); return v }()
 
-	q64 = new(big.Int).Lsh(bignum.One, 64)
+	// uQ64 = 2^64 (for remainder check in GetSqrtRatioAtTick)
+	uQ64Tick = func() uint256.Int { var v uint256.Int; v.SetUint64(1); v.Lsh(&v, 64); return v }()
 
-	tickLog2Mul       = bignum.NewBig10("255738958999603826347141")
-	tickLowOffset     = bignum.NewBig10("3402992956809132418596140100660247210")
-	tickHiOffset      = bignum.NewBig10("291339464771989622907027621153398088495")
-	tickMsbBias       = big.NewInt(128)
-	tickMsbThresholds = []struct {
-		cmp  *big.Int
-		bits uint
-	}{
-		{bignum.NewBig("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), 7},
-		{bignum.NewBig("0xFFFFFFFFFFFFFFFF"), 6},
-		{bignum.NewBig("0xFFFFFFFF"), 5},
-		{bignum.NewBig("0xFFFF"), 4},
-		{bignum.NewBig("0xFF"), 3},
-		{bignum.NewBig("0xF"), 2},
-		{bignum.NewBig("0x3"), 1},
-		{bignum.NewBig("0x1"), 0},
-	}
+	uMaxUint256 = func() uint256.Int { var v uint256.Int; v.Not(new(uint256.Int)); return v }()
 
-	tickMagicFactors = []*big.Int{
-		bignum.NewBig("0xfffcb933bd6fad37aa2d162d1a594001"),
-		bignum.NewBig("0xfff97272373d413259a46990580e213a"),
-		bignum.NewBig("0xfff2e50f5f656932ef12357cf3c7fdcc"),
-		bignum.NewBig("0xffe5caca7e10e4e61c3624eaa0941cd0"),
-		bignum.NewBig("0xffcb9843d60f6159c9db58835c926644"),
-		bignum.NewBig("0xff973b41fa98c081472e6896dfb254c0"),
-		bignum.NewBig("0xff2ea16466c96a3843ec78b326b52861"),
-		bignum.NewBig("0xfe5dee046a99a2a811c461f1969c3053"),
-		bignum.NewBig("0xfcbe86c7900a88aedcffc83b479aa3a4"),
-		bignum.NewBig("0xf987a7253ac413176f2b074cf7815e54"),
-		bignum.NewBig("0xf3392b0822b70005940c7a398e4b70f3"),
-		bignum.NewBig("0xe7159475a2c29b7443b29c7fa6e889d9"),
-		bignum.NewBig("0xd097f3bdfd2022b8845ad8f792aa5825"),
-		bignum.NewBig("0xa9f746462d870fdf8a65dc1f90e061e5"),
-		bignum.NewBig("0x70d869a156d2a1b890bb3df62baf32f7"),
-		bignum.NewBig("0x31be135f97d08fd981231505542fcfa6"),
-		bignum.NewBig("0x9aa508b5b7a84e1c677de54f3e99bc9"),
-		bignum.NewBig("0x5d6af8dedb81196699c329225ee604"),
-		bignum.NewBig("0x2216e584f5fa1ea926041bedfe98"),
-		bignum.NewBig("0x48a170391f7dc42444e8fa2"),
+	// CrocTickMath constants (from Ambient Finance Solidity).
+	uTickLog2Mul   = mustU256Dec("255738958999603826347141")
+	uTickLowOffset = mustU256Dec("3402992956809132418596140100660247210")
+	uTickHiOffset  = mustU256Dec("291339464771989622907027621153398088495")
+
+	uTickMagicFactors = [20]uint256.Int{
+		*uint256.MustFromHex("0xfffcb933bd6fad37aa2d162d1a594001"),
+		*uint256.MustFromHex("0xfff97272373d413259a46990580e213a"),
+		*uint256.MustFromHex("0xfff2e50f5f656932ef12357cf3c7fdcc"),
+		*uint256.MustFromHex("0xffe5caca7e10e4e61c3624eaa0941cd0"),
+		*uint256.MustFromHex("0xffcb9843d60f6159c9db58835c926644"),
+		*uint256.MustFromHex("0xff973b41fa98c081472e6896dfb254c0"),
+		*uint256.MustFromHex("0xff2ea16466c96a3843ec78b326b52861"),
+		*uint256.MustFromHex("0xfe5dee046a99a2a811c461f1969c3053"),
+		*uint256.MustFromHex("0xfcbe86c7900a88aedcffc83b479aa3a4"),
+		*uint256.MustFromHex("0xf987a7253ac413176f2b074cf7815e54"),
+		*uint256.MustFromHex("0xf3392b0822b70005940c7a398e4b70f3"),
+		*uint256.MustFromHex("0xe7159475a2c29b7443b29c7fa6e889d9"),
+		*uint256.MustFromHex("0xd097f3bdfd2022b8845ad8f792aa5825"),
+		*uint256.MustFromHex("0xa9f746462d870fdf8a65dc1f90e061e5"),
+		*uint256.MustFromHex("0x70d869a156d2a1b890bb3df62baf32f7"),
+		*uint256.MustFromHex("0x31be135f97d08fd981231505542fcfa6"),
+		*uint256.MustFromHex("0x9aa508b5b7a84e1c677de54f3e99bc9"),
+		*uint256.MustFromHex("0x5d6af8dedb81196699c329225ee604"),
+		*uint256.MustFromHex("0x2216e584f5fa1ea926041bedfe98"),
+		*uint256.MustFromHex("0x48a170391f7dc42444e8fa2"),
 	}
 )
 
-func GetSqrtRatioAtTick(tick int32) *big.Int {
-	// Clamp to the supported tick range. On-chain math reverts here; in the
-	// quoting path we prefer to saturate rather than crash the caller.
+// GetSqrtRatioAtTick returns the Q64.64 sqrt ratio for the given tick (clamped to [MinTick, MaxTick]).
+func GetSqrtRatioAtTick(tick int32) uint256.Int {
 	if tick < MinTick {
 		tick = MinTick
 	} else if tick > MaxTick {
 		tick = MaxTick
 	}
 
-	absTick := int64(tick)
-	if absTick < 0 {
-		absTick = -absTick
+	absTick := uint32(tick)
+	if tick < 0 {
+		absTick = uint32(-int64(tick))
 	}
 
-	ratio := new(big.Int)
+	var ratio uint256.Int
 	if absTick&0x1 != 0 {
-		ratio.Set(tickMagicFactors[0])
+		ratio.Set(&uTickMagicFactors[0])
 	} else {
-		ratio.Set(bignum.B2Pow128)
+		ratio.Set(u256.U2Pow128)
 	}
 
-	for i := 1; i < len(tickMagicFactors); i++ {
-		bit := int64(1) << uint(i)
-		if absTick&bit != 0 {
-			ratio.Mul(ratio, tickMagicFactors[i])
-			ratio.Rsh(ratio, 128)
+	for i := 1; i < len(uTickMagicFactors); i++ {
+		if absTick&(uint32(1)<<uint(i)) != 0 {
+			ratio.Mul(&ratio, &uTickMagicFactors[i])
+			ratio.Rsh(&ratio, 128)
 		}
 	}
 
 	if tick > 0 {
-		ratio.Div(bignum.MaxUint256, ratio)
+		ratio.Div(&uMaxUint256, &ratio)
 	}
 
-	rem := new(big.Int).Mod(ratio, q64)
-	result := new(big.Int).Rsh(ratio, 64)
-	if rem.Sign() != 0 {
-		result.Add(result, bignum.One)
+	var rem uint256.Int
+	rem.Mod(&ratio, &uQ64Tick)
+	ratio.Rsh(&ratio, 64)
+	if !rem.IsZero() {
+		ratio.Add(&ratio, u256.U1)
 	}
-	return result
+	return ratio
 }
 
-func GetTickAtSqrtRatio(sqrtPriceX64 *big.Int) int32 {
-	// Clamp to the supported sqrt-price range (see GetSqrtRatioAtTick).
-	if sqrtPriceX64.Cmp(MinSqrtRatio) < 0 {
-		sqrtPriceX64 = new(big.Int).Set(MinSqrtRatio)
-	} else if sqrtPriceX64.Cmp(MaxSqrtRatio) >= 0 {
-		sqrtPriceX64 = new(big.Int).Sub(MaxSqrtRatio, bignum.One)
+// GetTickAtSqrtRatio returns the greatest tick t such that GetSqrtRatioAtTick(t) <= sqrtPriceX64.
+func GetTickAtSqrtRatio(sqrtPriceX64 uint256.Int) int32 {
+	if sqrtPriceX64.Lt(&uMinSqrtRatio) {
+		sqrtPriceX64.Set(&uMinSqrtRatio)
+	} else if sqrtPriceX64.Cmp(&uMaxSqrtRatio) >= 0 {
+		sqrtPriceX64.Sub(&uMaxSqrtRatio, u256.U1)
 	}
 
-	ratio := new(big.Int).Lsh(sqrtPriceX64, 64)
-	r := new(big.Int).Set(ratio)
-	msb := uint(0)
+	var ratio uint256.Int
+	ratio.Lsh(&sqrtPriceX64, 64)
 
-	for _, t := range tickMsbThresholds {
-		if r.Cmp(t.cmp) > 0 {
-			f := uint(1) << t.bits
-			msb |= f
-			r.Rsh(r, f)
-		}
-	}
-	// last one: f = gt(r, 0x1)
-	if r.Cmp(bignum.One) > 0 {
-		msb |= 1
-	}
+	r := ratio // value copy for MSB computation
+	// floor(log2(r)) via BitLen — replaces the original 8-threshold loop.
+	msb := uint(r.BitLen()) - 1 // r > 0 guaranteed (MinSqrtRatio > 0)
 
+	var log2 uint256.Int
 	if msb >= 128 {
-		r.Rsh(ratio, msb-127)
+		r.Rsh(&ratio, msb-127)
+		var delta uint256.Int
+		delta.SetUint64(uint64(msb - 128))
+		delta.Lsh(&delta, 64)
+		log2.Set(&delta)
 	} else {
-		r.Lsh(ratio, 127-msb)
+		r.Lsh(&ratio, 127-msb)
+		// log2 = -(128-msb)<<64 as 256-bit two's complement
+		var delta uint256.Int
+		delta.SetUint64(uint64(128 - msb))
+		delta.Lsh(&delta, 64)
+		log2.Not(&delta)
+		log2.Add(&log2, u256.U1)
 	}
 
-	log2 := new(big.Int).Sub(big.NewInt(int64(msb)), tickMsbBias)
-	log2.Lsh(log2, 64)
-
-	for i := uint(63); i >= 50; i-- {
-		r.Mul(r, r)
-		r.Rsh(r, 127)
-		f := new(big.Int).Rsh(r, 128)
-		log2.Or(log2, new(big.Int).Lsh(f, i))
-		r.Rsh(r, uint(f.Uint64()))
+	for i := uint(63); ; i-- {
+		r.Mul(&r, &r)
+		r.Rsh(&r, 127)
+		var f, shifted uint256.Int
+		f.Rsh(&r, 128)
+		shifted.Lsh(&f, i)
+		log2.Or(&log2, &shifted)
+		r.Rsh(&r, uint(f.Uint64()))
 		if i == 50 {
 			break
 		}
 	}
 
-	logSqrt10001 := new(big.Int).Mul(log2, tickLog2Mul)
+	var logSqrt10001, tmp uint256.Int
+	logSqrt10001.Mul(&log2, &uTickLog2Mul)
 
-	tickLow := new(big.Int).Sub(logSqrt10001, tickLowOffset)
-	tickLow.Rsh(tickLow, 128)
-	if logSqrt10001.Sign() < 0 || tickLow.Sign() < 0 {
-		// handle negative: arithmetic right shift
-		tickLow = arithRsh128(new(big.Int).Sub(logSqrt10001, tickLowOffset))
-	}
+	tmp.Sub(&logSqrt10001, &uTickLowOffset)
+	tickLow := arithRsh128(tmp)
 
-	tickHi := new(big.Int).Add(logSqrt10001, tickHiOffset)
-	tickHi = arithRsh128(tickHi)
+	tmp.Add(&logSqrt10001, &uTickHiOffset)
+	tickHi := arithRsh128(tmp)
 
-	if tickLow.Cmp(tickHi) == 0 {
-		return int32(tickLow.Int64())
+	tickLow32 := int32(int64(tickLow.Uint64()))
+	tickHi32 := int32(int64(tickHi.Uint64()))
+
+	if tickLow32 == tickHi32 {
+		return tickLow32
 	}
-	if GetSqrtRatioAtTick(int32(tickHi.Int64())).Cmp(sqrtPriceX64) <= 0 {
-		return int32(tickHi.Int64())
+	sqrtCheck := GetSqrtRatioAtTick(tickHi32)
+	if sqrtCheck.Cmp(&sqrtPriceX64) <= 0 {
+		return tickHi32
 	}
-	return int32(tickLow.Int64())
+	return tickLow32
 }
 
-func arithRsh128(x *big.Int) *big.Int {
-	if x.Sign() >= 0 {
-		return new(big.Int).Rsh(x, 128)
+// arithRsh128 performs arithmetic (sign-extending) right shift by 128 bits on a
+// 256-bit two's complement integer represented as uint256.Int.
+func arithRsh128(x uint256.Int) uint256.Int {
+	isNeg := x[3]>>63 != 0 // sign bit before shift
+	x.Rsh(&x, 128)
+	if isNeg {
+		x[2] = ^uint64(0)
+		x[3] = ^uint64(0)
 	}
-	// For negative: floor division by 2^128
-	result := new(big.Int).Rsh(new(big.Int).Neg(x), 128)
-	result.Neg(result)
-	// Check if there was a remainder
-	shifted := new(big.Int).Lsh(result, 128)
-	if shifted.Cmp(x) != 0 {
-		result.Sub(result, bignum.One)
-	}
-	return result
+	return x
 }

--- a/pkg/liquidity-source/ambient/tickmath_test.go
+++ b/pkg/liquidity-source/ambient/tickmath_test.go
@@ -69,3 +69,89 @@ func TestActiveLiquidity(t *testing.T) {
 		t.Errorf("ActiveLiquidity = %s, want %s", liq.ToBig(), expected)
 	}
 }
+
+func TestCalcFeeOverFlow(t *testing.T) {
+	var flow uint256.Int
+	flow.SetUint64(1_000_000)
+	feeRate := uint16(2500) // 0.25%
+	protoProp := uint8(0)
+
+	liqFee, protoFee := CalcFeeOverFlow(flow, feeRate, protoProp)
+
+	if liqFee.Uint64() != 2500 {
+		t.Errorf("liqFee = %s, want 2500", liqFee.ToBig())
+	}
+	if !protoFee.IsZero() {
+		t.Errorf("protoFee = %s, want 0", protoFee.ToBig())
+	}
+
+	// With protocol take
+	protoProp = 128 // 50%
+	liqFee, protoFee = CalcFeeOverFlow(flow, feeRate, protoProp)
+	if protoFee.Uint64() != 1250 {
+		t.Errorf("protoFee with 50%% take = %s, want 1250", protoFee.ToBig())
+	}
+	if liqFee.Uint64() != 1250 {
+		t.Errorf("liqFee with 50%% take = %s, want 1250", liqFee.ToBig())
+	}
+}
+
+func TestCompoundStack(t *testing.T) {
+	// (1+0) * (1+0) - 1 = 0
+	if CompoundStack(0, 0) != 0 {
+		t.Error("CompoundStack(0,0) should be 0")
+	}
+
+	// Commutativity
+	a, b := uint64(100000), uint64(200000)
+	if CompoundStack(a, b) != CompoundStack(b, a) {
+		t.Error("CompoundStack should be commutative")
+	}
+}
+
+func TestLotsToLiquidity(t *testing.T) {
+	var lots, liq uint256.Int
+	lots.SetUint64(100)
+	LotsToLiquidity(&liq, &lots)
+	if liq.Uint64() != 100*1024 {
+		t.Errorf("LotsToLiquidity(100) = %s, want %d", liq.ToBig(), 100*1024)
+	}
+
+	// Odd lots (knockout flag) should mask out the flag
+	lots.SetUint64(101) // bit 0 set
+	LotsToLiquidity(&liq, &lots)
+	if liq.Uint64() != 100*1024 {
+		t.Errorf("LotsToLiquidity(101) = %s, want %d", liq.ToBig(), 100*1024)
+	}
+}
+
+func TestBitmapHelpers(t *testing.T) {
+	if CastBitmapIndex(0) != 128 {
+		t.Error("CastBitmapIndex(0) should be 128")
+	}
+	if CastBitmapIndex(-128) != 0 {
+		t.Error("CastBitmapIndex(-128) should be 0")
+	}
+	if CastBitmapIndex(127) != 255 {
+		t.Error("CastBitmapIndex(127) should be 255")
+	}
+	if UncastBitmapIndex(128) != 0 {
+		t.Error("UncastBitmapIndex(128) should be 0")
+	}
+	if UncastBitmapIndex(0) != -128 {
+		t.Error("UncastBitmapIndex(0) should be -128")
+	}
+}
+
+func TestWeldTick(t *testing.T) {
+	tick := int32(-197080)
+	lobby := LobbyKey(tick)
+	mezzB := MezzBit(tick)
+	termB := TermBit(tick)
+
+	reconstructed := WeldLobbyMezzTerm(lobby, mezzB, termB)
+	if reconstructed != tick {
+		t.Errorf("weld roundtrip: got %d, want %d (lobby=%d mezzBit=%d termBit=%d)",
+			reconstructed, tick, lobby, mezzB, termB)
+	}
+}

--- a/pkg/liquidity-source/ambient/tickmath_test.go
+++ b/pkg/liquidity-source/ambient/tickmath_test.go
@@ -3,6 +3,8 @@ package ambient
 import (
 	"math/big"
 	"testing"
+
+	"github.com/holiman/uint256"
 )
 
 func TestGetSqrtRatioAtTick_KnownValues(t *testing.T) {
@@ -10,16 +12,16 @@ func TestGetSqrtRatioAtTick_KnownValues(t *testing.T) {
 		tick     int32
 		expected string
 	}{
-		{0, "18446744073709551616"},                         // 2^64 = 1.0 in Q64.64
-		{MinTick, "65538"},                                  // MIN_SQRT_RATIO
-		{MaxTick, "21267430153580247136652501917186561138"}, // MAX_SQRT_RATIO
+		{0, "18446744073709551616"}, // 2^64
+		{MinTick, "65538"},
+		{MaxTick, "21267430153580247136652501917186561138"},
 	}
 
 	for _, tt := range tests {
 		got := GetSqrtRatioAtTick(tt.tick)
 		expected, _ := new(big.Int).SetString(tt.expected, 10)
-		if got.Cmp(expected) != 0 {
-			t.Errorf("GetSqrtRatioAtTick(%d) = %s, want %s", tt.tick, got, expected)
+		if got.ToBig().Cmp(expected) != 0 {
+			t.Errorf("GetSqrtRatioAtTick(%d) = %s, want %s", tt.tick, got.ToBig(), expected)
 		}
 	}
 }
@@ -30,123 +32,40 @@ func TestGetTickAtSqrtRatio_Roundtrip(t *testing.T) {
 		price := GetSqrtRatioAtTick(tick)
 		gotTick := GetTickAtSqrtRatio(price)
 		if gotTick != tick {
-			t.Errorf("roundtrip tick %d: getSqrt=%s, getTick=%d", tick, price, gotTick)
+			t.Errorf("roundtrip tick %d: getSqrt=%s, getTick=%d", tick, price.ToBig(), gotTick)
 		}
 	}
 }
 
 func TestGetSqrtRatioAtTick_Boundaries(t *testing.T) {
 	minPrice := GetSqrtRatioAtTick(MinTick)
-	if minPrice.Cmp(MinSqrtRatio) != 0 {
-		t.Errorf("MinTick price: got %s, want %s", minPrice, MinSqrtRatio)
+	if minPrice.Cmp(&uMinSqrtRatio) != 0 {
+		t.Errorf("MinTick price: got %s, want %s", minPrice.ToBig(), uMinSqrtRatio.ToBig())
 	}
 
 	maxPrice := GetSqrtRatioAtTick(MaxTick)
-	if maxPrice.Cmp(MaxSqrtRatio) != 0 {
-		t.Errorf("MaxTick price: got %s, want %s", maxPrice, MaxSqrtRatio)
+	if maxPrice.Cmp(&uMaxSqrtRatio) != 0 {
+		t.Errorf("MaxTick price: got %s, want %s", maxPrice.ToBig(), uMaxSqrtRatio.ToBig())
 	}
 }
 
 func TestActiveLiquidity(t *testing.T) {
+	var seeds, concLiq uint256.Int
+	seeds.SetUint64(1_000_000)
+	concLiq.SetUint64(500_000)
+
 	curve := &CurveState{
-		PriceRoot:    big.NewInt(18446744073709551),
-		AmbientSeeds: big.NewInt(1000000),
-		ConcLiq:      big.NewInt(500000),
+		PriceRoot:    *uint256.NewInt(18446744073709551),
+		AmbientSeeds: seeds,
+		ConcLiq:      concLiq,
 		SeedDeflator: 0,
 		ConcGrowth:   0,
 	}
-	liq := ActiveLiquidity(curve)
-	// With zero deflator, ambient = seeds * (1 + 0) = seeds
-	expected := new(big.Int).Add(big.NewInt(1000000), big.NewInt(500000))
-	if liq.Cmp(expected) != 0 {
-		t.Errorf("ActiveLiquidity = %s, want %s", liq, expected)
-	}
-}
+	var liq uint256.Int
+	ActiveLiquidity(&liq, curve)
 
-func TestCalcFeeOverFlow(t *testing.T) {
-	flow := big.NewInt(1_000_000)
-	feeRate := uint16(2500) // 0.25%
-	protoProp := uint8(0)
-
-	liqFee, protoFee := CalcFeeOverFlow(flow, feeRate, protoProp)
-
-	expectedTotal := big.NewInt(2500) // 1M * 2500 / 1M
-	if liqFee.Cmp(expectedTotal) != 0 {
-		t.Errorf("liqFee = %s, want %s", liqFee, expectedTotal)
-	}
-	if protoFee.Sign() != 0 {
-		t.Errorf("protoFee = %s, want 0", protoFee)
-	}
-
-	// With protocol take
-	protoProp = 128 // 50%
-	liqFee, protoFee = CalcFeeOverFlow(flow, feeRate, protoProp)
-	if protoFee.Cmp(big.NewInt(1250)) != 0 {
-		t.Errorf("protoFee with 50%% take = %s, want 1250", protoFee)
-	}
-	if liqFee.Cmp(big.NewInt(1250)) != 0 {
-		t.Errorf("liqFee with 50%% take = %s, want 1250", liqFee)
-	}
-}
-
-func TestCompoundStack(t *testing.T) {
-	// (1+0) * (1+0) - 1 = 0
-	if CompoundStack(0, 0) != 0 {
-		t.Error("CompoundStack(0,0) should be 0")
-	}
-
-	// Commutativity
-	a, b := uint64(100000), uint64(200000)
-	if CompoundStack(a, b) != CompoundStack(b, a) {
-		t.Error("CompoundStack should be commutative")
-	}
-}
-
-func TestLotsToLiquidity(t *testing.T) {
-	lots := big.NewInt(100)
-	liq := LotsToLiquidity(lots)
-	expected := big.NewInt(100 * 1024) // 100 << 10
-	if liq.Cmp(expected) != 0 {
-		t.Errorf("LotsToLiquidity(100) = %s, want %s", liq, expected)
-	}
-
-	// Odd lots (knockout flag) should mask out the flag
-	oddLots := big.NewInt(101) // bit 0 set
-	liq = LotsToLiquidity(oddLots)
-	expected = big.NewInt(100 * 1024) // 100 << 10 (flag cleared)
-	if liq.Cmp(expected) != 0 {
-		t.Errorf("LotsToLiquidity(101) = %s, want %s", liq, expected)
-	}
-}
-
-func TestBitmapHelpers(t *testing.T) {
-	if CastBitmapIndex(0) != 128 {
-		t.Error("CastBitmapIndex(0) should be 128")
-	}
-	if CastBitmapIndex(-128) != 0 {
-		t.Error("CastBitmapIndex(-128) should be 0")
-	}
-	if CastBitmapIndex(127) != 255 {
-		t.Error("CastBitmapIndex(127) should be 255")
-	}
-	if UncastBitmapIndex(128) != 0 {
-		t.Error("UncastBitmapIndex(128) should be 0")
-	}
-	if UncastBitmapIndex(0) != -128 {
-		t.Error("UncastBitmapIndex(0) should be -128")
-	}
-}
-
-func TestWeldTick(t *testing.T) {
-	tick := int32(-197080)
-	lobby := LobbyKey(tick)
-	mezz := MezzKey(tick)
-	mezzB := MezzBit(tick)
-	termB := TermBit(tick)
-
-	reconstructed := WeldLobbyMezzTerm(lobby, mezzB, termB)
-	if reconstructed != tick {
-		t.Errorf("weld roundtrip: got %d, want %d (lobby=%d mezz=%d mezzBit=%d termBit=%d)",
-			reconstructed, tick, lobby, mezz, mezzB, termB)
+	expected := new(big.Int).Add(big.NewInt(1_000_000), big.NewInt(500_000))
+	if liq.ToBig().Cmp(expected) != 0 {
+		t.Errorf("ActiveLiquidity = %s, want %s", liq.ToBig(), expected)
 	}
 }

--- a/pkg/liquidity-source/ambient/tracker.go
+++ b/pkg/liquidity-source/ambient/tracker.go
@@ -82,7 +82,7 @@ func (t *StateTracker) LoadCentered(
 	if err != nil {
 		return nil, fmt.Errorf("centered load: read curve: %w", err)
 	}
-	if curve.PriceRoot == nil || curve.PriceRoot.Sign() == 0 {
+	if curve.PriceRoot.IsZero() {
 		return &TrackerExtra{
 			Base: orderedBase, Quote: orderedQuote,
 			PoolIdx: poolIdx, PoolHash: poolHash,
@@ -119,7 +119,6 @@ func (t *StateTracker) LoadWindow(
 	maxLobby := int16(LobbyKey(window.MaxTick))
 	numLobbies := int(maxLobby-minLobby) + 1
 
-	// ---- Stage A: curve(2) + poolSpec(1) + lobby mezz reads.
 	const numFixed = 3
 	stageA := make([]common.Hash, 0, numFixed+numLobbies)
 	stageA = append(stageA,
@@ -141,7 +140,6 @@ func (t *StateTracker) LoadWindow(
 	poolSpec := DecodePoolSpec(slotWord(wordsA[2]))
 	mezzWords := wordsA[numFixed:]
 
-	// ---- Stage B: terminus reads for every non-empty mezz word.
 	type mezzHit struct {
 		lobby   int8
 		mezzBit uint8
@@ -184,7 +182,6 @@ func (t *StateTracker) LoadWindow(
 	}
 	sort.Slice(activeTicks, func(i, j int) bool { return activeTicks[i] < activeTicks[j] })
 
-	// ---- Stage C: per active tick, one level slot.
 	stageC := make([]common.Hash, 0, len(activeTicks))
 	for _, tick := range activeTicks {
 		stageC = append(stageC, LevelSlot(poolHash, tick))
@@ -218,10 +215,6 @@ func (t *StateTracker) LoadWindow(
 	}, nil
 }
 
-// Refresh reuses prev when curve + poolSpec fingerprints are unchanged,
-// else falls back to LoadWindow. Returns (extra, changed, err).
-// Caveat: mints/burns inside an already-active mezz word don't move the curve,
-// so pair with periodic full reload for bit-exact tick distribution.
 func (t *StateTracker) Refresh(
 	ctx context.Context,
 	prev *TrackerExtra,
@@ -260,16 +253,9 @@ func poolSpecEqual(a, b PoolSpec) bool {
 func curveEqual(a, b CurveState) bool {
 	return a.SeedDeflator == b.SeedDeflator &&
 		a.ConcGrowth == b.ConcGrowth &&
-		bigEqual(a.PriceRoot, b.PriceRoot) &&
-		bigEqual(a.AmbientSeeds, b.AmbientSeeds) &&
-		bigEqual(a.ConcLiq, b.ConcLiq)
-}
-
-func bigEqual(a, b *big.Int) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return a.Cmp(b) == 0
+		a.PriceRoot.Eq(&b.PriceRoot) &&
+		a.AmbientSeeds.Eq(&b.AmbientSeeds) &&
+		a.ConcLiq.Eq(&b.ConcLiq)
 }
 
 func normalizePair(base, quote string) (string, string) {
@@ -308,6 +294,5 @@ func slotWord(word *big.Int) [32]byte {
 	if word != nil {
 		word.FillBytes(out[:])
 	}
-
 	return out
 }

--- a/pkg/util/testutil/calc_amount_out.go
+++ b/pkg/util/testutil/calc_amount_out.go
@@ -65,11 +65,12 @@ func Test[TB interface {
 			tokens[idxOut],
 			nil,
 		)
-		if updateBalance {
+		if updateBalance && err == nil {
 			poolSim.UpdateBalance(pool.UpdateBalanceParams{
 				TokenAmountIn:  pool.TokenAmount{Token: tokens[idxIn], Amount: bignumber.NewBig10(amtIn)},
 				TokenAmountOut: *amtOut.TokenAmountOut,
 				Fee:            *amtOut.Fee,
+				SwapInfo:       amtOut.SwapInfo,
 			})
 		}
 		if expected == "" {


### PR DESCRIPTION
Migrates the Ambient DEX integration's internal math layer from `math/big` (`*big.Int`) to `holiman/uint256` (`uint256.Int`) across all hot-path helpers — liquidity, fee, compound growth, assimilation, curveroll, fixedpoint, and sweepswap — eliminating heap allocations in quoting paths.

## Why did we need it?
`big.Int` allocates on every arithmetic operation. The Ambient simulator is called on every quote, making these allocations a measurable source of GC pressure. `uint256.Int` is a value type (four `uint64` fields) that fits on the stack in most call patterns, removing per-operation heap traffic.

**Key changes:**
- All internal math helpers (`liquidity.go`, `compound.go`, `fixedpoint.go`, `assimilate.go`, `curveroll.go`, `swapcurve.go`, `sweepswap.go`) ported to `uint256.Int` with destination-pointer output convention (`func Foo(dst, a, b *uint256.Int)`)
- `CurveState` fields (`PriceRoot`, `AmbientSeeds`, `ConcLiq`) changed from `*big.Int` to `uint256.Int` (inline value)
- `bitmap_view.QueryLevel` returns `(bidLots, askLots uint256.Int)` by value instead of allocated `*big.Int`
- **Review fix — `pool_simulator.go`:** `SetFromBig` overflow now returns a dedicated `ErrOverflow` (new sentinel in `constant.go`) instead of the misleading `ErrZeroAmount`, so callers can distinguish overflow from genuine zero-amount input
- **Review fix — `tick_range_test.go`:** `calcChainBitmapOut` now checks the overflow bool from `SetFromBig` and returns `ErrOverflow` rather than silently truncating large inputs
- **Review fix — `tickmath_test.go`:** Restored focused unit tests for `CalcFeeOverFlow`, `CompoundStack`, `LotsToLiquidity`, `CastBitmapIndex`/`UncastBitmapIndex`, and `WeldLobbyMezzTerm` that were dropped during the migration

## Related Issue

## Release Note
No breaking changes for external callers. `CurveState` struct layout changed (fields are now inline `uint256.Int` instead of `*big.Int`) — any code that directly constructs or inspects `CurveState` outside this package must be updated.

## How Has This Been Tested?
Existing simulator parity tests (`pool_simulator_test.go`, `tick_range_test.go`) exercise the full swap path against on-chain values. Low-level helper coverage is provided by the restored unit tests in `tickmath_test.go`.

## Screenshots (if appropriate):