### PR TITLE
perf: uniswap-v3

### DIFF
--- a/pkg/liquidity-source/pancake/infinity/cl/pool_simulator.go
+++ b/pkg/liquidity-source/pancake/infinity/cl/pool_simulator.go
@@ -3,9 +3,7 @@ package cl
 import (
 	"fmt"
 	"math/big"
-	"strings"
 
-	v3Utils "github.com/KyberNetwork/uniswapv3-sdk-uint256/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
 
@@ -349,10 +347,6 @@ func (p *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {
 		tokenOutAddress = common.HexToAddress(tokenOut)
 	}
 
-	zeroForOne := strings.EqualFold(tokenIn, p.GetTokens()[0])
-	var priceLimit v3Utils.Uint160
-	_ = p.GetSqrtPriceLimit(zeroForOne, &priceLimit)
-
 	return PoolMetaInfo{
 		Vault:       p.staticExtra.VaultAddress,
 		PoolManager: p.staticExtra.PoolManagerAddress,
@@ -363,7 +357,7 @@ func (p *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {
 		Parameters:  p.staticExtra.Parameters,
 		HookAddress: p.staticExtra.HooksAddress,
 		HookData:    []byte{},
-		PriceLimit:  &priceLimit,
+		PriceLimit:  p.GetSqrtPriceLimit(tokenIn == p.GetTokens()[0]),
 		SwapFee:     p.Info.SwapFee.Uint64(),
 	}
 }

--- a/pkg/liquidity-source/uniswap/v3/bench_test.go
+++ b/pkg/liquidity-source/uniswap/v3/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
@@ -44,7 +45,7 @@ var (
 )
 
 func benchmarkCalcAmountOut(b *testing.B, amount *big.Int, sim pool.IPoolSimulator) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = sim.CalcAmountOut(pool.CalcAmountOutParams{
 			TokenAmountIn: pool.TokenAmount{
 				Token:  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -81,7 +82,77 @@ func BenchmarkCalcAmountOutCrossManyTickV2(b *testing.B) {
 }
 
 func BenchmarkNewPoolSimulatorV2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = NewPoolSimulator(poolEnt, valueobject.ChainIDEthereum)
+	}
+}
+
+// ---------- micro-benchmarks for hot-path functions ----------
+
+// BenchmarkGetSqrtRatioAtTick covers the per-tick-crossing cost paid on every
+// swap loop iteration.  Ticks are spread across the valid range to exercise
+// all 20 conditional multiply branches.
+func BenchmarkGetSqrtRatioAtTick(b *testing.B) {
+	ticks := []int{0, 1, 100, 1000, 10000, 27139, 100000, -1000, -27139, MinTick + 1, MaxTick - 1}
+	var result uint256.Int
+	b.ResetTimer()
+	for i := range b.N {
+		_ = GetSqrtRatioAtTick(ticks[i%len(ticks)], &result)
+	}
+}
+
+// BenchmarkGetTickAtSqrtRatio covers the reverse direction, which is called
+// when a swap step doesn't fully cross a tick.
+func BenchmarkGetTickAtSqrtRatio(b *testing.B) {
+	// build a few representative sqrtPriceX96 values from different ticks
+	tickSamples := []int{0, 1000, 10000, 27139, -1000, -27139}
+	prices := make([]*uint256.Int, len(tickSamples))
+	for i, t := range tickSamples {
+		p := new(uint256.Int)
+		_ = GetSqrtRatioAtTick(t, p)
+		prices[i] = p
+	}
+	b.ResetTimer()
+	for i := range b.N {
+		_, _ = GetTickAtSqrtRatio(prices[i%len(prices)])
+	}
+}
+
+// BenchmarkMostSignificantBit isolates the MSB subroutine inside
+// GetTickAtSqrtRatio.  sqrtPX128 values are ~192-bit numbers.
+func BenchmarkMostSignificantBit(b *testing.B) {
+	vals := make([]*uint256.Int, 8)
+	for i, t := range []int{0, 1000, 10000, 27139, -1000, -10000, -27139, MaxTick - 1} {
+		var p uint256.Int
+		_ = GetSqrtRatioAtTick(t, &p)
+		p.Lsh(&p, 32) // simulate sqrtPX128 = sqrtPX96 << 32
+		vals[i] = &p
+	}
+	b.ResetTimer()
+	for i := range b.N {
+		_, _ = MostSignificantBit(vals[i%len(vals)])
+	}
+}
+
+// BenchmarkBinarySearch benchmarks the tick-list binary search on the
+// realistic ~400-tick pool from the benchmark fixture.
+func BenchmarkBinarySearch(b *testing.B) {
+	ticks := simV2.V3Pool.Ticks
+	// query ticks spread across the list
+	queries := []int{ticks[0].Index, ticks[len(ticks)/4].Index, ticks[len(ticks)/2].Index,
+		ticks[3*len(ticks)/4].Index, ticks[len(ticks)-1].Index, 27139}
+	b.ResetTimer()
+	for i := range b.N {
+		_, _ = binarySearch(ticks, queries[i%len(queries)])
+	}
+}
+
+// BenchmarkNextInitializedTickIndex covers the full tick-lookup chain
+// (bounds check + binary search) that runs on every swap loop iteration.
+func BenchmarkNextInitializedTickIndex(b *testing.B) {
+	ticks := simV2.V3Pool.Ticks
+	b.ResetTimer()
+	for i := range b.N {
+		_, _, _ = nextInitializedTickIndex(ticks, 27139, i%2 == 0)
 	}
 }

--- a/pkg/liquidity-source/uniswap/v3/math.go
+++ b/pkg/liquidity-source/uniswap/v3/math.go
@@ -3,12 +3,8 @@ package uniswapv3
 import (
 	"errors"
 
-	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/kutils"
 	"github.com/holiman/uint256"
-	"github.com/samber/lo"
-
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 var (
@@ -28,35 +24,26 @@ var (
 
 // Pool holds the mutable state needed to simulate Uniswap V3 swaps.
 type Pool struct {
-	Fee          FeeAmount
-	TickSpacing  int
-	TickCurrent  int
-	SqrtRatioX96 *uint256.Int
-	Liquidity    *uint256.Int
-	Ticks        []TickU256
+	Fee            FeeAmount
+	TickSpacing    int
+	TickCurrent    int
+	SqrtRatioX96   uint256.Int
+	Liquidity      uint256.Int
+	Ticks          []TickU256
+	TickSqrtPrices []uint256.Int // precomputed GetSqrtRatioAtTick(Ticks[i].Index); read-only after construction
 }
 
 type SwapResult struct {
-	AmountCalculated   *int256.Int
-	SqrtRatioX96       *uint256.Int
-	Liquidity          *uint256.Int
-	RemainingAmountIn  *int256.Int
-	CurrentTick        int
-	CrossInitTickLoops int
-}
-
-// GetAmountResultV2 is returned by GetOutputAmountV2 and GetInputAmountV2.
-type GetAmountResultV2 struct {
-	ReturnedAmount     *int256.Int
-	RemainingAmountIn  *int256.Int
-	SqrtRatioX96       *uint256.Int
-	Liquidity          *uint256.Int
+	AmountCalculated   uint256.Int
+	SqrtRatioX96       uint256.Int
+	Liquidity          uint256.Int
+	RemainingAmountIn  uint256.Int
 	CurrentTick        int
 	CrossInitTickLoops int
 }
 
 // NewPool constructs a Pool, validating the fee tier and sqrtRatioX96 range.
-func NewPool(fee FeeAmount, sqrtRatioX96 *uint256.Int, liquidity *uint256.Int, tickCurrent int, ticks []TickU256,
+func NewPool(fee FeeAmount, sqrtRatioX96 uint256.Int, liquidity uint256.Int, tickCurrent int, ticks []TickU256,
 	tickSpacing int) (*Pool, error) {
 	if fee >= FeeMax {
 		return nil, ErrFeeTooHigh
@@ -73,110 +60,106 @@ func NewPool(fee FeeAmount, sqrtRatioX96 *uint256.Int, liquidity *uint256.Int, t
 	} else if !sqrtRatioX96.Lt(&sqrtP) {
 		return nil, ErrInvalidSqrtRatioX96
 	}
+	sqrtPrices := make([]uint256.Int, len(ticks))
+	for i, t := range ticks {
+		if err := GetSqrtRatioAtTick(t.Index, &sqrtPrices[i]); err != nil {
+			return nil, err
+		}
+	}
 	return &Pool{
-		Fee:          fee,
-		TickSpacing:  tickSpacing,
-		TickCurrent:  tickCurrent,
-		SqrtRatioX96: sqrtRatioX96,
-		Liquidity:    liquidity,
-		Ticks:        ticks,
+		Fee:            fee,
+		TickSpacing:    tickSpacing,
+		TickCurrent:    tickCurrent,
+		SqrtRatioX96:   sqrtRatioX96,
+		Liquidity:      liquidity,
+		Ticks:          ticks,
+		TickSqrtPrices: sqrtPrices,
 	}, nil
 }
 
 // GetOutputAmountV2 computes the output for an exact-input swap (positive amountSpecified).
-func (p *Pool) GetOutputAmountV2(inputAmount *int256.Int, zeroForOne bool,
-	sqrtPriceLimitX96 *uint256.Int) (*GetAmountResultV2, error) {
+// Returns (outputAmount, swapInfo, crossedTicks, err).
+func (p *Pool) GetOutputAmountV2(zeroForOne bool, inputAmount, sqrtPriceLimitX96 uint256.Int) (SwapResult, error) {
 	sr, err := p.Swap(zeroForOne, inputAmount, sqrtPriceLimitX96)
 	if err != nil {
-		return nil, err
+		return SwapResult{}, err
 	}
-	return &GetAmountResultV2{
-		ReturnedAmount:     new(int256.Int).Neg(sr.AmountCalculated),
-		RemainingAmountIn:  new(int256.Int).Set(sr.RemainingAmountIn),
-		SqrtRatioX96:       sr.SqrtRatioX96,
-		Liquidity:          sr.Liquidity,
-		CurrentTick:        sr.CurrentTick,
-		CrossInitTickLoops: sr.CrossInitTickLoops,
-	}, nil
+	sr.AmountCalculated.Neg(&sr.AmountCalculated)
+	return sr, nil
 }
 
 // GetInputAmountV2 computes the input for an exact-output swap.
-// outputAmount must be positive. Returns (inputAmount, newPoolState, err).
-func (p *Pool) GetInputAmountV2(outputAmount *int256.Int, zeroForOne bool, sqrtPriceLimitX96 *uint256.Int) (*int256.Int,
-	*Pool, error) {
-	negOut := new(int256.Int).Neg(outputAmount)
-	sr, err := p.Swap(zeroForOne, negOut, sqrtPriceLimitX96)
+// outputAmount must be positive. Returns (inputAmount, swapInfo, err).
+func (p *Pool) GetInputAmountV2(zeroForOne bool, outputAmount, sqrtPriceLimitX96 uint256.Int) (SwapResult, error) {
+	outputAmount.Neg(&outputAmount)
+	sr, err := p.Swap(zeroForOne, outputAmount, sqrtPriceLimitX96)
 	if err != nil {
-		return nil, nil, err
+		return SwapResult{}, err
 	}
-	pool := &Pool{
-		Fee:          p.Fee,
-		SqrtRatioX96: sr.SqrtRatioX96,
-		Liquidity:    sr.Liquidity,
-		TickCurrent:  sr.CurrentTick,
-		Ticks:        p.Ticks,
-	}
-	return sr.AmountCalculated, pool, nil
+	return sr, nil
 }
 
 // Swap is the core Uniswap V3 swap algorithm.
 // Positive amountSpecified → exact input. Negative → exact output.
-func (p *Pool) Swap(zeroForOne bool, amountSpecified *int256.Int, sqrtPriceLimitX96 *uint256.Int) (*SwapResult, error) {
-	if sqrtPriceLimitX96 == nil {
+func (p *Pool) Swap(zeroForOne bool, amountSpecified, sqrtPriceLimitX96 uint256.Int) (SwapResult, error) {
+	if sqrtPriceLimitX96.IsZero() {
 		if zeroForOne {
-			sqrtPriceLimitX96 = new(uint256.Int).AddUint64(MinSqrtRatioU256, 1)
+			sqrtPriceLimitX96 = *MinSqrtRatioU256P1
 		} else {
-			sqrtPriceLimitX96 = new(uint256.Int).SubUint64(MaxSqrtRatioU256, 1)
+			sqrtPriceLimitX96 = *MaxSqrtRatioU256M1
 		}
-	}
-
-	if zeroForOne {
+	} else if zeroForOne {
 		if sqrtPriceLimitX96.Lt(MinSqrtRatioU256) {
-			return nil, ErrSqrtPriceLimitX96TooLow
-		} else if !sqrtPriceLimitX96.Lt(p.SqrtRatioX96) {
-			return nil, ErrSqrtPriceLimitX96TooHigh
+			return SwapResult{}, ErrSqrtPriceLimitX96TooLow
+		} else if !sqrtPriceLimitX96.Lt(&p.SqrtRatioX96) {
+			return SwapResult{}, ErrSqrtPriceLimitX96TooHigh
 		}
 	} else {
 		if sqrtPriceLimitX96.Gt(MaxSqrtRatioU256) {
-			return nil, ErrSqrtPriceLimitX96TooHigh
-		} else if !sqrtPriceLimitX96.Gt(p.SqrtRatioX96) {
-			return nil, ErrSqrtPriceLimitX96TooLow
+			return SwapResult{}, ErrSqrtPriceLimitX96TooHigh
+		} else if !sqrtPriceLimitX96.Gt(&p.SqrtRatioX96) {
+			return SwapResult{}, ErrSqrtPriceLimitX96TooLow
 		}
 	}
 
 	exactInput := amountSpecified.Sign() >= 0
 
-	amountSpecifiedRemaining := new(int256.Int).Set(amountSpecified)
-	amountCalculated := int256.NewInt(0)
-	sqrtPriceX96 := new(uint256.Int).Set(p.SqrtRatioX96)
+	amountSpecifiedRemaining := amountSpecified
+	var amountCalculated uint256.Int
+	sqrtPriceX96 := p.SqrtRatioX96
+	liquidity := p.Liquidity
 	tick := p.TickCurrent
-	liquidity := new(uint256.Int).Set(p.Liquidity)
-	crossInitTickLoops := 0
+	var crossInitTickLoops int
 
-	for !amountSpecifiedRemaining.IsZero() && !sqrtPriceX96.Eq(sqrtPriceLimitX96) {
-		var sqrtPriceStartX96, sqrtPriceNextX96 uint256.Int
-		sqrtPriceStartX96.Set(sqrtPriceX96)
+	for !amountSpecifiedRemaining.IsZero() && !sqrtPriceLimitX96.Eq(&sqrtPriceX96) {
+		sqrtPriceStartX96 := sqrtPriceX96
+		var sqrtPriceNextX96 uint256.Int
 
-		tickNext, initialized, err := nextInitializedTickIndex(p.Ticks, tick, zeroForOne)
+		tickNext, slicePos, initialized, err := nextInitializedTickPos(p.Ticks, tick, zeroForOne)
 		if err != nil {
-			return nil, err
+			return SwapResult{}, err
 		} else if tickNext < MinTick {
 			tickNext = MinTick
+			sqrtPriceNextX96 = *MinSqrtRatioU256
 		} else if tickNext > MaxTick {
 			tickNext = MaxTick
-		}
-
-		if err = GetSqrtRatioAtTick(tickNext, &sqrtPriceNextX96); err != nil {
-			return nil, err
+			sqrtPriceNextX96 = *MaxSqrtRatioU256P1
+		} else {
+			sqrtPriceNextX96 = p.TickSqrtPrices[slicePos]
 		}
 
 		var targetValue uint256.Int
-		targetValue.Set(lo.Ternary(zeroForOne, big256.Max, big256.Min)(sqrtPriceLimitX96, &sqrtPriceNextX96))
+		if zeroForOne && sqrtPriceLimitX96.Gt(&sqrtPriceNextX96) ||
+			!zeroForOne && sqrtPriceLimitX96.Lt(&sqrtPriceNextX96) {
+			targetValue = sqrtPriceLimitX96
+		} else {
+			targetValue = sqrtPriceNextX96
+		}
 
 		var nxtSqrtPriceX96, amountIn, amountOut, feeAmount uint256.Int
-		if err = ComputeSwapStep(sqrtPriceX96, &targetValue, liquidity, amountSpecifiedRemaining,
+		if err = ComputeSwapStep(&sqrtPriceX96, &targetValue, &liquidity, &amountSpecifiedRemaining,
 			p.Fee, &nxtSqrtPriceX96, &amountIn, &amountOut, &feeAmount); err != nil {
-			return nil, err
+			return SwapResult{}, err
 		}
 
 		// per-tick rounding: exactIn floors amountOut, exactOut ceils amountIn.
@@ -184,44 +167,56 @@ func (p *Pool) Swap(zeroForOne bool, amountSpecified *int256.Int, sqrtPriceLimit
 		// nextInitializedTickWithinOneWord; each step rounds amountOut down by ≤1 unit.
 		// wordCrossings ≈ number of bitmap words traversed = ceil(tick-spacings / 256).
 		fullyCrossed := sqrtPriceX96.Set(&nxtSqrtPriceX96).Eq(&sqrtPriceNextX96)
-		tickSpacingsCrossed := (kutils.Abs(tickNext-tick) - lo.Ternary(fullyCrossed, 1, 0)) / p.TickSpacing
-		wordCrossings := targetValue.SetUint64(uint64(max(1, (tickSpacingsCrossed+255)/256)))
+		crossedBonus := 0
+		if fullyCrossed {
+			crossedBonus = 1
+		}
+		tickSpacingsCrossed := (kutils.Abs(tickNext-tick) - crossedBonus) / p.TickSpacing
+		wordCrossings := sqrtPriceNextX96.SetUint64(uint64(max(1, (tickSpacingsCrossed+255)/256)))
 		if exactInput {
 			amountOut.SDiv(&amountOut, wordCrossings).Mul(&amountOut, wordCrossings)
 		} else {
-			amountIn.Add(&amountIn, wordCrossings).SubUint64(&amountIn, 1).SDiv(&amountIn, wordCrossings).Mul(&amountIn, wordCrossings)
+			amountIn.Add(&amountIn, wordCrossings).SubUint64(&amountIn, 1).SDiv(&amountIn, wordCrossings).Mul(&amountIn,
+				wordCrossings)
 		}
 
 		amountInPlusFee := feeAmount.Add(&amountIn, &feeAmount)
 		if exactInput {
-			amountSpecifiedRemaining.Sub(amountSpecifiedRemaining, (*int256.Int)(amountInPlusFee))
-			amountCalculated.Sub(amountCalculated, (*int256.Int)(&amountOut))
+			amountSpecifiedRemaining.Sub(&amountSpecifiedRemaining, amountInPlusFee)
+			amountCalculated.Sub(&amountCalculated, &amountOut)
 		} else {
-			amountSpecifiedRemaining.Add(amountSpecifiedRemaining, (*int256.Int)(&amountOut))
-			amountCalculated.Add(amountCalculated, (*int256.Int)(amountInPlusFee))
+			amountSpecifiedRemaining.Add(&amountSpecifiedRemaining, &amountOut)
+			amountCalculated.Add(&amountCalculated, amountInPlusFee)
 		}
 
 		if fullyCrossed {
 			if initialized {
 				t, err := getTick(p.Ticks, tickNext)
 				if err != nil {
-					return nil, err
+					return SwapResult{}, err
+				} else if zeroForOne {
+					liquidity.Sub(&liquidity, (*uint256.Int)(t.LiquidityNet))
+				} else {
+					liquidity.Add(&liquidity, (*uint256.Int)(t.LiquidityNet))
 				}
-				if lo.Ternary(zeroForOne, liquidity.Sub, liquidity.Add)(
-					liquidity, (*uint256.Int)(t.LiquidityNet)).Sign() < 0 {
-					return nil, errOverflowUint128
+				if liquidity.Sign() < 0 {
+					return SwapResult{}, errOverflowUint128
 				}
 				crossInitTickLoops++
 			}
-			tick = lo.Ternary(zeroForOne, tickNext-1, tickNext)
+			if zeroForOne {
+				tick = tickNext - 1
+			} else {
+				tick = tickNext
+			}
 		} else if !sqrtPriceX96.Eq(&sqrtPriceStartX96) {
-			if tick, err = GetTickAtSqrtRatio(sqrtPriceX96); err != nil {
-				return nil, err
+			if tick, err = GetTickAtSqrtRatio(&sqrtPriceX96); err != nil {
+				return SwapResult{}, err
 			}
 		}
 	}
 
-	return &SwapResult{
+	return SwapResult{
 		AmountCalculated:   amountCalculated,
 		SqrtRatioX96:       sqrtPriceX96,
 		Liquidity:          liquidity,
@@ -237,22 +232,17 @@ func validateList(ticks []TickU256, tickSpacing int) error {
 	if tickSpacing <= 0 {
 		return ErrZeroTickSpacing
 	}
-	for _, t := range ticks {
-		if t.Index%tickSpacing != 0 {
+	var sum uint256.Int
+	for i, t := range ticks {
+		if i > 0 && ticks[i-1].Index > ticks[i].Index {
+			return ErrSorted
+		} else if t.Index%tickSpacing != 0 {
 			return ErrInvalidTickSpacing
 		}
-	}
-	var sum int256.Int
-	for _, t := range ticks {
-		sum.Add(&sum, t.LiquidityNet)
+		sum.Add(&sum, (*uint256.Int)(t.LiquidityNet))
 	}
 	if !sum.IsZero() {
 		return ErrZeroNet
-	}
-	for i := 0; i < len(ticks)-1; i++ {
-		if ticks[i].Index > ticks[i+1].Index {
-			return ErrSorted
-		}
 	}
 	return nil
 }
@@ -282,51 +272,45 @@ func getTick(ticks []TickU256, index int) (TickU256, error) {
 	return ticks[idx], nil
 }
 
-func nextInitializedTick(ticks []TickU256, tick int, lte bool) (TickU256, error) {
+// nextInitializedTickPos returns the tick value, its slice index, initialized
+// flag, and any error.  The slice index lets the caller look up the
+// precomputed sqrtPrice in Pool.TickSqrtPrices without a second binary search.
+func nextInitializedTickPos(ticks []TickU256, tick int, lte bool) (tickVal, slicePos int, initialized bool, err error) {
 	if lte {
-		below, err := isBelowSmallest(ticks, tick)
-		if err != nil {
-			return TickU256{}, err
+		below, berr := isBelowSmallest(ticks, tick)
+		if berr != nil {
+			return 0, 0, false, berr
 		} else if below {
-			return TickU256{}, ErrBelowSmallest
+			return 0, 0, false, ErrBelowSmallest
 		}
-		above, err := isAtOrAboveLargest(ticks, tick)
-		if err != nil {
-			return TickU256{}, err
-		} else if above {
-			return ticks[len(ticks)-1], nil
+		last := len(ticks) - 1
+		if above, _ := isAtOrAboveLargest(ticks, tick); above {
+			t := &ticks[last]
+			return t.Index, last, !t.LiquidityGross.IsZero(), nil
 		}
-		idx, err := binarySearch(ticks, tick)
-		if err != nil {
-			return TickU256{}, err
-		}
-		return ticks[idx], nil
+		idx := binarySearchRaw(ticks, tick)
+		t := &ticks[idx]
+		return t.Index, idx, !t.LiquidityGross.IsZero(), nil
 	}
-	above, err := isAtOrAboveLargest(ticks, tick)
-	if err != nil {
-		return TickU256{}, err
+	if above, aerr := isAtOrAboveLargest(ticks, tick); aerr != nil {
+		return 0, 0, false, aerr
 	} else if above {
-		return TickU256{}, ErrAtOrAboveLargest
+		return 0, 0, false, ErrAtOrAboveLargest
 	}
-	below, err := isBelowSmallest(ticks, tick)
-	if err != nil {
-		return TickU256{}, err
-	} else if below {
-		return ticks[0], nil
+	if below, _ := isBelowSmallest(ticks, tick); below {
+		t := &ticks[0]
+		return t.Index, 0, !t.LiquidityGross.IsZero(), nil
 	}
-	idx, err := binarySearch(ticks, tick)
-	if err != nil {
-		return TickU256{}, err
-	}
-	return ticks[idx+1], nil
+	idx := binarySearchRaw(ticks, tick) + 1
+	t := &ticks[idx]
+	return t.Index, idx, !t.LiquidityGross.IsZero(), nil
 }
 
+// nextInitializedTickIndex is kept for callers outside of Swap that don't need
+// the slice position.
 func nextInitializedTickIndex(ticks []TickU256, tick int, lte bool) (int, bool, error) {
-	t, err := nextInitializedTick(ticks, tick, lte)
-	if err != nil {
-		return 0, false, err
-	}
-	return t.Index, !t.LiquidityGross.IsZero(), nil
+	tickVal, _, initialized, err := nextInitializedTickPos(ticks, tick, lte)
+	return tickVal, initialized, err
 }
 
 func binarySearch(ticks []TickU256, tick int) (int, error) {
@@ -336,19 +320,22 @@ func binarySearch(ticks []TickU256, tick int) (int, error) {
 	} else if below {
 		return 0, ErrBelowSmallest
 	}
+	return binarySearchRaw(ticks, tick), nil
+}
+
+// binarySearchRaw finds the index of the largest tick with Index <= tick.
+// Caller must guarantee tick >= ticks[0].Index (isBelowSmallest is false).
+func binarySearchRaw(ticks []TickU256, tick int) int {
 	start, end := 0, len(ticks)-1
 	for start <= end {
 		mid := (start + end) / 2
 		if ticks[mid].Index == tick {
-			return mid, nil
+			return mid
 		} else if ticks[mid].Index < tick {
 			start = mid + 1
 		} else {
 			end = mid - 1
 		}
 	}
-	if start < len(ticks) && ticks[start].Index < tick {
-		return start, nil
-	}
-	return start - 1, nil
+	return start - 1
 }

--- a/pkg/liquidity-source/uniswap/v3/math.go
+++ b/pkg/liquidity-source/uniswap/v3/math.go
@@ -122,13 +122,21 @@ func (p *Pool) Swap(zeroForOne bool, amountSpecified, sqrtPriceLimitX96 uint256.
 		}
 	}
 
-	exactInput := amountSpecified.Sign() >= 0
+	if len(p.Ticks) == 0 {
+		return SwapResult{
+			RemainingAmountIn: amountSpecified,
+			SqrtRatioX96:      p.SqrtRatioX96,
+			Liquidity:         p.Liquidity,
+			CurrentTick:       p.TickCurrent,
+		}, nil
+	}
 
 	amountSpecifiedRemaining := amountSpecified
-	var amountCalculated uint256.Int
 	sqrtPriceX96 := p.SqrtRatioX96
-	liquidity := p.Liquidity
 	tick := p.TickCurrent
+	liquidity := p.Liquidity
+	exactInput := amountSpecified.Sign() >= 0
+	var amountCalculated uint256.Int
 	var crossInitTickLoops int
 
 	for !amountSpecifiedRemaining.IsZero() && !sqrtPriceLimitX96.Eq(&sqrtPriceX96) {

--- a/pkg/liquidity-source/uniswap/v3/math_sdk.go
+++ b/pkg/liquidity-source/uniswap/v3/math_sdk.go
@@ -6,12 +6,14 @@ package uniswapv3
 
 import (
 	"errors"
+	"math"
 	"math/bits"
 	"slices"
 
-	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/kutils"
 	"github.com/holiman/uint256"
+
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
 // ---------- Fee constants (from constants/constants.go) ----------
@@ -47,12 +49,15 @@ const (
 )
 
 var (
-	MinSqrtRatioU256 = uint256.NewInt(4295128739)
-	MaxSqrtRatioU256 = uint256.MustFromDecimal("1461446703485210103287273052203988822378723970342")
-	q32U256          = uint256.NewInt(1 << 32)
-	q96U256          = new(uint256.Int).Exp(uint256.NewInt(2), uint256.NewInt(96))
-	maxUint256       = uint256.MustFromHex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-	uint160Max       = uint256.MustFromHex("0xffffffffffffffffffffffffffffffffffffffff")
+	MinSqrtRatioU256   = uint256.NewInt(4295128739)
+	MinSqrtRatioU256P1 = uint256.NewInt(4295128740)
+	MaxSqrtRatioU256P1 = uint256.MustFromDecimal("1461446703485210103287273052203988822378723970342")
+	MaxSqrtRatioU256   = uint256.MustFromDecimal("1461446703485210103287273052203988822378723970341")
+	MaxSqrtRatioU256M1 = uint256.MustFromDecimal("1461446703485210103287273052203988822378723970340")
+	q32U256            = uint256.NewInt(1 << 32)
+	q96U256            = new(uint256.Int).Exp(uint256.NewInt(2), uint256.NewInt(96))
+	maxUint256         = uint256.MustFromHex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	uint160Max         = uint256.MustFromHex("0xffffffffffffffffffffffffffffffffffffffff")
 )
 
 // ---------- Errors ----------
@@ -289,36 +294,14 @@ func DivRoundingUp(a, denominator, result *uint256.Int) {
 
 // ---------- Most significant bit (from utils/most_significant_bit.go) ----------
 
-type powerOf2 struct {
-	power uint
-	value *uint256.Int
-}
-
-var powersOf2 = []powerOf2{
-	{128, uint256.MustFromHex("0x100000000000000000000000000000000")},
-	{64, uint256.MustFromHex("0x10000000000000000")},
-	{32, uint256.MustFromHex("0x100000000")},
-	{16, uint256.MustFromHex("0x10000")},
-	{8, uint256.MustFromHex("0x100")},
-	{4, uint256.MustFromHex("0x10")},
-	{2, uint256.MustFromHex("0x4")},
-	{1, uint256.MustFromHex("0x2")},
-}
-
+// MostSignificantBit returns floor(log2(x)) for x > 0.
+// Equivalent to x.BitLen()-1 but expressed as the named helper the rest of
+// the package uses.
 func MostSignificantBit(x *uint256.Int) (uint, error) {
 	if x.IsZero() {
 		return 0, errInvalidInput
 	}
-	var tmpX uint256.Int
-	tmpX.Set(x)
-	var msb uint
-	for _, p := range powersOf2 {
-		if !tmpX.Lt(p.value) {
-			tmpX.Rsh(&tmpX, p.power)
-			msb += p.power
-		}
-	}
-	return msb, nil
+	return uint(x.BitLen()) - 1, nil
 }
 
 // ---------- Tick math (from utils/tick_math.go) ----------
@@ -424,58 +407,44 @@ func GetSqrtRatioAtTick(tick int, result *uint256.Int) error {
 	return nil
 }
 
-var (
-	magicSqrt10001 = int256.MustFromDec("255738958999603826347141")
-	magicTickLow   = int256.MustFromDec("3402992956809132418596140100660247210")
-	magicTickHigh  = int256.MustFromDec("291339464771989622907027621153398088495")
-)
+// invLog2Sqrt1_0001 converts log2 of a Q96 sqrt-price to tick space.
+// tick = log_{sqrt(1.0001)}(sqrtPX96/2^96) = log2(sqrtPX96/2^96) / log2(sqrt(1.0001))
+//
+//	= log2(sqrtPX96/2^96) × (2 / log2(1.0001))
+var invLog2Sqrt1_0001 = 2.0 / math.Log2(1.0001)
+
+const q96 = 0x1p96 // 2^96, the Q96 denominator
 
 func GetTickAtSqrtRatio(sqrtPX96 *uint256.Int) (int, error) {
 	if sqrtPX96.Lt(MinSqrtRatioU256) || !sqrtPX96.Lt(MaxSqrtRatioU256) {
 		return 0, errInvalidSqrtRatio
 	}
-	var sqrtPX128 uint256.Int
-	sqrtPX128.Lsh(sqrtPX96, 32)
-	msb, err := MostSignificantBit(&sqrtPX128)
-	if err != nil {
+
+	// Synthesize uint256 to float64. Valid sqrtPX96 fits in ≤161 bits (MaxSqrtRatio < 2^161),
+	// so sqrtPX96[3] == 0 for all valid inputs and is omitted. float64's 53-bit mantissa
+	// gives ~4e-12 tick precision — far below 1 tick — so the estimate needs at most a ±1
+	// correction, verified by at most two GetSqrtRatioAtTick calls.
+	sqrtF := float64(sqrtPX96[2])*0x1p128 + float64(sqrtPX96[1])*0x1p64 + float64(sqrtPX96[0])
+	tick := int(math.Floor(math.Log2(sqrtF/q96) * invLog2Sqrt1_0001))
+	// Float error can push tick one past the valid range; clamp before calling GetSqrtRatioAtTick.
+	if tick < MinTick {
+		tick = MinTick
+	} else if tick >= MaxTick {
+		tick = MaxTick - 1
+	}
+
+	// Verify and correct by at most 1 tick.
+	var sqrt uint256.Int
+	if err := GetSqrtRatioAtTick(tick, &sqrt); err != nil {
 		return 0, err
-	}
-	var r uint256.Int
-	if msb >= 128 {
-		r.Rsh(&sqrtPX128, msb-127)
-	} else {
-		r.Lsh(&sqrtPX128, 127-msb)
-	}
-
-	log2 := int256.NewInt(int64(msb - 128))
-	log2.Lsh(log2, 64)
-
-	var tmp, f uint256.Int
-	for i := range 14 {
-		tmp.Mul(&r, &r)
-		r.Rsh(&tmp, 127)
-		f.Rsh(&r, 128)
-		tmp.Lsh(&f, uint(63-i))
-		log2.Or(log2, (*int256.Int)(&tmp))
-		r.Rsh(&r, uint(f.Uint64()))
-	}
-
-	var logSqrt10001, tmp1, tmp2 int256.Int
-	logSqrt10001.Mul(log2, magicSqrt10001)
-	tickLow := tmp2.Rsh(tmp1.Sub(&logSqrt10001, magicTickLow), 128).Uint64()
-	tickHigh := tmp2.Rsh(tmp1.Add(&logSqrt10001, magicTickHigh), 128).Uint64()
-
-	if tickLow == tickHigh {
-		return int(tickLow), nil
-	}
-	var sqrtP uint256.Int
-	if err = GetSqrtRatioAtTick(int(tickHigh), &sqrtP); err != nil {
+	} else if sqrt.Gt(sqrtPX96) {
+		return tick - 1, nil
+	} else if err = GetSqrtRatioAtTick(tick+1, &sqrt); err != nil {
 		return 0, err
+	} else if !sqrt.Gt(sqrtPX96) {
+		return tick + 1, nil
 	}
-	if !sqrtP.Gt(sqrtPX96) {
-		return int(tickHigh), nil
-	}
-	return int(tickLow), nil
+	return tick, nil
 }
 
 // ---------- Sqrt price math (from utils/sqrtprice_math.go) ----------
@@ -523,11 +492,9 @@ func GetNextSqrtPriceFromInput(sqrtPX96 *uint256.Int, liquidity *uint256.Int, am
 	result *uint256.Int) error {
 	if sqrtPX96.Sign() <= 0 {
 		return errSqrtPriceLessThanZero
-	}
-	if liquidity.Sign() <= 0 {
+	} else if liquidity.Sign() <= 0 {
 		return errLiquidityLessThanZero
-	}
-	if zeroForOne {
+	} else if zeroForOne {
 		return getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true, result)
 	}
 	return getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true, result)
@@ -537,11 +504,9 @@ func GetNextSqrtPriceFromOutput(sqrtPX96 *uint256.Int, liquidity *uint256.Int, a
 	result *uint256.Int) error {
 	if sqrtPX96.Sign() <= 0 {
 		return errSqrtPriceLessThanZero
-	}
-	if liquidity.Sign() <= 0 {
+	} else if liquidity.Sign() <= 0 {
 		return errLiquidityLessThanZero
-	}
-	if zeroForOne {
+	} else if zeroForOne {
 		return getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false, result)
 	}
 	return getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false, result)
@@ -567,10 +532,7 @@ func getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96 *uint256.Int, liquidity *uin
 		DivRoundingUp(&numerator1, &tmp, result)
 		return nil
 	}
-	if !tmp.Div(&product, amount).Eq(sqrtPX96) {
-		return errInvariant
-	}
-	if !numerator1.Gt(&product) {
+	if !tmp.Div(&product, amount).Eq(sqrtPX96) || !numerator1.Gt(&product) {
 		return errInvariant
 	}
 	denominator.Sub(&numerator1, &product)
@@ -585,8 +547,7 @@ func getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96 *uint256.Int, liquidity *u
 			tmp.Lsh(amount, 96)
 			quotient.Div(&tmp, liquidity)
 		} else {
-			tmp.Mul(amount, q96U256)
-			quotient.Div(&tmp, liquidity)
+			u256.MulDivDown(&quotient, amount, q96U256, liquidity)
 		}
 		_, overflow := quotient.AddOverflow(&quotient, sqrtPX96)
 		if overflow {
@@ -601,8 +562,7 @@ func getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96 *uint256.Int, liquidity *u
 	var quotient uint256.Int
 	if err := MulDivRoundingUpV2(amount, q96U256, liquidity, &quotient); err != nil {
 		return err
-	}
-	if !sqrtPX96.Gt(&quotient) {
+	} else if !sqrtPX96.Gt(&quotient) {
 		return errInvariant
 	}
 	quotient.Sub(sqrtPX96, &quotient)
@@ -619,43 +579,38 @@ var maxFeeUint256 = uint256.NewInt(maxFeeInt)
 func ComputeSwapStep(
 	sqrtPCurrentX96, sqrtPTargetX96 *uint256.Int,
 	liquidity *uint256.Int,
-	amountRemaining *int256.Int,
+	amountRemaining *uint256.Int,
 	feePips FeeAmount,
 	sqrtPNextX96 *uint256.Int, amountIn, amountOut, feeAmount *uint256.Int,
 ) error {
 	zeroForOne := !sqrtPCurrentX96.Lt(sqrtPTargetX96)
 	exactIn := amountRemaining.Sign() >= 0
 
-	amountRemainingU := uint256.Int(*amountRemaining)
-	if !exactIn {
-		amountRemainingU.Neg(&amountRemainingU)
+	var amountRemainingU uint256.Int
+	if exactIn {
+		amountRemainingU.Set(amountRemaining)
+	} else {
+		amountRemainingU.Neg(amountRemaining)
 	}
 
 	var maxFeeMinusFeePips uint256.Int
 	maxFeeMinusFeePips.SetUint64(maxFeeInt - uint64(feePips))
 
 	if exactIn {
-		var amountRemainingLessFee, tmp uint256.Int
-		tmp.Mul(&amountRemainingU, &maxFeeMinusFeePips)
-		amountRemainingLessFee.Div(&tmp, maxFeeUint256)
 		if zeroForOne {
-			if err := GetAmount0DeltaV2(sqrtPTargetX96, sqrtPCurrentX96, liquidity, true,
-				amountIn); err != nil {
+			if err := GetAmount0DeltaV2(sqrtPTargetX96, sqrtPCurrentX96, liquidity, true, amountIn); err != nil {
 				return err
 			}
-		} else {
-			if err := GetAmount1DeltaV2(sqrtPCurrentX96, sqrtPTargetX96, liquidity, true,
-				amountIn); err != nil {
-				return err
-			}
+		} else if err := GetAmount1DeltaV2(sqrtPCurrentX96, sqrtPTargetX96, liquidity, true, amountIn); err != nil {
+			return err
 		}
+		var amountRemainingLessFee uint256.Int
+		u256.MulDivDown(&amountRemainingLessFee, &amountRemainingU, &maxFeeMinusFeePips, maxFeeUint256)
 		if !amountRemainingLessFee.Lt(amountIn) {
 			sqrtPNextX96.Set(sqrtPTargetX96)
-		} else {
-			if err := GetNextSqrtPriceFromInput(sqrtPCurrentX96, liquidity, &amountRemainingLessFee, zeroForOne,
-				sqrtPNextX96); err != nil {
-				return err
-			}
+		} else if err := GetNextSqrtPriceFromInput(sqrtPCurrentX96, liquidity, &amountRemainingLessFee, zeroForOne,
+			sqrtPNextX96); err != nil {
+			return err
 		}
 	} else {
 		if zeroForOne {
@@ -683,8 +638,7 @@ func ComputeSwapStep(
 			}
 		}
 		if !maxSqrt || exactIn {
-			if err := GetAmount1DeltaV2(sqrtPNextX96, sqrtPCurrentX96, liquidity, false,
-				amountOut); err != nil {
+			if err := GetAmount1DeltaV2(sqrtPNextX96, sqrtPCurrentX96, liquidity, false, amountOut); err != nil {
 				return err
 			}
 		}
@@ -695,8 +649,7 @@ func ComputeSwapStep(
 			}
 		}
 		if !maxSqrt || exactIn {
-			if err := GetAmount0DeltaV2(sqrtPCurrentX96, sqrtPNextX96, liquidity, false,
-				amountOut); err != nil {
+			if err := GetAmount0DeltaV2(sqrtPCurrentX96, sqrtPNextX96, liquidity, false, amountOut); err != nil {
 				return err
 			}
 		}
@@ -707,9 +660,12 @@ func ComputeSwapStep(
 	}
 	if exactIn && !sqrtPNextX96.Eq(sqrtPTargetX96) {
 		feeAmount.Sub(&amountRemainingU, amountIn)
-	} else if err := MulDivRoundingUpV2(amountIn, uint256.NewInt(uint64(feePips)), &maxFeeMinusFeePips,
-		feeAmount); err != nil {
-		return err
+	} else {
+		var feePipsU256 uint256.Int
+		feePipsU256.SetUint64(uint64(feePips))
+		if err := MulDivRoundingUpV2(amountIn, &feePipsU256, &maxFeeMinusFeePips, feeAmount); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/liquidity-source/uniswap/v3/math_test.go
+++ b/pkg/liquidity-source/uniswap/v3/math_test.go
@@ -18,10 +18,10 @@ func makeSmallPool(t *testing.T) *Pool {
 		{Index: -79320, LiquidityGross: uint256.MustFromDecimal("59713631504779700614879"), LiquidityNet: int256.MustFromDec("59713631504779700614879")},
 		{Index: 887220, LiquidityGross: uint256.MustFromDecimal("62905097377105506759002"), LiquidityNet: int256.MustFromDec("-62905097377105506759002")},
 	}
-	sqrtPrice, _ := uint256.FromDecimal("4082682361430349352208957440")
-	liquidity, _ := uint256.FromDecimal("461286494113032089234462")
+	sqrtPrice := uint256.MustFromDecimal("4082682361430349352208957440")
+	liquidity := uint256.MustFromDecimal("461286494113032089234462")
 
-	pool, err := NewPool(FeeAmount(3000), sqrtPrice, liquidity, -59315, ticks, 60)
+	pool, err := NewPool(FeeAmount(3000), *sqrtPrice, *liquidity, -59315, ticks, 60)
 	require.NoError(t, err)
 	return pool
 }
@@ -129,8 +129,8 @@ func TestNewPool(t *testing.T) {
 
 	// valid pool at tick 0: sqrtPrice must be between sqrtRatioAtTick(0) and sqrtRatioAtTick(1)
 	// sqrtRatioAtTick(0) = 79228162514264337593543950336 (Q96)
-	sqrtPrice, _ := uint256.FromDecimal("79228162514264337593543950336")
-	liquidity := uint256.NewInt(1e9)
+	sqrtPrice := *uint256.MustFromDecimal("79228162514264337593543950336")
+	liquidity := *uint256.NewInt(1e9)
 
 	p, err := NewPool(FeeMedium, sqrtPrice, liquidity, 0, ticks, 60)
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestNewPool(t *testing.T) {
 	require.ErrorIs(t, err, ErrFeeTooHigh)
 
 	// sqrtPrice out of range for tick
-	bad, _ := uint256.FromDecimal("1")
+	bad := *uint256.MustFromDecimal("1")
 	_, err = NewPool(FeeMedium, bad, liquidity, 0, ticks, 60)
 	require.ErrorIs(t, err, ErrInvalidSqrtRatioX96)
 }
@@ -154,17 +154,17 @@ func TestGetOutputAmountV2(t *testing.T) {
 	p := makeSmallPool(t)
 
 	// Swap 1 WETH (1e18) in as token1 (zeroForOne=false, token1→token0)
-	amountIn := new(int256.Int)
-	amountIn.SetFromBig(new(big.Int).Mul(big.NewInt(1), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)))
+	var amountIn uint256.Int
+	amountIn.SetFromBig(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 
 	// price limit: slightly above current sqrt price (going up, token1→token0)
 	priceLimit, _ := uint256.FromDecimal("1461446703485210103287273052203988822378723970341") // MaxSqrtRatio - 1
 
-	result, err := p.GetOutputAmountV2(amountIn, false, priceLimit)
+	res, err := p.GetOutputAmountV2(false, amountIn, *priceLimit)
 	require.NoError(t, err)
-	require.True(t, result.ReturnedAmount.Sign() > 0, "output must be positive")
-	require.NotNil(t, result.SqrtRatioX96)
-	require.NotNil(t, result.Liquidity)
+	require.True(t, res.AmountCalculated.Sign() > 0, "output must be positive")
+	require.NotNil(t, res.SqrtRatioX96)
+	require.NotNil(t, res.Liquidity)
 }
 
 // ---------- GetInputAmountV2 (exact output) ----------
@@ -174,28 +174,145 @@ func TestGetInputAmountV2(t *testing.T) {
 	p := makeSmallPool(t)
 
 	// We want exactly 1e15 of token0 out (zeroForOne=true, token0 output)
-	amountOut := new(int256.Int)
+	var amountOut uint256.Int
 	amountOut.SetFromBig(new(big.Int).Exp(big.NewInt(10), big.NewInt(15), nil))
 
 	priceLimit, _ := uint256.FromDecimal("4295128740") // MinSqrtRatio + 1
 
-	amountIn, newState, err := p.GetInputAmountV2(amountOut, true, priceLimit)
+	sr, err := p.GetInputAmountV2(true, amountOut, *priceLimit)
 	require.NoError(t, err)
-	require.True(t, amountIn.Sign() > 0, "input amount must be positive")
-	require.NotNil(t, newState)
-	require.NotNil(t, newState.SqrtRatioX96)
+	require.True(t, sr.AmountCalculated.Sign() > 0, "input amount must be positive")
+	require.NotNil(t, sr.SqrtRatioX96)
 
 	// Cross-check: feeding the computed amountIn back into GetOutputAmountV2 should yield
 	// approximately amountOut. Per-tick rounding in exactIn can reduce the output by up to
 	// ticksCrossed-1 units, so gotOut may be slightly less than requested.
 	priceLimit2, _ := uint256.FromDecimal("4295128740")
-	outResult, err := p.GetOutputAmountV2(amountIn, true, priceLimit2)
+	res, err := p.GetOutputAmountV2(true, sr.AmountCalculated, *priceLimit2)
 	require.NoError(t, err)
-	gotOut := outResult.ReturnedAmount.ToBig()
-	requested := amountOut.ToBig()
-	delta := new(big.Int).Sub(requested, gotOut) // positive if gotOut < requested
-	require.True(t, delta.Sign() >= 0 && delta.Cmp(new(big.Int).Rsh(requested, 10)) <= 0,
-		"round-trip: out(%s) too far from requested(%s)", gotOut, requested)
+	gotOut := res.AmountCalculated.ToBig()
+	requestedBI := amountOut.ToBig()
+	delta := new(big.Int).Sub(requestedBI, gotOut) // positive if gotOut < requested
+	require.True(t, delta.Sign() >= 0 && delta.Cmp(new(big.Int).Rsh(requestedBI, 10)) <= 0,
+		"round-trip: out(%s) too far from requested(%s)", gotOut, requestedBI)
+}
+
+// ---------- GetTickAtSqrtRatio ----------
+
+func TestGetTickAtSqrtRatio(t *testing.T) {
+	t.Parallel()
+
+	// ── error cases ──────────────────────────────────────────────────────────
+
+	t.Run("error: below min sqrt ratio", func(t *testing.T) {
+		var below uint256.Int
+		below.SubUint64(MinSqrtRatioU256, 1)
+		_, err := GetTickAtSqrtRatio(&below)
+		require.ErrorIs(t, err, errInvalidSqrtRatio)
+	})
+
+	t.Run("error: at max sqrt ratio", func(t *testing.T) {
+		_, err := GetTickAtSqrtRatio(MaxSqrtRatioU256)
+		require.ErrorIs(t, err, errInvalidSqrtRatio)
+	})
+
+	t.Run("error: zero", func(t *testing.T) {
+		_, err := GetTickAtSqrtRatio(new(uint256.Int))
+		require.ErrorIs(t, err, errInvalidSqrtRatio)
+	})
+
+	// ── known absolute values ─────────────────────────────────────────────────
+
+	t.Run("min sqrt ratio → MinTick", func(t *testing.T) {
+		tick, err := GetTickAtSqrtRatio(MinSqrtRatioU256)
+		require.NoError(t, err)
+		require.Equal(t, MinTick, tick)
+	})
+
+	t.Run("max valid sqrt ratio → MaxTick-1", func(t *testing.T) {
+		var maxValid uint256.Int
+		maxValid.SubUint64(MaxSqrtRatioU256, 1)
+		tick, err := GetTickAtSqrtRatio(&maxValid)
+		require.NoError(t, err)
+		require.Equal(t, MaxTick-1, tick)
+	})
+
+	t.Run("tick 0 sqrt price", func(t *testing.T) {
+		// sqrtRatioAtTick(0) = 2^96 exactly
+		sqrtP, _ := uint256.FromDecimal("79228162514264337593543950336")
+		tick, err := GetTickAtSqrtRatio(sqrtP)
+		require.NoError(t, err)
+		require.Equal(t, 0, tick)
+	})
+
+	// ── round-trip: GetTickAtSqrtRatio(GetSqrtRatioAtTick(t)) == t ───────────
+	// This exercises all three code paths (no correction, over-estimate, under-estimate).
+
+	t.Run("round-trip dense [-1000, 1000]", func(t *testing.T) {
+		for tick := -1000; tick <= 1000; tick++ {
+			var sqrtP uint256.Int
+			require.NoError(t, GetSqrtRatioAtTick(tick, &sqrtP))
+			got, err := GetTickAtSqrtRatio(&sqrtP)
+			require.NoError(t, err)
+			require.Equal(t, tick, got, "tick=%d", tick)
+		}
+	})
+
+	t.Run("round-trip near MinTick", func(t *testing.T) {
+		var sqrtP uint256.Int
+		require.NoError(t, GetSqrtRatioAtTick(MinTick, &sqrtP))
+		require.Equal(t, MinSqrtRatioU256, &sqrtP)
+		for tick := MinTick; tick <= MinTick+100; tick++ {
+			require.NoError(t, GetSqrtRatioAtTick(tick, &sqrtP))
+			got, err := GetTickAtSqrtRatio(&sqrtP)
+			require.NoError(t, err)
+			require.Equal(t, tick, got, "tick=%d", tick)
+		}
+	})
+
+	t.Run("round-trip near MaxTick", func(t *testing.T) {
+		var sqrtP uint256.Int
+		require.NoError(t, GetSqrtRatioAtTick(MaxTick, &sqrtP))
+		require.Equal(t, MaxSqrtRatioU256P1, &sqrtP)
+		for tick := MaxTick - 101; tick < MaxTick; tick++ {
+			require.NoError(t, GetSqrtRatioAtTick(tick, &sqrtP))
+			got, err := GetTickAtSqrtRatio(&sqrtP)
+			require.NoError(t, err)
+			require.Equal(t, tick, got, "tick=%d", tick)
+		}
+	})
+
+	t.Run("round-trip sparse full range", func(t *testing.T) {
+		for tick := MinTick; tick < MaxTick; tick += 1000 {
+			var sqrtP uint256.Int
+			require.NoError(t, GetSqrtRatioAtTick(tick, &sqrtP))
+			got, err := GetTickAtSqrtRatio(&sqrtP)
+			require.NoError(t, err)
+			require.Equal(t, tick, got, "tick=%d", tick)
+		}
+	})
+
+	// ── intermediate values: sqrtP strictly between consecutive ticks ─────────
+	// For tick t, if sqrtRatioAtTick(t)+1 < sqrtRatioAtTick(t+1), then
+	// sqrtRatioAtTick(t)+1 must also map to t.
+
+	t.Run("intermediate values", func(t *testing.T) {
+		testTicks := []int{MinTick, -200000, -1000, -1, 0, 1, 1000, 200000, MaxTick - 2}
+		for _, tick := range testTicks {
+			var sqrtLo, sqrtHi uint256.Int
+			require.NoError(t, GetSqrtRatioAtTick(tick, &sqrtLo))
+			require.NoError(t, GetSqrtRatioAtTick(tick+1, &sqrtHi))
+			var mid uint256.Int
+			mid.AddUint64(&sqrtLo, 1)
+			if !mid.Lt(&sqrtHi) {
+				// consecutive ticks share only one sqrtP value; nothing to test
+				continue
+			}
+			got, err := GetTickAtSqrtRatio(&mid)
+			require.NoError(t, err)
+			require.Equal(t, tick, got, "tick=%d mid=%s", tick, mid.Dec())
+		}
+	})
 }
 
 // ---------- getTick ----------

--- a/pkg/liquidity-source/uniswap/v3/math_test.go
+++ b/pkg/liquidity-source/uniswap/v3/math_test.go
@@ -163,8 +163,8 @@ func TestGetOutputAmountV2(t *testing.T) {
 	res, err := p.GetOutputAmountV2(false, amountIn, *priceLimit)
 	require.NoError(t, err)
 	require.True(t, res.AmountCalculated.Sign() > 0, "output must be positive")
-	require.NotNil(t, res.SqrtRatioX96)
-	require.NotNil(t, res.Liquidity)
+	require.False(t, res.SqrtRatioX96.IsZero(), "sqrt ratio must be non-zero")
+	require.False(t, res.Liquidity.IsZero(), "liquidity must be non-zero")
 }
 
 // ---------- GetInputAmountV2 (exact output) ----------
@@ -182,7 +182,7 @@ func TestGetInputAmountV2(t *testing.T) {
 	sr, err := p.GetInputAmountV2(true, amountOut, *priceLimit)
 	require.NoError(t, err)
 	require.True(t, sr.AmountCalculated.Sign() > 0, "input amount must be positive")
-	require.NotNil(t, sr.SqrtRatioX96)
+	require.False(t, sr.SqrtRatioX96.IsZero(), "sqrt ratio must be non-zero")
 
 	// Cross-check: feeding the computed amountIn back into GetOutputAmountV2 should yield
 	// approximately amountOut. Per-tick rounding in exactIn can reduce the output by up to
@@ -336,4 +336,43 @@ func TestGetTick(t *testing.T) {
 
 	_, err = getTick(ticks, 99)
 	require.Error(t, err)
+}
+
+// ---------- Swap with empty tick list (AllowEmptyTicks pools) ----------
+
+func TestSwapEmptyTicks(t *testing.T) {
+	t.Parallel()
+
+	// Pool at tick 0, sqrtPrice = sqrtRatioAtTick(0), no initialized ticks.
+	// This models a Uniswap V4 hook pool that manages liquidity outside the
+	// standard tick bitmap.
+	sqrtPrice := *uint256.MustFromDecimal("79228162514264337593543950336") // sqrtRatioAtTick(0)
+	liquidity := *uint256.MustFromDecimal("1000000000000000000")           // 1e18
+	p, err := NewPool(FeeMedium, sqrtPrice, liquidity, 0, nil, 60)
+	require.NoError(t, err)
+
+	amountIn := *uint256.MustFromDecimal("1000000000000") // 1e12
+
+	t.Run("exactInput zeroForOne", func(t *testing.T) {
+		res, err := p.GetOutputAmountV2(true, amountIn, uint256.Int{})
+		require.NoError(t, err)
+		require.True(t, res.AmountCalculated.IsZero(), "no output for empty-tick pool")
+		require.Equal(t, amountIn, res.RemainingAmountIn, "full input returned as remaining")
+		require.Equal(t, sqrtPrice, res.SqrtRatioX96, "price unchanged")
+	})
+
+	t.Run("exactInput !zeroForOne", func(t *testing.T) {
+		res, err := p.GetOutputAmountV2(false, amountIn, uint256.Int{})
+		require.NoError(t, err)
+		require.True(t, res.AmountCalculated.IsZero(), "no output for empty-tick pool")
+		require.Equal(t, amountIn, res.RemainingAmountIn, "full input returned as remaining")
+		require.Equal(t, sqrtPrice, res.SqrtRatioX96, "price unchanged")
+	})
+
+	t.Run("exactOutput zeroForOne", func(t *testing.T) {
+		amountOut := *uint256.MustFromDecimal("1000000000000")
+		res, err := p.GetInputAmountV2(true, amountOut, uint256.Int{})
+		require.NoError(t, err)
+		require.True(t, res.AmountCalculated.IsZero(), "no input computed for empty-tick pool")
+	})
 }

--- a/pkg/liquidity-source/uniswap/v3/pool_simulator.go
+++ b/pkg/liquidity-source/uniswap/v3/pool_simulator.go
@@ -1,14 +1,11 @@
 package uniswapv3
 
 import (
-	"fmt"
 	"math/big"
 
-	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/logger"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
-	"github.com/samber/lo"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
@@ -19,10 +16,12 @@ import (
 type PoolSimulator struct {
 	V3Pool *Pool
 	pool.Pool
-	Gas             Gas
-	tickMin         int
-	tickMax         int
-	allowEmptyTicks bool
+	Gas               Gas
+	tickMin           int
+	tickMax           int
+	sqrtPriceLimitMin uint256.Int // GetSqrtRatioAtTick(tickMin) + 1 for zeroForOne swaps
+	sqrtPriceLimitMax uint256.Int // GetSqrtRatioAtTick(tickMax) - 1 for oneForZero swaps
+	allowEmptyTicks   bool
 }
 
 var _ = pool.RegisterFactory1(DexTypeUniswapV3, NewPoolSimulator)
@@ -89,8 +88,8 @@ func NewPoolSimulatorWithExtra(entityPool entity.Pool,
 	}
 	v3Pool, err := NewPool(
 		FeeAmount(entityPool.SwapFee),
-		extra.SqrtPriceX96,
-		extra.Liquidity,
+		*extra.SqrtPriceX96,
+		*extra.Liquidity,
 		*extra.Tick,
 		v3Ticks,
 		tickSpacing,
@@ -105,7 +104,7 @@ func NewPoolSimulatorWithExtra(entityPool entity.Pool,
 		tickMax = v3Ticks[len(v3Ticks)-1].Index
 	}
 
-	return &PoolSimulator{
+	sim := &PoolSimulator{
 		Pool: pool.Pool{Info: pool.PoolInfo{
 			Address:  entityPool.Address,
 			SwapFee:  swapFee,
@@ -119,17 +118,25 @@ func NewPoolSimulatorWithExtra(entityPool entity.Pool,
 		tickMin:         tickMin,
 		tickMax:         tickMax,
 		allowEmptyTicks: cfg.AllowEmptyTicks,
-	}, nil
+	}
+	if err := GetSqrtRatioAtTick(tickMin, &sim.sqrtPriceLimitMin); err != nil {
+		return nil, err
+	}
+	sim.sqrtPriceLimitMin.AddUint64(&sim.sqrtPriceLimitMin, 1)
+	if err := GetSqrtRatioAtTick(tickMax, &sim.sqrtPriceLimitMax); err != nil {
+		return nil, err
+	}
+	sim.sqrtPriceLimitMax.SubUint64(&sim.sqrtPriceLimitMax, 1)
+	return sim, nil
 }
 
 // GetSqrtPriceLimit get the price limit of pool based on the initialized ticks that this pool has
-func (p *PoolSimulator) GetSqrtPriceLimit(zeroForOne bool, result *uint256.Int) error {
-	tickLimit := lo.Ternary(zeroForOne, p.tickMin, p.tickMax)
-	if err := GetSqrtRatioAtTick(tickLimit, result); err != nil {
-		return err
+func (p *PoolSimulator) GetSqrtPriceLimit(zeroForOne bool) *uint256.Int {
+	if zeroForOne {
+		return &p.sqrtPriceLimitMin
+	} else {
+		return &p.sqrtPriceLimitMax
 	}
-	lo.Ternary(zeroForOne, result.AddUint64, result.SubUint64)(result, 1)
-	return nil
 }
 
 func (p *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
@@ -144,21 +151,17 @@ func (p *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcA
 
 	zeroForOne := tokenInIndex == 0
 
-	var amountOutI256 int256.Int
-	if overflow := amountOutI256.SetFromBig(tokenAmountOut.Amount); overflow {
+	var amountOut uint256.Int
+	if overflow := amountOut.SetFromBig(tokenAmountOut.Amount); overflow {
 		return nil, ErrOverflow
 	}
 
-	var priceLimit uint256.Int
-	if err := p.GetSqrtPriceLimit(zeroForOne, &priceLimit); err != nil {
-		return nil, fmt.Errorf("can not GetSqrtPriceLimit, err: %+v", err)
-	}
-	amountIn, newPoolState, err := p.V3Pool.GetInputAmountV2(&amountOutI256, zeroForOne, &priceLimit)
+	result, err := p.V3Pool.GetInputAmountV2(zeroForOne, amountOut, uint256.Int{})
 	if err != nil {
 		return nil, err
 	}
 
-	amountInBI := amountIn.ToBig()
+	amountInBI := result.AmountCalculated.ToBig()
 	if !p.allowEmptyTicks {
 		if amountInBI.Sign() <= 0 {
 			return nil, ErrZeroAmount
@@ -166,18 +169,13 @@ func (p *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcA
 	}
 
 	return &pool.CalcAmountInResult{
-		TokenAmountIn: &pool.TokenAmount{
-			Token:  tokenIn,
-			Amount: amountInBI,
-		},
-		Fee: &pool.TokenAmount{
-			Token: tokenIn,
-		},
-		Gas: p.Gas.BaseGas, // TODO: update GetInputAmountV2 to return crossed tick if we ever need this
+		TokenAmountIn: &pool.TokenAmount{Token: tokenIn, Amount: amountInBI},
+		Fee:           &pool.TokenAmount{Token: tokenIn},
+		Gas:           p.Gas.BaseGas + p.Gas.CrossInitTickGas*int64(result.CrossInitTickLoops),
 		SwapInfo: SwapInfo{
-			NextStateSqrtRatioX96: newPoolState.SqrtRatioX96,
-			nextStateLiquidity:    newPoolState.Liquidity,
-			NextStateTickCurrent:  newPoolState.TickCurrent,
+			NextStateSqrtRatioX96: &result.SqrtRatioX96,
+			nextStateLiquidity:    result.Liquidity,
+			NextStateTickCurrent:  result.CurrentTick,
 		},
 	}, nil
 }
@@ -190,25 +188,18 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		return nil, ErrInvalidToken
 	}
 
-	var amountIn int256.Int
+	var amountIn uint256.Int
 	if overflow := amountIn.SetFromBig(tokenAmountIn.Amount); overflow {
 		return nil, ErrOverflow
 	}
 	zeroForOne := tokenInIndex == 0
-	var priceLimit uint256.Int
-	if err := p.GetSqrtPriceLimit(zeroForOne, &priceLimit); err != nil {
-		return nil, fmt.Errorf("can not GetSqrtPriceLimit, err: %+v", err)
-	}
-	amountOutResult, err := p.V3Pool.GetOutputAmountV2(&amountIn, zeroForOne, &priceLimit)
+	result, err := p.V3Pool.GetOutputAmountV2(zeroForOne, amountIn, uint256.Int{})
 	if err != nil {
 		return nil, err
-	}
-
-	amountOut := amountOutResult.ReturnedAmount
-	if !p.allowEmptyTicks && amountOut.Sign() <= 0 {
+	} else if !p.allowEmptyTicks && result.AmountCalculated.Sign() <= 0 {
 		return nil, ErrZeroAmount
 	}
-	amountOutBI := amountOut.ToBig()
+	amountOutBI := result.AmountCalculated.ToBig()
 	if amountOutBI.Cmp(p.GetReserves()[tokenOutIndex]) > 0 {
 		return nil, ErrInsufficientBalance
 	}
@@ -217,29 +208,19 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		Token:  tokenIn,
 		Amount: bignumber.ZeroBI,
 	}
-	if amountOutResult.RemainingAmountIn != nil {
-		if amountOutResult.RemainingAmountIn.Sign() == 0 {
-			amountOutResult.RemainingAmountIn = nil
-		} else {
-			remainingTokenAmountIn.Amount = amountOutResult.RemainingAmountIn.ToBig()
-		}
+	if !result.RemainingAmountIn.IsZero() {
+		remainingTokenAmountIn.Amount = result.RemainingAmountIn.ToBig()
 	}
 
 	return &pool.CalcAmountOutResult{
-		TokenAmountOut: &pool.TokenAmount{
-			Token:  tokenOut,
-			Amount: amountOutBI,
-		},
-		RemainingTokenAmountIn: remainingTokenAmountIn,
-		Fee: &pool.TokenAmount{
-			Token: tokenIn,
-		},
-		Gas: p.Gas.BaseGas + p.Gas.CrossInitTickGas*int64(amountOutResult.CrossInitTickLoops),
+		TokenAmountOut:         &pool.TokenAmount{Token: tokenOut, Amount: amountOutBI},
+		RemainingTokenAmountIn: remainingTokenAmountIn, Fee: &pool.TokenAmount{Token: tokenIn},
+		Gas: p.Gas.BaseGas + p.Gas.CrossInitTickGas*int64(result.CrossInitTickLoops),
 		SwapInfo: SwapInfo{
-			RemainingAmountIn:     amountOutResult.RemainingAmountIn,
-			NextStateSqrtRatioX96: amountOutResult.SqrtRatioX96,
-			nextStateLiquidity:    amountOutResult.Liquidity,
-			NextStateTickCurrent:  amountOutResult.CurrentTick,
+			RemainingAmountIn:     &result.RemainingAmountIn,
+			NextStateSqrtRatioX96: &result.SqrtRatioX96,
+			nextStateLiquidity:    result.Liquidity,
+			NextStateTickCurrent:  result.CurrentTick,
 		},
 	}, nil
 }
@@ -257,8 +238,8 @@ func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 		logger.Warn("failed to UpdateBalance for UniV3 pool, wrong swapInfo type")
 		return
 	}
-	p.V3Pool.SqrtRatioX96 = si.NextStateSqrtRatioX96
-	p.V3Pool.Liquidity = si.nextStateLiquidity
+	p.V3Pool.SqrtRatioX96.Set(si.NextStateSqrtRatioX96)
+	p.V3Pool.Liquidity.Set(&si.nextStateLiquidity)
 	p.V3Pool.TickCurrent = si.NextStateTickCurrent
 	tokenAmtIn, tokenAmtOut := params.TokenAmountIn, params.TokenAmountOut
 	if p.GetTokenIndex(tokenAmtIn.Token) == 0 {
@@ -271,10 +252,8 @@ func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 }
 
 func (p *PoolSimulator) GetMetaInfo(tokenIn string, _ string) any {
-	var priceLimit uint256.Int
-	_ = p.GetSqrtPriceLimit(tokenIn == p.Info.Tokens[0], &priceLimit)
 	return PoolMeta{
 		SwapFee:    uint32(p.Info.SwapFee.Int64()),
-		PriceLimit: &priceLimit,
+		PriceLimit: p.GetSqrtPriceLimit(tokenIn == p.Info.Tokens[0]),
 	}
 }

--- a/pkg/liquidity-source/uniswap/v3/pool_tracker.go
+++ b/pkg/liquidity-source/uniswap/v3/pool_tracker.go
@@ -26,6 +26,7 @@ import (
 	graphqlpkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/metrics"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/ticklens"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 var _ = pooltrack.RegisterFactoryCEG(DexTypeUniswapV3, NewTracker)
@@ -268,7 +269,7 @@ func (t *Tracker) computeTicksFromLogs(
 	affectedTickSet := make(map[int]struct{})
 
 	for _, event := range logs {
-		if len(event.Topics) == 0 || eth.IsZeroAddress(event.Address) {
+		if len(event.Topics) == 0 || valueobject.IsZeroAddress(event.Address) {
 			continue
 		}
 
@@ -437,7 +438,7 @@ func (t *Tracker) getAffectedTickIdsFromLogs(logs []ethtypes.Log) ([]int, error)
 	affectedTickIds := make(map[int]struct{})
 
 	for _, event := range logs {
-		if len(event.Topics) == 0 || eth.IsZeroAddress(event.Address) {
+		if len(event.Topics) == 0 || valueobject.IsZeroAddress(event.Address) {
 			continue
 		}
 
@@ -458,7 +459,7 @@ func (t *Tracker) getAffectedTickIdsFromLogs(logs []ethtypes.Log) ([]int, error)
 }
 
 func (t *Tracker) extractEventData(event ethtypes.Log) (int, int, *big.Int, error) {
-	if len(event.Topics) == 0 || eth.IsZeroAddress(event.Address) {
+	if len(event.Topics) == 0 || valueobject.IsZeroAddress(event.Address) {
 		return 0, 0, big.NewInt(0), nil
 	}
 
@@ -644,7 +645,7 @@ func (t *Tracker) BootstrapPoolState(ctx context.Context, p entity.Pool, _ poolp
 		// Link to issue: https://www.notion.so/kybernetwork/Aggregator-1-20-defect-1caec6062f9d4da0918fc3443e6e1963#0810d1462cc14f0a9465f935c9e641fe
 		// TLDR: Optimism has some pre-genesis Uniswap V3 pool. Subgraph does not have data for these pools
 		// So we have to fetch ticks data from the TickLens smart contract (which is slower).
-		if t.config.AlwaysUseTickLens || lo.Contains[string](t.config.preGenesisPoolIDs, p.Address) {
+		if t.config.AlwaysUseTickLens || lo.Contains(t.config.preGenesisPoolIDs, p.Address) {
 			poolTicks, err = ticklens.GetPoolTicksFromSC(ctx, t.ethrpcClient, t.config.TickLensAddress, p, nil)
 			if err != nil {
 				l.WithFields(logger.Fields{

--- a/pkg/liquidity-source/uniswap/v3/type.go
+++ b/pkg/liquidity-source/uniswap/v3/type.go
@@ -17,9 +17,9 @@ type Gas struct {
 }
 
 type SwapInfo struct {
-	RemainingAmountIn     *int256.Int  `json:"rAI,omitempty"`
+	RemainingAmountIn     *uint256.Int `json:"rAI,omitempty"`
 	NextStateSqrtRatioX96 *uint256.Int `json:"nSqrtRx96"`
-	nextStateLiquidity    *uint256.Int
+	nextStateLiquidity    uint256.Int
 	NextStateTickCurrent  int `json:"nT"`
 }
 

--- a/pkg/liquidity-source/uniswap/v4/pool_simulator.go
+++ b/pkg/liquidity-source/uniswap/v4/pool_simulator.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"slices"
 
-	v3Utils "github.com/KyberNetwork/uniswapv3-sdk-uint256/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
 
@@ -485,8 +484,6 @@ func (p *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {
 	if !p.staticExtra.IsNative[p.GetTokenIndex(tokenOutBeforeUnwrap)] {
 		tokenOutAddress = common.HexToAddress(tokenOutBeforeUnwrap)
 	}
-	var priceLimit v3Utils.Uint160
-	_ = p.GetSqrtPriceLimit(tokenInAfterWrap == p.Info.Tokens[0], &priceLimit)
 
 	return PoolMetaInfo{
 		Router:            p.staticExtra.UniversalRouterAddress,
@@ -497,7 +494,7 @@ func (p *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {
 		TickSpacing:       p.staticExtra.TickSpacing,
 		HookAddress:       p.staticExtra.HooksAddress,
 		HookData:          p.hook.GetHookData(),
-		PriceLimit:        &priceLimit,
+		PriceLimit:        p.GetSqrtPriceLimit(tokenInAfterWrap == p.Info.Tokens[0]),
 		TokenWrapMetadata: wrapMetadata,
 	}
 }


### PR DESCRIPTION
Refactor Uniswap V3 swap math to use uint256.Int values more pervasively, reduce pointer churn, and precompute per-tick sqrt prices for faster swap stepping.
Update GetTickAtSqrtRatio / MSB logic and expand tests + benchmarks for critical tick-math paths.
Adjust Uniswap V4 and Pancake Infinity CL meta info to use the updated UniV3 price-limit access pattern.