### PR TITLE
feat(umbrae): add Umbrae DLMM + DAMM liquidity sources (Base)

### DIFF
--- a/pkg/liquidity-source/umbrae-damm/abi.go
+++ b/pkg/liquidity-source/umbrae-damm/abi.go
@@ -1,0 +1,17 @@
+package umbraedamm
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var pairABI abi.ABI
+
+func init() {
+	var err error
+	pairABI, err = abi.JSON(bytes.NewReader(pairABIJson))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/liquidity-source/umbrae-damm/abi/DAMMPair.json
+++ b/pkg/liquidity-source/umbrae-damm/abi/DAMMPair.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "function",
+    "name": "tokenX",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "tokenY",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "getReserves",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      { "name": "reserveX", "type": "uint112" },
+      { "name": "reserveY", "type": "uint112" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "currentFeeBps",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint16" }]
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "getAmountOut",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "amountIn", "type": "uint256" },
+      { "name": "xToY", "type": "bool" }
+    ],
+    "outputs": [{ "name": "amountOut", "type": "uint256" }]
+  }
+]

--- a/pkg/liquidity-source/umbrae-damm/config.go
+++ b/pkg/liquidity-source/umbrae-damm/config.go
@@ -1,0 +1,8 @@
+package umbraedamm
+
+// Config drives the DAMM integration. DAMM has no factory/registry on-chain — each pair is a
+// standalone constant-product contract — so the set of pools is supplied explicitly.
+type Config struct {
+	DexID string   `json:"dexID"`
+	Pools []string `json:"pools"`
+}

--- a/pkg/liquidity-source/umbrae-damm/constant.go
+++ b/pkg/liquidity-source/umbrae-damm/constant.go
@@ -1,0 +1,33 @@
+package umbraedamm
+
+import (
+	"errors"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+const (
+	DexType = valueobject.ExchangeUmbraeDamm
+
+	// defaultGas is a conservative estimate for a single DAMM pair.swap() call.
+	defaultGas int64 = 125000
+
+	// feeDenominator mirrors the contract's FEE_DENOMINATOR (basis points).
+	feeDenominator = 10000
+
+	pairMethodTokenX        = "tokenX"
+	pairMethodTokenY        = "tokenY"
+	pairMethodGetReserves   = "getReserves"
+	pairMethodCurrentFeeBps = "currentFeeBps"
+	pairMethodFeeToken      = "feeToken"
+)
+
+var (
+	ErrInvalidToken          = errors.New("invalid token")
+	ErrInvalidReserve        = errors.New("invalid reserve")
+	ErrInvalidAmountIn       = errors.New("invalid amount in")
+	ErrInvalidAmountOut      = errors.New("invalid amount out")
+	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
+	ErrInsufficientInput     = errors.New("insufficient input amount")
+	ErrInsufficientOutput    = errors.New("insufficient output amount")
+)

--- a/pkg/liquidity-source/umbrae-damm/embed.go
+++ b/pkg/liquidity-source/umbrae-damm/embed.go
@@ -1,0 +1,6 @@
+package umbraedamm
+
+import _ "embed"
+
+//go:embed abi/DAMMPair.json
+var pairABIJson []byte

--- a/pkg/liquidity-source/umbrae-damm/math.go
+++ b/pkg/liquidity-source/umbrae-damm/math.go
@@ -1,0 +1,45 @@
+package umbraedamm
+
+import "github.com/holiman/uint256"
+
+var feeDenom = uint256.NewInt(feeDenominator)
+
+// cpQuote is the constant-product output, mirroring DAMMPairUpgradeable._quote:
+// out = floor(in * reserveOut / (reserveIn + in)).
+func cpQuote(in, reserveIn, reserveOut *uint256.Int) *uint256.Int {
+	var num, den uint256.Int
+	num.Mul(in, reserveOut)
+	den.Add(reserveIn, in)
+	return num.Div(&num, &den)
+}
+
+// getAmountOut mirrors DAMMPairUpgradeable.getAmountOut / swap exactly. The fee is ALWAYS charged
+// in feeToken: on the input when feeToken is the input side, otherwise on the output.
+//
+//	feeOnInput:  inAfterFee = amountIn - floor(amountIn*feeBps/FEE_DENOM); out = quote(inAfterFee)
+//	feeOnOutput: outFull = quote(amountIn); fee = floor(outFull*feeBps/FEE_DENOM); out = outFull - fee
+//
+// Returns amountOut, the fee (denominated in feeToken), and the reserve deltas: the amount that
+// joins reserveIn and the amount that leaves reserveOut (fees exit reserves into accumulators, so
+// K stays constant).
+func getAmountOut(amountIn, reserveIn, reserveOut, feeBps *uint256.Int, feeOnInput bool) (
+	amountOut, fee, reserveInDelta, reserveOutDelta *uint256.Int,
+) {
+	if feeOnInput {
+		fee = feeOf(amountIn, feeBps)
+		inAfterFee := new(uint256.Int).Sub(amountIn, fee)
+		amountOut = cpQuote(inAfterFee, reserveIn, reserveOut)
+		return amountOut, fee, inAfterFee, amountOut
+	}
+	outFull := cpQuote(amountIn, reserveIn, reserveOut)
+	fee = feeOf(outFull, feeBps)
+	amountOut = new(uint256.Int).Sub(outFull, fee)
+	return amountOut, fee, amountIn, outFull
+}
+
+// feeOf returns floor(amount * feeBps / FEE_DENOMINATOR).
+func feeOf(amount, feeBps *uint256.Int) *uint256.Int {
+	var f uint256.Int
+	f.Mul(amount, feeBps)
+	return f.Div(&f, feeDenom)
+}

--- a/pkg/liquidity-source/umbrae-damm/pool_list_updater.go
+++ b/pkg/liquidity-source/umbrae-damm/pool_list_updater.go
@@ -1,0 +1,86 @@
+package umbraedamm
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+	initialized  bool
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: cfg, ethrpcClient: ethrpcClient}
+}
+
+// GetNewPools discovers the configured DAMM pairs once. DAMM has no factory, so the pair set is
+// static and supplied via config. Reserves are left at 0 — the tracker fills them in.
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	if u.initialized {
+		return nil, metadataBytes, nil
+	}
+
+	logger.WithFields(logger.Fields{"dex_id": u.config.DexID}).Info("started getting new pools")
+
+	pools, err := u.initPools(ctx, u.config.Pools)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": u.config.DexID, "err": err}).Error("initPools failed")
+		return nil, metadataBytes, err
+	}
+
+	u.initialized = true
+	logger.WithFields(logger.Fields{"dex_id": u.config.DexID, "pools_len": len(pools)}).Info("finished getting new pools")
+
+	return pools, metadataBytes, nil
+}
+
+func (u *PoolsListUpdater) initPools(ctx context.Context, addresses []string) ([]entity.Pool, error) {
+	tokenX := make([]common.Address, len(addresses))
+	tokenY := make([]common.Address, len(addresses))
+
+	req := u.ethrpcClient.R().SetContext(ctx)
+	for i, addr := range addresses {
+		req.AddCall(&ethrpc.Call{
+			ABI:    pairABI,
+			Target: addr,
+			Method: pairMethodTokenX,
+		}, []any{&tokenX[i]}).AddCall(&ethrpc.Call{
+			ABI:    pairABI,
+			Target: addr,
+			Method: pairMethodTokenY,
+		}, []any{&tokenY[i]})
+	}
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+
+	pools := make([]entity.Pool, 0, len(addresses))
+	for i, addr := range addresses {
+		pools = append(pools, entity.Pool{
+			Address:   strings.ToLower(addr),
+			Exchange:  u.config.DexID,
+			Type:      DexType,
+			Timestamp: time.Now().Unix(),
+			Reserves:  entity.PoolReserves{"0", "0"},
+			Tokens: []*entity.PoolToken{
+				{Address: strings.ToLower(tokenX[i].Hex()), Swappable: true},
+				{Address: strings.ToLower(tokenY[i].Hex()), Swappable: true},
+			},
+			Extra: "{}",
+		})
+	}
+
+	return pools, nil
+}

--- a/pkg/liquidity-source/umbrae-damm/pool_simulator.go
+++ b/pkg/liquidity-source/umbrae-damm/pool_simulator.go
@@ -1,0 +1,136 @@
+package umbraedamm
+
+import (
+	"math/big"
+	"slices"
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+
+	// reserves[0] = reserveX, reserves[1] = reserveY, matching the pair's tokenX/tokenY order.
+	reserves []*uint256.Int
+	feeBps   *uint256.Int
+	feeToken string // lowercased; fee is always charged in this token
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(ep entity.Pool) (*PoolSimulator, error) {
+	var extra Extra
+	if err := json.Unmarshal([]byte(ep.Extra), &extra); err != nil {
+		return nil, err
+	}
+
+	reserves := make([]*uint256.Int, len(ep.Reserves))
+	for i, r := range ep.Reserves {
+		v, err := uint256.FromDecimal(r)
+		if err != nil {
+			return nil, ErrInvalidReserve
+		}
+		reserves[i] = v
+	}
+
+	return &PoolSimulator{
+		Pool: pool.Pool{Info: pool.PoolInfo{
+			Address:     ep.Address,
+			Exchange:    ep.Exchange,
+			Type:        ep.Type,
+			Tokens:      lo.Map(ep.Tokens, func(t *entity.PoolToken, _ int) string { return t.Address }),
+			Reserves:    lo.Map(ep.Reserves, func(r string, _ int) *big.Int { return bignumber.NewBig(r) }),
+			BlockNumber: ep.BlockNumber,
+		}},
+		reserves: reserves,
+		feeBps:   uint256.NewInt(extra.FeeBps),
+		feeToken: strings.ToLower(extra.FeeToken),
+	}, nil
+}
+
+func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	indexIn, indexOut := s.GetTokenIndex(param.TokenAmountIn.Token), s.GetTokenIndex(param.TokenOut)
+	if indexIn < 0 || indexOut < 0 {
+		return nil, ErrInvalidToken
+	}
+
+	amountIn, overflow := uint256.FromBig(param.TokenAmountIn.Amount)
+	if overflow || amountIn.Sign() <= 0 {
+		return nil, ErrInvalidAmountIn
+	}
+
+	reserveIn, reserveOut := s.reserves[indexIn], s.reserves[indexOut]
+	if reserveIn.IsZero() || reserveOut.IsZero() {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	// Fee is always charged in feeToken: on input when the input side is feeToken, else on output.
+	feeOnInput := strings.EqualFold(param.TokenAmountIn.Token, s.feeToken)
+	amountOut, fee, reserveInDelta, reserveOutDelta := getAmountOut(amountIn, reserveIn, reserveOut, s.feeBps, feeOnInput)
+
+	if amountOut.Sign() <= 0 {
+		return nil, ErrInsufficientOutput
+	}
+	if reserveOutDelta.Cmp(reserveOut) >= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	feeToken := param.TokenAmountIn.Token
+	if !feeOnInput {
+		feeToken = param.TokenOut
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: param.TokenOut, Amount: amountOut.ToBig()},
+		Fee:            &pool.TokenAmount{Token: feeToken, Amount: fee.ToBig()},
+		Gas:            defaultGas,
+		SwapInfo:       SwapInfo{ReserveInDelta: reserveInDelta.ToBig(), ReserveOutDelta: reserveOutDelta.ToBig()},
+	}, nil
+}
+
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	indexIn, indexOut := s.GetTokenIndex(params.TokenAmountIn.Token), s.GetTokenIndex(params.TokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 {
+		return
+	}
+
+	// Reserve deltas come from CalcAmountOut; fees exit reserves into accumulators, so reserveOut
+	// drops by the full pre-fee output and reserveIn rises by the post-fee input (K stays constant).
+	inDelta := params.TokenAmountIn.Amount
+	outDelta := params.TokenAmountOut.Amount
+	if si, ok := params.SwapInfo.(SwapInfo); ok {
+		if si.ReserveInDelta != nil {
+			inDelta = si.ReserveInDelta
+		}
+		if si.ReserveOutDelta != nil {
+			outDelta = si.ReserveOutDelta
+		}
+	}
+
+	// Reassign (copy-on-write) so cloned states never share these pointers.
+	s.reserves[indexIn] = new(uint256.Int).Add(s.reserves[indexIn], uint256.MustFromBig(inDelta))
+	s.reserves[indexOut] = new(uint256.Int).Sub(s.reserves[indexOut], uint256.MustFromBig(outDelta))
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.reserves = slices.Clone(s.reserves)
+	return &cloned
+}
+
+// GetApprovalAddress returns the pair itself: DAMM has no router — the user approves the pair and
+// calls pair.swap() directly.
+func (s *PoolSimulator) GetApprovalAddress(_, _ string) string {
+	return s.Info.Address
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return PoolMeta{BlockNumber: s.Info.BlockNumber}
+}

--- a/pkg/liquidity-source/umbrae-damm/pool_simulator_test.go
+++ b/pkg/liquidity-source/umbrae-damm/pool_simulator_test.go
@@ -1,0 +1,110 @@
+package umbraedamm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+const (
+	tokenX = "0x14a4e80d633af55ace1160c320f5a36d41cced3e" // U1
+	tokenY = "0x4200000000000000000000000000000000000006" // WETH (feeToken)
+)
+
+func newSim(t *testing.T, reserveX, reserveY string, feeBps uint64) *PoolSimulator {
+	t.Helper()
+	extra, _ := json.Marshal(Extra{FeeBps: feeBps, FeeToken: tokenY})
+	sim, err := NewPoolSimulator(entity.Pool{
+		Address:  "0x296964c34a571fcf85d3f74fb815ee871f5a08d4",
+		Exchange: DexType,
+		Type:     DexType,
+		Reserves: entity.PoolReserves{reserveX, reserveY},
+		Tokens:   []*entity.PoolToken{{Address: tokenX}, {Address: tokenY}},
+		Extra:    string(extra),
+	})
+	require.NoError(t, err)
+	return sim
+}
+
+func cpRef(in, rIn, rOut *big.Int) *big.Int {
+	return new(big.Int).Div(new(big.Int).Mul(in, rOut), new(big.Int).Add(rIn, in))
+}
+func feeRef(amt *big.Int, feeBps int64) *big.Int {
+	return new(big.Int).Div(new(big.Int).Mul(amt, big.NewInt(feeBps)), big.NewInt(feeDenominator))
+}
+
+// TestCalcAmountOut_FeeTokenModel verifies the deployed feeToken fee model: fee is always charged
+// in feeToken (WETH = tokenY) — on the input for Y->X, on the output for X->Y.
+func TestCalcAmountOut_FeeTokenModel(t *testing.T) {
+	rx, _ := new(big.Int).SetString("1000000000000000000000", 10)
+	ry, _ := new(big.Int).SetString("500000000000000000000", 10)
+	sim := newSim(t, rx.String(), ry.String(), 30)
+	amountIn, _ := new(big.Int).SetString("10000000000000000000", 10) // 10
+
+	// Y->X: feeToken (WETH) is the input -> fee on input.
+	resYX, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: amountIn}, TokenOut: tokenX,
+	})
+	require.NoError(t, err)
+	feeIn := feeRef(amountIn, 30)
+	wantYX := cpRef(new(big.Int).Sub(amountIn, feeIn), ry, rx)
+	require.Equal(t, wantYX, resYX.TokenAmountOut.Amount)
+	require.Equal(t, feeIn, resYX.Fee.Amount)
+	require.Equal(t, tokenY, resYX.Fee.Token) // fee always in feeToken
+
+	// X->Y: feeToken (WETH) is the output -> fee on output.
+	resXY, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: amountIn}, TokenOut: tokenY,
+	})
+	require.NoError(t, err)
+	outFull := cpRef(amountIn, rx, ry)
+	feeOut := feeRef(outFull, 30)
+	require.Equal(t, new(big.Int).Sub(outFull, feeOut), resXY.TokenAmountOut.Amount)
+	require.Equal(t, feeOut, resXY.Fee.Amount)
+	require.Equal(t, tokenY, resXY.Fee.Token)
+}
+
+// TestUpdateBalance_KConstant checks the reserve deltas: reserveOut drops by the full pre-fee
+// output, reserveIn rises by the post-fee input (fees exit into accumulators, K constant).
+func TestUpdateBalance_KConstant(t *testing.T) {
+	rx, _ := new(big.Int).SetString("1000000000000000000000", 10)
+	ry, _ := new(big.Int).SetString("500000000000000000000", 10)
+	sim := newSim(t, rx.String(), ry.String(), 30)
+	amountIn, _ := new(big.Int).SetString("10000000000000000000", 10)
+
+	// X->Y (fee on output): reserveX += amountIn; reserveY -= outFull.
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: amountIn}, TokenOut: tokenY,
+	})
+	require.NoError(t, err)
+
+	clone := sim.CloneState()
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenX, Amount: amountIn},
+		TokenAmountOut: pool.TokenAmount{Token: tokenY, Amount: res.TokenAmountOut.Amount},
+		Fee:            *res.Fee,
+		SwapInfo:       res.SwapInfo,
+	})
+
+	outFull := cpRef(amountIn, rx, ry)
+	require.Equal(t, new(big.Int).Add(rx, amountIn), sim.reserves[0].ToBig())
+	require.Equal(t, new(big.Int).Sub(ry, outFull), sim.reserves[1].ToBig())
+	require.Equal(t, rx, clone.GetReserves()[0]) // clone untouched
+}
+
+func TestCalcAmountOut_Errors(t *testing.T) {
+	sim := newSim(t, "1000000000000000000000", "500000000000000000000", 30)
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: "0xdead", Amount: big.NewInt(1)}, TokenOut: tokenY,
+	})
+	require.ErrorIs(t, err, ErrInvalidToken)
+	_, err = sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: big.NewInt(0)}, TokenOut: tokenY,
+	})
+	require.ErrorIs(t, err, ErrInvalidAmountIn)
+}

--- a/pkg/liquidity-source/umbrae-damm/pool_tracker.go
+++ b/pkg/liquidity-source/umbrae-damm/pool_tracker.go
@@ -1,0 +1,71 @@
+package umbraedamm
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(config *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
+	return &PoolTracker{config: config, ethrpcClient: ethrpcClient}
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	logger.WithFields(logger.Fields{"pool_id": p.Address}).Info("getting new pool state")
+
+	var (
+		reserves struct {
+			ReserveX *big.Int
+			ReserveY *big.Int
+		}
+		feeBps   uint16
+		feeToken common.Address
+	)
+
+	// Pin all reads to one block so reserves and the fee snapshot are consistent.
+	resp, err := t.ethrpcClient.R().SetContext(ctx).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetReserves}, []any{&reserves}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodCurrentFeeBps}, []any{&feeBps}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodFeeToken}, []any{&feeToken}).
+		TryBlockAndAggregate()
+	if err != nil {
+		return p, err
+	}
+
+	extraBytes, err := json.Marshal(Extra{
+		FeeBps:   uint64(feeBps),
+		FeeToken: strings.ToLower(feeToken.Hex()),
+	})
+	if err != nil {
+		return p, err
+	}
+
+	p.Extra = string(extraBytes)
+	p.Reserves = entity.PoolReserves{reserves.ReserveX.String(), reserves.ReserveY.String()}
+	p.BlockNumber = resp.BlockNumber.Uint64()
+	p.Timestamp = time.Now().Unix()
+
+	logger.WithFields(logger.Fields{"pool_id": p.Address}).Info("finished getting new pool state")
+	return p, nil
+}

--- a/pkg/liquidity-source/umbrae-damm/type.go
+++ b/pkg/liquidity-source/umbrae-damm/type.go
@@ -1,0 +1,28 @@
+package umbraedamm
+
+import "math/big"
+
+// Extra is the mutable per-pool state the tracker refreshes each block.
+//
+//   - FeeBps is the current dynamic fee in basis points, snapshotted from currentFeeBps(). The
+//     contract recomputes this from a volatility accumulator on every swap; KyberSwap re-tracks on
+//     new blocks, so the simulator prices against the snapshot — the value getAmountOut() uses at
+//     the tracked block.
+//   - FeeToken is the side the fee is always charged in (WETH on the U1/WETH pair). The fee is
+//     taken on the input when feeToken is the input side, otherwise on the output.
+type Extra struct {
+	FeeBps   uint64 `json:"feeBps"`
+	FeeToken string `json:"feeToken"`
+}
+
+// SwapInfo carries the pair-side reserve deltas from CalcAmountOut to UpdateBalance so the latter
+// never recomputes swap math. Fees exit reserves into accumulators (K stays constant), so the
+// reserve deltas differ from the user-facing in/out amounts.
+type SwapInfo struct {
+	ReserveInDelta  *big.Int `json:"-"`
+	ReserveOutDelta *big.Int `json:"-"`
+}
+
+type PoolMeta struct {
+	BlockNumber uint64 `json:"blockNumber"`
+}

--- a/pkg/liquidity-source/umbrae-damm/verification_test.go
+++ b/pkg/liquidity-source/umbrae-damm/verification_test.go
@@ -1,0 +1,106 @@
+package umbraedamm
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+// Canonical Base mainnet U1/WETH DAMM pair.
+const (
+	verifyPair     = "0x296964C34a571fCf85d3F74FB815ee871F5A08d4"
+	multicall3Base = "0xcA11bde05977b3631167028862bE2a173976CA11"
+)
+
+// TestVerifyAgainstChain compares the simulator's CalcAmountOut against the pair's getAmountOut.
+// Reserves, fee, and every getAmountOut probe are pinned to one block (getAmountOut recomputes the
+// dynamic fee live, so the snapshot only matches at the same block). Set UMBRAE_BASE_RPC_URL to run.
+func TestVerifyAgainstChain(t *testing.T) {
+	rpcURL := os.Getenv("UMBRAE_BASE_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("UMBRAE_BASE_RPC_URL not set; skipping live verification")
+	}
+	client := ethrpc.New(rpcURL).SetMulticallContract(common.HexToAddress(multicall3Base))
+	ctx := context.Background()
+
+	lister := NewPoolsListUpdater(&Config{DexID: DexType, Pools: []string{verifyPair}}, client)
+	pools, _, err := lister.GetNewPools(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, pools, 1)
+	tokenX := pools[0].Tokens[0].Address
+	tokenY := pools[0].Tokens[1].Address
+
+	amounts := []*big.Int{exp10(14), exp10(15), exp10(16), exp10(17), exp10(18)}
+	dirs := []bool{true, false}
+
+	var (
+		reserves struct{ ReserveX, ReserveY *big.Int }
+		feeBps   uint16
+		feeToken common.Address
+	)
+	chainOuts := make([]*big.Int, len(amounts)*len(dirs))
+	req := client.R().SetContext(ctx).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodGetReserves}, []any{&reserves}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodCurrentFeeBps}, []any{&feeBps}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodFeeToken}, []any{&feeToken})
+	i := 0
+	for _, xToY := range dirs {
+		for _, amt := range amounts {
+			req.AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: "getAmountOut", Params: []any{amt, xToY}}, []any{&chainOuts[i]})
+			i++
+		}
+	}
+	_, err = req.TryBlockAndAggregate()
+	require.NoError(t, err)
+	t.Logf("DAMM same-block: reservesX=%s reservesY=%s feeBps=%d feeToken=%s", reserves.ReserveX, reserves.ReserveY, feeBps, feeToken.Hex())
+
+	extraBytes, _ := json.Marshal(Extra{FeeBps: uint64(feeBps), FeeToken: strings.ToLower(feeToken.Hex())})
+	ep := pools[0]
+	ep.Reserves = entity.PoolReserves{reserves.ReserveX.String(), reserves.ReserveY.String()}
+	ep.Extra = string(extraBytes)
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	var total, matched, idx int
+	for _, xToY := range dirs {
+		tokenIn, tokenOut := tokenX, tokenY
+		if !xToY {
+			tokenIn, tokenOut = tokenY, tokenX
+		}
+		for _, amt := range amounts {
+			chainOut := chainOuts[idx]
+			idx++
+			var simOut *big.Int = big.NewInt(0)
+			res, serr := sim.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{Token: tokenIn, Amount: amt}, TokenOut: tokenOut,
+			})
+			if serr == nil {
+				simOut = res.TokenAmountOut.Amount
+			}
+			total++
+			ok := chainOut.Cmp(simOut) == 0
+			if ok {
+				matched++
+			}
+			dir := "X->Y"
+			if !xToY {
+				dir = "Y->X"
+			}
+			t.Logf("%s in=%-22s | chain=%-24s sim=%-24s match=%v", dir, amt, chainOut, simOut, ok)
+		}
+	}
+	t.Logf("MATCHED %d/%d", matched, total)
+	require.Equal(t, total, matched, "simulator diverged from on-chain getAmountOut")
+}
+
+func exp10(n uint) *big.Int { return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(n)), nil) }

--- a/pkg/liquidity-source/umbrae-dlmm/abi.go
+++ b/pkg/liquidity-source/umbrae-dlmm/abi.go
@@ -1,0 +1,30 @@
+package umbraedlmm
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	pairABI    abi.ABI
+	factoryABI abi.ABI
+	viewerABI  abi.ABI
+)
+
+func init() {
+	for _, b := range []struct {
+		abi  *abi.ABI
+		data []byte
+	}{
+		{&pairABI, pairABIJson},
+		{&factoryABI, factoryABIJson},
+		{&viewerABI, viewerABIJson},
+	} {
+		parsed, err := abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+		*b.abi = parsed
+	}
+}

--- a/pkg/liquidity-source/umbrae-dlmm/abi/LBFactory.json
+++ b/pkg/liquidity-source/umbrae-dlmm/abi/LBFactory.json
@@ -1,0 +1,16 @@
+[
+  { "type": "function", "name": "allPairsLength", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "uint256" }] },
+  {
+    "type": "function", "name": "allPairs", "stateMutability": "view",
+    "inputs": [{ "name": "index", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function", "name": "getVariableFeeCap", "stateMutability": "view",
+    "inputs": [
+      { "name": "binStep", "type": "uint16" },
+      { "name": "baseFee", "type": "uint16" }
+    ],
+    "outputs": [{ "name": "variableFeeCap", "type": "uint16" }]
+  }
+]

--- a/pkg/liquidity-source/umbrae-dlmm/abi/LBPair.json
+++ b/pkg/liquidity-source/umbrae-dlmm/abi/LBPair.json
@@ -1,0 +1,95 @@
+[
+  { "type": "function", "name": "tokenX", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "address" }] },
+  { "type": "function", "name": "tokenY", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "address" }] },
+  { "type": "function", "name": "binStep", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "uint16" }] },
+  {
+    "type": "function", "name": "getDecimals", "stateMutability": "view", "inputs": [],
+    "outputs": [
+      { "name": "decimalsX", "type": "uint8" },
+      { "name": "decimalsY", "type": "uint8" }
+    ]
+  },
+  { "type": "function", "name": "getActiveId", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "uint24" }] },
+  {
+    "type": "function", "name": "getQuoteState", "stateMutability": "view", "inputs": [],
+    "outputs": [
+      {
+        "name": "feeParams", "type": "tuple",
+        "components": [
+          { "name": "baseFactor", "type": "uint16" },
+          { "name": "filterPeriod", "type": "uint16" },
+          { "name": "decayPeriod", "type": "uint16" },
+          { "name": "reductionFactor", "type": "uint16" },
+          { "name": "variableFeeControl", "type": "uint16" },
+          { "name": "maxVolatilityAccumulator", "type": "uint24" },
+          { "name": "minSwapBps", "type": "uint16" }
+        ]
+      },
+      { "name": "volatilityAccumulator", "type": "uint128" },
+      { "name": "volatilityReference", "type": "uint24" },
+      { "name": "lastVolatilityUpdate", "type": "uint40" },
+      { "name": "scaleX", "type": "uint256" },
+      { "name": "scaleY", "type": "uint256" },
+      { "name": "factory", "type": "address" }
+    ]
+  },
+  {
+    "type": "function", "name": "getPairStatistics", "stateMutability": "view", "inputs": [],
+    "outputs": [
+      { "name": "activeId", "type": "uint24" },
+      { "name": "reserveX", "type": "uint128" },
+      { "name": "reserveY", "type": "uint128" },
+      { "name": "protocolFeesX", "type": "uint128" },
+      { "name": "protocolFeesY", "type": "uint128" },
+      { "name": "volatility", "type": "uint128" },
+      { "name": "lastUpdateTimestamp", "type": "uint40" }
+    ]
+  },
+  {
+    "type": "function", "name": "getReserves", "stateMutability": "view", "inputs": [],
+    "outputs": [
+      { "name": "reserveX", "type": "uint128" },
+      { "name": "reserveY", "type": "uint128" }
+    ]
+  },
+  {
+    "type": "function", "name": "getBin", "stateMutability": "view",
+    "inputs": [{ "name": "id", "type": "uint24" }],
+    "outputs": [
+      { "name": "reserveX", "type": "uint128" },
+      { "name": "reserveY", "type": "uint128" }
+    ]
+  },
+  {
+    "type": "function", "name": "getFeeParameters", "stateMutability": "view", "inputs": [],
+    "outputs": [
+      {
+        "name": "", "type": "tuple",
+        "components": [
+          { "name": "baseFactor", "type": "uint16" },
+          { "name": "filterPeriod", "type": "uint16" },
+          { "name": "decayPeriod", "type": "uint16" },
+          { "name": "reductionFactor", "type": "uint16" },
+          { "name": "variableFeeControl", "type": "uint16" },
+          { "name": "protocolShare", "type": "uint16" },
+          { "name": "maxVolatilityAccumulator", "type": "uint24" },
+          { "name": "minSwapBps", "type": "uint16" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "function", "name": "quoteSwap", "stateMutability": "view",
+    "inputs": [
+      { "name": "swapForY", "type": "bool" },
+      { "name": "amountIn", "type": "uint256" }
+    ],
+    "outputs": [
+      { "name": "amountOut", "type": "uint256" },
+      { "name": "consumedAmountIn", "type": "uint256" },
+      { "name": "finalBinId", "type": "uint24" },
+      { "name": "binsTraversed", "type": "uint256" },
+      { "name": "totalFee", "type": "uint256" }
+    ]
+  }
+]

--- a/pkg/liquidity-source/umbrae-dlmm/abi/PairViewer.json
+++ b/pkg/liquidity-source/umbrae-dlmm/abi/PairViewer.json
@@ -1,0 +1,41 @@
+[
+  {
+    "type": "function", "name": "quoteSwap", "stateMutability": "view",
+    "inputs": [
+      { "name": "pair", "type": "address" },
+      { "name": "swapForY", "type": "bool" },
+      { "name": "amountIn", "type": "uint256" }
+    ],
+    "outputs": [
+      { "name": "amountOut", "type": "uint256" },
+      { "name": "consumedAmountIn", "type": "uint256" },
+      { "name": "finalBinId", "type": "uint24" },
+      { "name": "binsTraversed", "type": "uint256" },
+      { "name": "totalFee", "type": "uint256" }
+    ]
+  },
+  {
+    "type": "function", "name": "getActiveBinsWithReserves", "stateMutability": "view",
+    "inputs": [{ "name": "pair", "type": "address" }],
+    "outputs": [
+      { "name": "binIds", "type": "uint24[]" },
+      { "name": "reservesX", "type": "uint128[]" },
+      { "name": "reservesY", "type": "uint128[]" },
+      { "name": "totalShares", "type": "uint256[]" }
+    ]
+  },
+  {
+    "type": "function", "name": "getBinsInRange", "stateMutability": "view",
+    "inputs": [
+      { "name": "pair", "type": "address" },
+      { "name": "startId", "type": "uint24" },
+      { "name": "endId", "type": "uint24" }
+    ],
+    "outputs": [
+      { "name": "binIds", "type": "uint24[]" },
+      { "name": "reservesX", "type": "uint128[]" },
+      { "name": "reservesY", "type": "uint128[]" },
+      { "name": "totalShares", "type": "uint256[]" }
+    ]
+  }
+]

--- a/pkg/liquidity-source/umbrae-dlmm/config.go
+++ b/pkg/liquidity-source/umbrae-dlmm/config.go
@@ -1,0 +1,12 @@
+package umbraedlmm
+
+// Config drives DLMM discovery and tracking.
+//   - BinWindow overrides how many bins on each side of the active bin the tracker samples
+//     (0 -> defaultBinWindow).
+type Config struct {
+	DexID          string `json:"dexID"`
+	FactoryAddress string `json:"factoryAddress"`
+	ViewerAddress  string `json:"viewerAddress"` // PairViewer: fronts bins/quotes (the pair routes them to an extension)
+	RouterAddress  string `json:"routerAddress"` // DLMM Router: the swap entry point and token spender (the pair reverts on direct calls)
+	NewPoolLimit   int    `json:"newPoolLimit"`
+}

--- a/pkg/liquidity-source/umbrae-dlmm/constant.go
+++ b/pkg/liquidity-source/umbrae-dlmm/constant.go
@@ -1,0 +1,45 @@
+package umbraedlmm
+
+import (
+	"errors"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+const (
+	DexType = valueobject.ExchangeUmbraeDlmm
+
+	// defaultGas is a base cost; per-bin traversal adds gasPerBin.
+	defaultGas int64 = 180000
+	gasPerBin  int64 = 12000
+
+	// activeBinID is the 1:1 centre bin (2^23) — the price exponent's zero point.
+	activeBinID uint32 = 8388608
+
+	// Fee/price precision constants (mirror FeeHelper / BinHelper).
+	basisPoints = 10000
+	maxFeeBps   = 500 // FeeHelper.MAX_FEE — 5% total fee cap
+
+	factoryMethodAllPairs          = "allPairs"
+	factoryMethodAllPairsLength    = "allPairsLength"
+	factoryMethodGetVariableFeeCap = "getVariableFeeCap"
+
+	pairMethodTokenX            = "tokenX"
+	pairMethodTokenY            = "tokenY"
+	pairMethodBinStep           = "binStep"
+	pairMethodGetDecimals       = "getDecimals"
+	pairMethodGetActiveID       = "getActiveId"
+	pairMethodGetQuoteState     = "getQuoteState"
+	pairMethodGetPairStatistics = "getPairStatistics"
+
+	viewerMethodActiveBins = "getActiveBinsWithReserves"
+	viewerMethodQuoteSwap  = "quoteSwap"
+)
+
+var (
+	ErrInvalidToken       = errors.New("invalid token")
+	ErrInvalidReserve     = errors.New("invalid reserve")
+	ErrInvalidAmountIn    = errors.New("invalid amount in")
+	ErrInsufficientOutput = errors.New("insufficient output amount")
+	ErrInvalidPrice       = errors.New("invalid bin price")
+)

--- a/pkg/liquidity-source/umbrae-dlmm/embed.go
+++ b/pkg/liquidity-source/umbrae-dlmm/embed.go
@@ -1,0 +1,12 @@
+package umbraedlmm
+
+import _ "embed"
+
+//go:embed abi/LBPair.json
+var pairABIJson []byte
+
+//go:embed abi/LBFactory.json
+var factoryABIJson []byte
+
+//go:embed abi/PairViewer.json
+var viewerABIJson []byte

--- a/pkg/liquidity-source/umbrae-dlmm/math.go
+++ b/pkg/liquidity-source/umbrae-dlmm/math.go
@@ -1,0 +1,177 @@
+package umbraedlmm
+
+import "github.com/holiman/uint256"
+
+// Shared constants. These are read-only after init; never mutate them in place.
+var (
+	e18     = uint256.NewInt(1_000_000_000_000_000_000)
+	e10     = uint256.NewInt(10_000_000_000)
+	uMaxU   = new(uint256.Int).Not(uint256.NewInt(0)) // 2^256 - 1, the overflow cap value
+	uBP     = uint256.NewInt(basisPoints)
+	uMaxFee = uint256.NewInt(maxFeeBps)
+)
+
+// pow10 returns 10^n as a uint256.
+func pow10(n uint8) *uint256.Int {
+	return new(uint256.Int).Exp(uint256.NewInt(10), uint256.NewInt(uint64(n)))
+}
+
+// getNormalizedPriceFromId computes (1 + binStep/10000)^(binId-ACTIVE_BIN) in 1e18 fixed point,
+// mirroring the DEPLOYED BinHelper.getPriceFromId exactly: plain 1e18 exponentiation-by-squaring
+// (base = numerator*1e18/denominator; result = result*base/1e18; base = base*base/1e18), including
+// the saturate-on-overflow guard. (Note: this is NOT the 128.128 algorithm in the stale source.)
+func getNormalizedPriceFromId(binID uint32, binStep uint16) *uint256.Int {
+	exponent := int64(binID) - int64(activeBinID)
+	if exponent == 0 {
+		return new(uint256.Int).Set(e18)
+	}
+
+	absExp := uint64(exponent)
+	if exponent < 0 {
+		absExp = uint64(-exponent)
+	}
+	var numerator, denominator uint64
+	if exponent > 0 {
+		numerator, denominator = basisPoints+uint64(binStep), basisPoints
+	} else {
+		numerator, denominator = basisPoints, basisPoints+uint64(binStep)
+	}
+
+	result := new(uint256.Int).Set(e18)
+	base := new(uint256.Int).Mul(uint256.NewInt(numerator), e18)
+	base.Div(base, uint256.NewInt(denominator))
+
+	for absExp > 0 {
+		if absExp&1 == 1 {
+			result = mulDiv1e18Capped(result, base)
+		}
+		base = mulDiv1e18Capped(base, base)
+		absExp >>= 1
+	}
+	return result
+}
+
+// mulDiv1e18Capped returns floor(a*b/1e18), saturating to 2^256-1 on overflow (matching the
+// deployed `result > type(uint256).max / base` guard). For bins within the tradable range this
+// never saturates, but it is replicated for exactness.
+func mulDiv1e18Capped(a, b *uint256.Int) *uint256.Int {
+	if !b.IsZero() {
+		var lim uint256.Int
+		lim.Div(uMaxU, b)
+		if a.Cmp(&lim) > 0 {
+			return new(uint256.Int).Set(uMaxU)
+		}
+	}
+	r := new(uint256.Int).Mul(a, b)
+	return r.Div(r, e18)
+}
+
+// getPriceFromId returns the bin price in Y native decimals (Y per 1 whole X), mirroring the
+// deployed BinHelper.getPriceFromId.
+func getPriceFromId(binID uint32, binStep uint16, decimalsY uint8) (*uint256.Int, error) {
+	normalized := getNormalizedPriceFromId(binID, binStep)
+	if decimalsY <= 18 {
+		return new(uint256.Int).Div(normalized, pow10(18-decimalsY)), nil
+	}
+	return new(uint256.Int).Mul(normalized, pow10(decimalsY-18)), nil
+}
+
+// calculateDynamicFee mirrors the DEPLOYED FeeHelper.calculateDynamicFee: baseFee + quadratic
+// variable fee (capped at variableFeeCap when nonzero), total capped at MAX_FEE. Returns the fee
+// rate in basis points.
+func calculateDynamicFee(baseFactor, variableFeeControl uint16, volatility *uint256.Int, binStep, variableFeeCap uint16) *uint256.Int {
+	totalFee := uint256.NewInt(uint64(baseFactor))
+	if variableFeeControl != 0 {
+		prod := new(uint256.Int).Mul(volatility, uint256.NewInt(uint64(binStep)))
+		prod.Mul(prod, prod)
+		prod.Mul(prod, uint256.NewInt(uint64(variableFeeControl)))
+		prod.Div(prod, e10)
+		if variableFeeCap > 0 {
+			cap := uint256.NewInt(uint64(variableFeeCap))
+			if prod.Cmp(cap) > 0 {
+				prod = cap
+			}
+		}
+		totalFee.Add(totalFee, prod)
+	}
+	if totalFee.Cmp(uMaxFee) > 0 {
+		return new(uint256.Int).Set(uMaxFee)
+	}
+	return totalFee
+}
+
+// applyVolatilityDecay mirrors FeeHelper.applyVolatilityDecay: linear decay over decayPeriod, with
+// a floor of 1 to avoid premature rounding to 0. Used by the tracker to decay the accumulator to
+// the tracked block.
+func applyVolatilityDecay(volatility uint64, timeDelta, decayPeriod uint64) uint64 {
+	if decayPeriod == 0 || timeDelta >= decayPeriod {
+		return 0
+	}
+	decayed := volatility * (decayPeriod - timeDelta) / decayPeriod
+	if decayed == 0 && volatility > 0 {
+		return 1
+	}
+	return decayed
+}
+
+// getFeeAmountFrom mirrors FeeHelper.getFeeAmountFrom: amount * totalFee / (10000 + totalFee).
+func getFeeAmountFrom(amount, totalFee *uint256.Int) *uint256.Int {
+	var num, den uint256.Int
+	num.Mul(amount, totalFee)
+	den.Add(uBP, totalFee)
+	return num.Div(&num, &den)
+}
+
+// protocolFeeFromTotal mirrors FeeHelper.calculateFeeDistribution's protocol portion (ceil).
+func protocolFeeFromTotal(totalFee *uint256.Int, protocolShare uint16) *uint256.Int {
+	var pf uint256.Int
+	pf.Mul(totalFee, uint256.NewInt(uint64(protocolShare)))
+	pf.Add(&pf, uint256.NewInt(basisPoints-1))
+	pf.Div(&pf, uBP)
+	if pf.Cmp(totalFee) > 0 {
+		return new(uint256.Int).Set(totalFee)
+	}
+	return pf.Clone()
+}
+
+// simulateBinSwap mirrors UmbraeLBPairUpgradeable._simulateBinSwap. All amounts are in the
+// 18-decimal normalized space. binReserveOut is the output-side reserve of the bin (reserveY when
+// swapForY, else reserveX).
+func simulateBinSwap(
+	binReserveOut, amountInNormalized, price, precisionX, scaleIn, scaleOut *uint256.Int,
+	swapForY bool,
+) (amountOutNormalized, amountInLeftNormalized *uint256.Int) {
+	amountInNative := new(uint256.Int).Div(amountInNormalized, scaleIn)
+
+	maxAmountOutNative := new(uint256.Int)
+	if swapForY {
+		maxAmountOutNative.Mul(amountInNative, price)
+		maxAmountOutNative.Div(maxAmountOutNative, precisionX)
+	} else {
+		maxAmountOutNative.Mul(amountInNative, precisionX)
+		maxAmountOutNative.Div(maxAmountOutNative, price)
+	}
+	maxAmountOut := new(uint256.Int).Mul(maxAmountOutNative, scaleOut)
+
+	if maxAmountOut.Cmp(binReserveOut) <= 0 {
+		return maxAmountOut, uint256.NewInt(0)
+	}
+
+	// Bin depleted: output capped at the bin reserve; back out the consumed input.
+	amountOutNormalized = new(uint256.Int).Set(binReserveOut)
+	binReserveOutNative := new(uint256.Int).Div(binReserveOut, scaleOut)
+	consumedNative := new(uint256.Int)
+	if swapForY {
+		consumedNative.Mul(binReserveOutNative, precisionX)
+		consumedNative.Div(consumedNative, price)
+	} else {
+		consumedNative.Mul(binReserveOutNative, price)
+		consumedNative.Div(consumedNative, precisionX)
+	}
+	consumed := new(uint256.Int).Mul(consumedNative, scaleIn)
+	amountInLeftNormalized = new(uint256.Int)
+	if amountInNormalized.Cmp(consumed) > 0 {
+		amountInLeftNormalized.Sub(amountInNormalized, consumed)
+	}
+	return amountOutNormalized, amountInLeftNormalized
+}

--- a/pkg/liquidity-source/umbrae-dlmm/math_test.go
+++ b/pkg/liquidity-source/umbrae-dlmm/math_test.go
@@ -1,0 +1,47 @@
+package umbraedlmm
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizedPriceFromId(t *testing.T) {
+	// Centre bin is exactly 1.0 in 1e18.
+	require.Equal(t, e18, getNormalizedPriceFromId(activeBinID, 25))
+	// One bin up at binStep 25: 1e18*10025/10000.
+	require.Equal(t, uint256.NewInt(1002500000000000000), getNormalizedPriceFromId(activeBinID+1, 25))
+	// One bin down: floor(1e18*10000/10025) — the deployed 1e18 exponentiation is exact here.
+	require.Equal(t, uint256.NewInt(997506234413965087), getNormalizedPriceFromId(activeBinID-1, 25))
+}
+
+func TestGetPriceFromId_DecimalScaling(t *testing.T) {
+	// 18-decimal quote: price equals the normalized price.
+	p, err := getPriceFromId(activeBinID, 25, 18)
+	require.NoError(t, err)
+	require.Equal(t, e18, p)
+
+	// 6-decimal quote (e.g. USDC): price = normalized / 10^12 = 10^6 at the centre bin.
+	p6, err := getPriceFromId(activeBinID, 25, 6)
+	require.NoError(t, err)
+	require.Equal(t, uint256.NewInt(1000000), p6)
+}
+
+func TestCalculateDynamicFee(t *testing.T) {
+	// vol=0 -> just the base factor (varFeeCap 0 = no cap).
+	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 4000, uint256.NewInt(0), 25, 0))
+	// vol=100, binStep=25, control=4000: (100*25)^2 * 4000 / 1e10 = 2 -> 32 bps.
+	require.Equal(t, uint256.NewInt(32), calculateDynamicFee(30, 4000, uint256.NewInt(100), 25, 0))
+	// variableFeeControl=0 disables the variable term.
+	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 0, uint256.NewInt(9999), 25, 0))
+	// Capped at MAX_FEE (500) when uncapped variable fee is huge.
+	require.Equal(t, uMaxFee, calculateDynamicFee(30, 4000, uint256.NewInt(35000), 25, 0))
+	// variableFeeCap caps the variable term: vol=100 gives variableFee 2, cap at 1 -> 31 bps.
+	require.Equal(t, uint256.NewInt(31), calculateDynamicFee(30, 4000, uint256.NewInt(100), 25, 1))
+}
+
+func TestGetFeeAmountFrom(t *testing.T) {
+	// 1e18 at 30 bps fee = floor(1e18*30/10030) = floor(3e19/10030).
+	require.Equal(t, uint256.NewInt(2991026919242273), getFeeAmountFrom(e18, uint256.NewInt(30)))
+}

--- a/pkg/liquidity-source/umbrae-dlmm/pool_list_updater.go
+++ b/pkg/liquidity-source/umbrae-dlmm/pool_list_updater.go
@@ -1,0 +1,169 @@
+package umbraedlmm
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+type PoolsListUpdaterMetadata struct {
+	Offset int `json:"offset"`
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: cfg, ethrpcClient: ethrpcClient}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	startTime := time.Now()
+	logger.WithFields(logger.Fields{"dex_id": u.config.DexID}).Info("Started getting new pools")
+
+	total, err := u.allPairsLength(ctx)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	offset := u.getOffset(metadataBytes)
+	limit := u.config.NewPoolLimit
+	if limit <= 0 || offset+limit > total {
+		limit = total - offset
+	}
+	if limit <= 0 {
+		return nil, metadataBytes, nil
+	}
+
+	addresses, err := u.listPairAddresses(ctx, offset, limit)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	pools, err := u.initPools(ctx, addresses)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	newMeta, err := json.Marshal(PoolsListUpdaterMetadata{Offset: offset + limit})
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	logger.WithFields(logger.Fields{
+		"dex_id": u.config.DexID, "pools_len": len(pools), "offset": offset,
+		"duration_ms": time.Since(startTime).Milliseconds(),
+	}).Info("Finished getting new pools")
+
+	return pools, newMeta, nil
+}
+
+func (u *PoolsListUpdater) allPairsLength(ctx context.Context) (int, error) {
+	var length *big.Int
+	if _, err := u.ethrpcClient.R().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: u.config.FactoryAddress,
+		Method: factoryMethodAllPairsLength,
+	}, []any{&length}).Call(); err != nil {
+		return 0, err
+	}
+	return int(length.Int64()), nil
+}
+
+func (u *PoolsListUpdater) getOffset(metadataBytes []byte) int {
+	if len(metadataBytes) == 0 {
+		return 0
+	}
+	var m PoolsListUpdaterMetadata
+	if err := json.Unmarshal(metadataBytes, &m); err != nil {
+		return 0
+	}
+	return m.Offset
+}
+
+func (u *PoolsListUpdater) listPairAddresses(ctx context.Context, offset, limit int) ([]common.Address, error) {
+	out := make([]common.Address, limit)
+	req := u.ethrpcClient.R().SetContext(ctx)
+	for i := 0; i < limit; i++ {
+		req.AddCall(&ethrpc.Call{
+			ABI:    factoryABI,
+			Target: u.config.FactoryAddress,
+			Method: factoryMethodAllPairs,
+			Params: []any{big.NewInt(int64(offset + i))},
+		}, []any{&out[i]})
+	}
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+	var addresses []common.Address
+	for i, ok := range resp.Result {
+		if ok {
+			addresses = append(addresses, out[i])
+		}
+	}
+	return addresses, nil
+}
+
+// initPools reads the immutable pair config (tokens, binStep, decimals) into StaticExtra. Reserves
+// are left at 0; the tracker fills bins and reserves later.
+func (u *PoolsListUpdater) initPools(ctx context.Context, addresses []common.Address) ([]entity.Pool, error) {
+	type pairInfo struct {
+		tokenX, tokenY common.Address
+		binStep        uint16
+		dec            decimalsResult
+	}
+	infos := make([]pairInfo, len(addresses))
+
+	req := u.ethrpcClient.R().SetContext(ctx)
+	for i, addr := range addresses {
+		target := addr.Hex()
+		req.AddCall(&ethrpc.Call{ABI: pairABI, Target: target, Method: pairMethodTokenX}, []any{&infos[i].tokenX}).
+			AddCall(&ethrpc.Call{ABI: pairABI, Target: target, Method: pairMethodTokenY}, []any{&infos[i].tokenY}).
+			AddCall(&ethrpc.Call{ABI: pairABI, Target: target, Method: pairMethodBinStep}, []any{&infos[i].binStep}).
+			AddCall(&ethrpc.Call{ABI: pairABI, Target: target, Method: pairMethodGetDecimals}, []any{&infos[i].dec})
+	}
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+
+	pools := make([]entity.Pool, 0, len(addresses))
+	for i, addr := range addresses {
+		staticExtra, err := json.Marshal(StaticExtra{
+			BinStep:   infos[i].binStep,
+			DecimalsX: infos[i].dec.DecimalsX,
+			DecimalsY: infos[i].dec.DecimalsY,
+			Router:    u.config.RouterAddress,
+		})
+		if err != nil {
+			return nil, err
+		}
+		pools = append(pools, entity.Pool{
+			Address:   strings.ToLower(addr.Hex()),
+			Exchange:  u.config.DexID,
+			Type:      DexType,
+			Timestamp: time.Now().Unix(),
+			Reserves:  entity.PoolReserves{"0", "0"},
+			Tokens: []*entity.PoolToken{
+				{Address: strings.ToLower(infos[i].tokenX.Hex()), Swappable: true},
+				{Address: strings.ToLower(infos[i].tokenY.Hex()), Swappable: true},
+			},
+			Extra:       "{}",
+			StaticExtra: string(staticExtra),
+		})
+	}
+	return pools, nil
+}

--- a/pkg/liquidity-source/umbrae-dlmm/pool_simulator.go
+++ b/pkg/liquidity-source/umbrae-dlmm/pool_simulator.go
@@ -1,0 +1,307 @@
+package umbraedlmm
+
+import (
+	"math/big"
+	"sort"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+
+	binStep    uint16
+	decimalsY  uint8
+	scaleX     *uint256.Int // 10^(18-decimalsX)
+	scaleY     *uint256.Int // 10^(18-decimalsY)
+	precisionX *uint256.Int // 10^decimalsX
+
+	activeID uint32
+	bins     []Bin          // sorted ascending by ID; normalized reserves
+	binIndex map[uint32]int // bin ID -> index into bins
+
+	fp             FeeParameters
+	variableFeeCap uint16
+	startVol       *uint256.Int // volatility accumulator, already decayed to the tracked block
+	volRef         uint32       // volatility reference bin (== activeId when idle)
+	minSwap        *uint256.Int // precomputed _getMinSwapForVolatility threshold (native units)
+	router         string       // DLMM Router: the token spender / approval target
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(ep entity.Pool) (*PoolSimulator, error) {
+	var static StaticExtra
+	if err := json.Unmarshal([]byte(ep.StaticExtra), &static); err != nil {
+		return nil, err
+	}
+	var extra Extra
+	if err := json.Unmarshal([]byte(ep.Extra), &extra); err != nil {
+		return nil, err
+	}
+
+	bins := append([]Bin(nil), extra.Bins...)
+	sort.Slice(bins, func(i, j int) bool { return bins[i].ID < bins[j].ID })
+	binIndex := make(map[uint32]int, len(bins))
+	for i, b := range bins {
+		binIndex[b.ID] = i
+	}
+
+	s := &PoolSimulator{
+		Pool: pool.Pool{Info: pool.PoolInfo{
+			Address:     ep.Address,
+			Exchange:    ep.Exchange,
+			Type:        ep.Type,
+			Tokens:      lo.Map(ep.Tokens, func(t *entity.PoolToken, _ int) string { return t.Address }),
+			Reserves:    lo.Map(ep.Reserves, func(r string, _ int) *big.Int { return bignumber.NewBig(r) }),
+			BlockNumber: ep.BlockNumber,
+		}},
+		binStep:        static.BinStep,
+		decimalsY:      static.DecimalsY,
+		scaleX:         pow10(18 - static.DecimalsX),
+		scaleY:         pow10(18 - static.DecimalsY),
+		precisionX:     pow10(static.DecimalsX),
+		activeID:       extra.ActiveID,
+		bins:           bins,
+		binIndex:       binIndex,
+		fp:             extra.FeeParameters,
+		variableFeeCap: extra.VariableFeeCap,
+		startVol:       uint256.NewInt(extra.VolatilityAccumulator),
+		volRef:         extra.VolatilityReference,
+		minSwap:        minSwapForVolatility(extra.NativeReserveX, extra.NativeReserveY, extra.FeeParameters.MinSwapBps),
+		router:         static.Router,
+	}
+	return s, nil
+}
+
+// minSwapForVolatility mirrors the DEPLOYED _getMinSwapForVolatility:
+// (nativeReserveX + nativeReserveY) * minSwapBps / 10000 (no bin-step factor). Returns 0 when
+// minSwapBps is 0 (matching the deployed early return).
+func minSwapForVolatility(nativeX, nativeY string, minSwapBps uint16) *uint256.Int {
+	if minSwapBps == 0 {
+		return uint256.NewInt(0)
+	}
+	total := new(uint256.Int)
+	if x, err := uint256.FromDecimal(nativeX); err == nil {
+		total.Add(total, x)
+	}
+	if y, err := uint256.FromDecimal(nativeY); err == nil {
+		total.Add(total, y)
+	}
+	total.Mul(total, uint256.NewInt(uint64(minSwapBps)))
+	return total.Div(total, uBP)
+}
+
+func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	indexIn, indexOut := s.GetTokenIndex(param.TokenAmountIn.Token), s.GetTokenIndex(param.TokenOut)
+	if indexIn < 0 || indexOut < 0 {
+		return nil, ErrInvalidToken
+	}
+	amountIn, overflow := uint256.FromBig(param.TokenAmountIn.Amount)
+	if overflow || amountIn.Sign() <= 0 {
+		return nil, ErrInvalidAmountIn
+	}
+
+	swapForY := indexIn == 0 // tokenX (index 0) in -> tokenY out
+
+	amountOut, fee, swapInfo, err := s.traverse(amountIn, swapForY)
+	if err != nil {
+		return nil, err
+	}
+	if amountOut.Sign() <= 0 {
+		return nil, ErrInsufficientOutput
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: param.TokenOut, Amount: amountOut.ToBig()},
+		Fee:            &pool.TokenAmount{Token: param.TokenAmountIn.Token, Amount: fee.ToBig()},
+		Gas:            defaultGas + int64(len(swapInfo.binUpdates))*gasPerBin,
+		SwapInfo:       swapInfo,
+	}, nil
+}
+
+// traverse reproduces the deployed PairViewer.quoteSwap loop: it starts from the tracked
+// (already-decayed) volatility, ramps it by distance from volRef as bins are crossed, and applies
+// the dynamic fee per bin. Returns the native output, native total fee, and post-swap bin updates.
+func (s *PoolSimulator) traverse(amountIn *uint256.Int, swapForY bool) (*uint256.Int, *uint256.Int, SwapInfo, error) {
+	scaleIn, scaleOut := s.scaleX, s.scaleY
+	if !swapForY {
+		scaleIn, scaleOut = s.scaleY, s.scaleX
+	}
+
+	currentBinID := s.activeID
+	amountInLeft := new(uint256.Int).Set(amountIn)
+	amountOutNormalized := uint256.NewInt(0)
+	totalFee := uint256.NewInt(0)
+	volatility := new(uint256.Int).Set(s.startVol) // already decayed to the tracked block
+	var binsTraversed int
+
+	updates := make(map[int]binUpdate)
+
+	for !amountInLeft.IsZero() {
+		feeRate := calculateDynamicFee(s.fp.BaseFactor, s.fp.VariableFeeControl, volatility, s.binStep, s.variableFeeCap)
+		binTotalFee := getFeeAmountFrom(amountInLeft, feeRate)
+		amountInAfterFee := new(uint256.Int).Sub(amountInLeft, binTotalFee)
+		amountInAfterFeeNormalized := new(uint256.Int).Mul(amountInAfterFee, scaleIn)
+
+		if idx, ok := s.binIndex[currentBinID]; ok {
+			b := s.workingBin(updates, idx)
+			binReserveOut := b.ReserveY
+			if !swapForY {
+				binReserveOut = b.ReserveX
+			}
+			if binReserveOut != nil && !binReserveOut.IsZero() { // hasLiquidityForSwap
+				price, err := getPriceFromId(currentBinID, s.binStep, s.decimalsY)
+				if err != nil {
+					return nil, nil, SwapInfo{}, err
+				}
+				if price.IsZero() {
+					return nil, nil, SwapInfo{}, ErrInvalidPrice
+				}
+
+				binAmountOut, amountInLeftNorm := simulateBinSwap(
+					binReserveOut, amountInAfterFeeNormalized, price, s.precisionX, scaleIn, scaleOut, swapForY)
+
+				amountOutNormalized.Add(amountOutNormalized, binAmountOut)
+
+				actualConsumedNorm := new(uint256.Int).Sub(amountInAfterFeeNormalized, amountInLeftNorm)
+				actualConsumed := new(uint256.Int).Div(actualConsumedNorm, scaleIn)
+
+				actualTotalFee := uint256.NewInt(0)
+				if actualConsumed.Sign() > 0 && amountInAfterFee.Sign() > 0 {
+					actualTotalFee.Mul(binTotalFee, actualConsumed)
+					actualTotalFee.Div(actualTotalFee, amountInAfterFee)
+				}
+				totalFee.Add(totalFee, actualTotalFee)
+
+				amountInLeftAfterSwap := new(uint256.Int).Div(amountInLeftNorm, scaleIn)
+				leftoverFee := new(uint256.Int).Sub(binTotalFee, actualTotalFee)
+				amountInLeft.Add(amountInLeftAfterSwap, leftoverFee)
+
+				s.recordBinUpdate(updates, idx, binAmountOut, actualConsumedNorm, swapForY)
+			}
+		}
+
+		if amountInLeft.IsZero() {
+			break
+		}
+
+		nextBin, found := s.findNextActiveBin(currentBinID, swapForY)
+		if !found {
+			break // out of tracked liquidity -> partial quote, as on-chain runs out of bins
+		}
+		currentBinID = nextBin
+		binsTraversed++
+
+		// _wouldUpdateVolatility: outside the filter period (snapshot model), the gate reduces to
+		// amountIn >= minSwap && a fee was charged. Ramp volatility by distance from the reference.
+		if amountIn.Cmp(s.minSwap) >= 0 && totalFee.Sign() > 0 {
+			dist := distanceFrom(currentBinID, s.volRef)
+			if dist > uint64(s.fp.MaxVolatilityAccumulator) {
+				dist = uint64(s.fp.MaxVolatilityAccumulator)
+			}
+			volatility = uint256.NewInt(dist)
+		}
+	}
+
+	amountOut := new(uint256.Int).Div(amountOutNormalized, scaleOut)
+
+	return amountOut, totalFee, SwapInfo{
+		newActiveID: currentBinID,
+		binUpdates:  lo.Values(updates),
+	}, nil
+}
+
+// workingBin returns the current (possibly already-updated) reserves of bin at index idx.
+func (s *PoolSimulator) workingBin(updates map[int]binUpdate, idx int) Bin {
+	if u, ok := updates[idx]; ok {
+		return Bin{ID: s.bins[idx].ID, ReserveX: u.reserveX, ReserveY: u.reserveY}
+	}
+	return s.bins[idx]
+}
+
+// recordBinUpdate applies a bin's post-swap reserves (output reduced, input increased by the net
+// consumed) so UpdateBalance can replay them without recomputing.
+func (s *PoolSimulator) recordBinUpdate(updates map[int]binUpdate, idx int, outDelta, inDeltaNorm *uint256.Int, swapForY bool) {
+	cur := s.workingBin(updates, idx)
+	newX := new(uint256.Int).Set(orZero(cur.ReserveX))
+	newY := new(uint256.Int).Set(orZero(cur.ReserveY))
+	if swapForY {
+		newY.Sub(newY, outDelta)
+		newX.Add(newX, inDeltaNorm)
+	} else {
+		newX.Sub(newX, outDelta)
+		newY.Add(newY, inDeltaNorm)
+	}
+	updates[idx] = binUpdate{index: idx, reserveX: newX, reserveY: newY}
+}
+
+// findNextActiveBin returns the next non-empty bin in the swap direction. Direction is set from
+// observed on-chain behaviour (verified against the pair's quoteSwap): selling X for Y pushes the
+// price down (descending bin ids), selling Y for X pushes it up (ascending). Y lives in bins below
+// the active bin, X above — so swapForY (X->Y, taking Y out) walks DOWN and !swapForY walks UP.
+func (s *PoolSimulator) findNextActiveBin(current uint32, swapForY bool) (uint32, bool) {
+	if !swapForY { // Y->X: search up
+		i := sort.Search(len(s.bins), func(i int) bool { return s.bins[i].ID > current })
+		if i < len(s.bins) {
+			return s.bins[i].ID, true
+		}
+		return 0, false
+	}
+	// X->Y: search down for the largest ID < current
+	i := sort.Search(len(s.bins), func(i int) bool { return s.bins[i].ID >= current })
+	if i > 0 {
+		return s.bins[i-1].ID, true
+	}
+	return 0, false
+}
+
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	si, ok := params.SwapInfo.(SwapInfo)
+	if !ok {
+		return
+	}
+	s.activeID = si.newActiveID
+	for _, u := range si.binUpdates {
+		// Reassign the element (copy-on-write) so cloned states never share these pointers.
+		s.bins[u.index] = Bin{ID: s.bins[u.index].ID, ReserveX: u.reserveX, ReserveY: u.reserveY}
+	}
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.bins = append([]Bin(nil), s.bins...)
+	// binIndex maps by ID -> index; indices are stable under copy-on-write reassign, safe to share.
+	return &cloned
+}
+
+// GetApprovalAddress returns the DLMM Router — the swap entry point KyberSwap's executor approves
+// and calls. The pair itself is a BeaconProxy that reverts on direct swap calls ("No extension"), so
+// the pair address is never a valid spender.
+func (s *PoolSimulator) GetApprovalAddress(_, _ string) string {
+	return s.router
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return PoolMeta{BlockNumber: s.Info.BlockNumber}
+}
+
+func orZero(v *uint256.Int) *uint256.Int {
+	if v == nil {
+		return uint256.NewInt(0)
+	}
+	return v
+}
+
+func distanceFrom(a, b uint32) uint64 {
+	if a >= b {
+		return uint64(a - b)
+	}
+	return uint64(b - a)
+}

--- a/pkg/liquidity-source/umbrae-dlmm/pool_simulator_test.go
+++ b/pkg/liquidity-source/umbrae-dlmm/pool_simulator_test.go
@@ -1,0 +1,148 @@
+package umbraedlmm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+const (
+	tokenX = "0x14a4e80d633af55ace1160c320f5a36d41cced3e" // U1
+	tokenY = "0x4200000000000000000000000000000000000006" // WETH
+)
+
+func newSim(t *testing.T, static StaticExtra, extra Extra) *PoolSimulator {
+	t.Helper()
+	se, _ := json.Marshal(static)
+	ex, _ := json.Marshal(extra)
+	sim, err := NewPoolSimulator(entity.Pool{
+		Address:     "0x697b72320656e6dc60db7a4bfb95084c9d9c55a0",
+		Exchange:    DexType,
+		Type:        DexType,
+		Reserves:    entity.PoolReserves{"0", "0"},
+		Tokens:      []*entity.PoolToken{{Address: tokenX}, {Address: tokenY}},
+		StaticExtra: string(se),
+		Extra:       string(ex),
+	})
+	require.NoError(t, err)
+	return sim
+}
+
+func u(v string) *uint256.Int { return uint256.MustFromDecimal(v) }
+
+// TestCalcAmountOut_SingleBin verifies the full traversal arithmetic against a hand-computed case:
+// one active bin, 18/18 decimals, binStep 25, base fee 30 bps, variable fee disabled.
+func TestCalcAmountOut_SingleBin(t *testing.T) {
+	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}
+	extra := Extra{
+		ActiveID: activeBinID,
+		Bins: []Bin{
+			{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}, // 1000 Y
+		},
+		FeeParameters: FeeParameters{
+			BaseFactor: 30, VariableFeeControl: 0,
+			MaxVolatilityAccumulator: 35000, MinSwapBps: 0,
+		},
+		NativeReserveX: "0",
+		NativeReserveY: "1000000000000000000000",
+	}
+	sim := newSim(t, static, extra)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: big.NewInt(1_000_000_000_000_000_000)}, // 1 X
+		TokenOut:      tokenY,
+	})
+	require.NoError(t, err)
+	// inAfterFee = 1e18 - floor(1e18*30/10030); at a 1:1 bin price the full inAfterFee converts.
+	require.Equal(t, "997008973080757727", res.TokenAmountOut.Amount.String())
+	require.Equal(t, "2991026919242273", res.Fee.Amount.String())
+}
+
+func TestCalcAmountOut_UpdateBalanceAndClone(t *testing.T) {
+	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}
+	extra := Extra{
+		ActiveID: activeBinID,
+		Bins: []Bin{
+			{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")},
+		},
+		FeeParameters:  FeeParameters{BaseFactor: 30, VariableFeeControl: 0, MaxVolatilityAccumulator: 35000},
+		NativeReserveX: "0",
+		NativeReserveY: "1000000000000000000000",
+	}
+	sim := newSim(t, static, extra)
+	in := big.NewInt(1_000_000_000_000_000_000)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: in}, TokenOut: tokenY,
+	})
+	require.NoError(t, err)
+
+	clone := sim.CloneState()
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokenX, Amount: in},
+		TokenAmountOut: pool.TokenAmount{Token: tokenY, Amount: res.TokenAmountOut.Amount},
+		Fee:            *res.Fee,
+		SwapInfo:       res.SwapInfo,
+	})
+
+	// Active bin Y reserve dropped by the output amount.
+	wantY := new(uint256.Int).Sub(u("1000000000000000000000"), uint256.MustFromBig(res.TokenAmountOut.Amount))
+	require.Equal(t, wantY, sim.bins[0].ReserveY)
+	// Clone is untouched.
+	require.Equal(t, u("1000000000000000000000"), clone.(*PoolSimulator).bins[0].ReserveY)
+}
+
+// TestCalcAmountOut_DecimalScaling exercises the native<->normalized conversion (scaleIn/scaleOut/
+// precisionX) and the decimalsY price adjustment on a synthetic 6-dec X / 18-dec Y pool — the path
+// no on-chain Umbrae pair covers yet (all live pairs are 18/18). Values are hand-computed at the
+// active (1:1 normalized) bin, base fee 30 bps, variable fee off. The fee is charged in input-token
+// native decimals, so the 6-dec direction rounds coarser than 18/18 — that mirrors the contract.
+func TestCalcAmountOut_DecimalScaling(t *testing.T) {
+	// scaleX = 10^(18-6) = 1e12, precisionX = 10^6, scaleY = 1.
+	static := StaticExtra{BinStep: 25, DecimalsX: 6, DecimalsY: 18}
+	extra := Extra{
+		ActiveID: activeBinID,
+		Bins: []Bin{
+			// Normalized reserves: 1000 of each token (X: 1e9 native * 1e12 scale = 1e21; Y: 1e21).
+			{ID: activeBinID, ReserveX: u("1000000000000000000000"), ReserveY: u("1000000000000000000000")},
+		},
+		FeeParameters:  FeeParameters{BaseFactor: 30, VariableFeeControl: 0, MaxVolatilityAccumulator: 35000, MinSwapBps: 0},
+		NativeReserveX: "1000000000", NativeReserveY: "1000000000000000000000",
+	}
+	sim := newSim(t, static, extra)
+
+	// X->Y: 1 whole X = 1e6 native in. Fee (native X) = floor(1e6*30/10030) = 2991.
+	resXY, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: big.NewInt(1_000_000)}, TokenOut: tokenY,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "997009000000000000", resXY.TokenAmountOut.Amount.String(), "X->Y out (Y, 18-dec)")
+	require.Equal(t, "2991", resXY.Fee.Amount.String(), "X->Y fee (X, 6-dec)")
+
+	// Y->X: 1 Y = 1e18 native in. Fee (native Y) = floor(1e18*30/10030); out floors to 6-dec X.
+	resYX, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: big.NewInt(1_000_000_000_000_000_000)}, TokenOut: tokenX,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "997008", resYX.TokenAmountOut.Amount.String(), "Y->X out (X, 6-dec)")
+	require.Equal(t, "2991026919242273", resYX.Fee.Amount.String(), "Y->X fee (Y, 18-dec)")
+}
+
+func TestCalcAmountOut_InvalidToken(t *testing.T) {
+	sim := newSim(t, StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}, Extra{
+		ActiveID:       activeBinID,
+		Bins:           []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
+		FeeParameters:  FeeParameters{BaseFactor: 30, MaxVolatilityAccumulator: 35000},
+		NativeReserveX: "0", NativeReserveY: "1000000000000000000000",
+	})
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: "0xdead", Amount: big.NewInt(1)}, TokenOut: tokenY,
+	})
+	require.ErrorIs(t, err, ErrInvalidToken)
+}

--- a/pkg/liquidity-source/umbrae-dlmm/pool_tracker.go
+++ b/pkg/liquidity-source/umbrae-dlmm/pool_tracker.go
@@ -1,0 +1,172 @@
+package umbraedlmm
+
+import (
+	"context"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+// feeParamsRPC mirrors the DEPLOYED FeeHelper.FeeParameters tuple (7 fields, no protocolShare).
+type feeParamsRPC struct {
+	BaseFactor               uint16
+	FilterPeriod             uint16
+	DecayPeriod              uint16
+	ReductionFactor          uint16
+	VariableFeeControl       uint16
+	MaxVolatilityAccumulator *big.Int // uint24
+	MinSwapBps               uint16
+}
+
+type quoteStateRPC struct {
+	FeeParams             feeParamsRPC
+	VolatilityAccumulator *big.Int
+	VolatilityReference   *big.Int
+	LastVolatilityUpdate  *big.Int
+	ScaleX                *big.Int
+	ScaleY                *big.Int
+	Factory               common.Address
+}
+
+type pairStatsRPC struct {
+	ActiveId            *big.Int
+	ReserveX            *big.Int
+	ReserveY            *big.Int
+	ProtocolFeesX       *big.Int
+	ProtocolFeesY       *big.Int
+	Volatility          *big.Int
+	LastUpdateTimestamp *big.Int
+}
+
+type activeBinsRPC struct {
+	BinIds      []*big.Int
+	ReservesX   []*big.Int
+	ReservesY   []*big.Int
+	TotalShares []*big.Int
+}
+
+var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(config *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
+	return &PoolTracker{config: config, ethrpcClient: ethrpcClient}
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	logger.WithFields(logger.Fields{"pool_id": p.Address}).Info("getting new pool state")
+
+	var static StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &static); err != nil {
+		return p, err
+	}
+
+	// All reads pinned to one block. The deployed pair routes reserves/bins/quotes to an extension,
+	// so reserves/bins come via the PairViewer; fee + volatility state come via getQuoteState.
+	var (
+		activeID  *big.Int
+		quote     quoteStateRPC
+		stats     pairStatsRPC
+		activeBin activeBinsRPC
+	)
+	resp, err := t.ethrpcClient.R().SetContext(ctx).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetActiveID}, []any{&activeID}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetQuoteState}, []any{&quote}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetPairStatistics}, []any{&stats}).
+		AddCall(&ethrpc.Call{ABI: viewerABI, Target: t.config.ViewerAddress, Method: viewerMethodActiveBins, Params: []any{common.HexToAddress(p.Address)}}, []any{&activeBin}).
+		TryBlockAndAggregate()
+	if err != nil {
+		return p, err
+	}
+	blockNumber := resp.BlockNumber
+
+	var variableFeeCap uint16
+	if _, err := t.ethrpcClient.R().SetContext(ctx).SetBlockNumber(blockNumber).AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: t.config.FactoryAddress,
+		Method: factoryMethodGetVariableFeeCap,
+		Params: []any{static.BinStep, quote.FeeParams.BaseFactor},
+	}, []any{&variableFeeCap}).Call(); err != nil {
+		// getVariableFeeCap is best-effort (0 = no cap), matching the deployed try/catch.
+		variableFeeCap = 0
+	}
+
+	// Bins from the viewer are already normalized (18-decimal); use directly, drop empties.
+	bins := make([]Bin, 0, len(activeBin.BinIds))
+	for i, id := range activeBin.BinIds {
+		rx, _ := uint256.FromBig(activeBin.ReservesX[i])
+		ry, _ := uint256.FromBig(activeBin.ReservesY[i])
+		if (rx == nil || rx.IsZero()) && (ry == nil || ry.IsZero()) {
+			continue
+		}
+		bins = append(bins, Bin{ID: uint32(id.Uint64()), ReserveX: orZero(rx), ReserveY: orZero(ry)})
+	}
+	sort.Slice(bins, func(i, j int) bool { return bins[i].ID < bins[j].ID })
+
+	// Decay the accumulator to "now" (≈ tracked block) exactly as _getDecayedVolatility does.
+	startVol := decayedVolatility(quote, uint64(time.Now().Unix()))
+
+	extra := Extra{
+		ActiveID: uint32(activeID.Uint64()),
+		Bins:     bins,
+		FeeParameters: FeeParameters{
+			BaseFactor:               quote.FeeParams.BaseFactor,
+			FilterPeriod:             quote.FeeParams.FilterPeriod,
+			DecayPeriod:              quote.FeeParams.DecayPeriod,
+			ReductionFactor:          quote.FeeParams.ReductionFactor,
+			VariableFeeControl:       quote.FeeParams.VariableFeeControl,
+			MaxVolatilityAccumulator: uint32(quote.FeeParams.MaxVolatilityAccumulator.Uint64()),
+			MinSwapBps:               quote.FeeParams.MinSwapBps,
+		},
+		VariableFeeCap:        variableFeeCap,
+		VolatilityAccumulator: startVol,
+		VolatilityReference:   uint32(quote.VolatilityReference.Uint64()),
+		NativeReserveX:        stats.ReserveX.String(),
+		NativeReserveY:        stats.ReserveY.String(),
+	}
+
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return p, err
+	}
+
+	p.Extra = string(extraBytes)
+	p.Reserves = entity.PoolReserves{stats.ReserveX.String(), stats.ReserveY.String()}
+	p.BlockNumber = blockNumber.Uint64()
+	p.Timestamp = time.Now().Unix()
+
+	logger.WithFields(logger.Fields{"pool_id": p.Address, "bins": len(bins)}).Info("finished getting new pool state")
+	return p, nil
+}
+
+// decayedVolatility mirrors the viewer's _getDecayedVolatility: constant during the filter period,
+// linear decay after, to zero past decayPeriod.
+func decayedVolatility(q quoteStateRPC, now uint64) uint64 {
+	vol := q.VolatilityAccumulator.Uint64()
+	last := q.LastVolatilityUpdate.Uint64()
+	if now <= last {
+		return vol
+	}
+	delta := now - last
+	if delta < uint64(q.FeeParams.FilterPeriod) {
+		return vol
+	}
+	return applyVolatilityDecay(vol, delta, uint64(q.FeeParams.DecayPeriod))
+}

--- a/pkg/liquidity-source/umbrae-dlmm/type.go
+++ b/pkg/liquidity-source/umbrae-dlmm/type.go
@@ -1,0 +1,83 @@
+package umbraedlmm
+
+import "github.com/holiman/uint256"
+
+// StaticExtra holds immutable pair config the tracker/simulator need. scaleX/scaleY are derived
+// from the decimals (10^(18-decimals)); reserves are carried in the contract's internal 18-decimal
+// normalized space.
+type StaticExtra struct {
+	BinStep   uint16 `json:"binStep"`
+	DecimalsX uint8  `json:"decimalsX"`
+	DecimalsY uint8  `json:"decimalsY"`
+	// Router is the DLMM Router address — the swap entry point KyberSwap's executor approves and
+	// calls. Persisted by the lister from Config.RouterAddress so GetApprovalAddress is deployment-
+	// driven rather than hardcoded.
+	Router string `json:"router"`
+}
+
+// FeeParameters mirrors the DEPLOYED FeeHelper.FeeParameters (7 fields; no protocolShare —
+// protocol share is global on the factory). maxVolatilityAccumulator is uint24 on-chain.
+type FeeParameters struct {
+	BaseFactor               uint16 `json:"baseFactor"`
+	FilterPeriod             uint16 `json:"filterPeriod"`
+	DecayPeriod              uint16 `json:"decayPeriod"`
+	ReductionFactor          uint16 `json:"reductionFactor"`
+	VariableFeeControl       uint16 `json:"variableFeeControl"`
+	MaxVolatilityAccumulator uint32 `json:"maxVolatilityAccumulator"`
+	MinSwapBps               uint16 `json:"minSwapBps"`
+}
+
+// Bin is one discrete liquidity bin. Reserves are in the 18-decimal normalized space (native
+// getBin() reserves multiplied by the token scale factor).
+type Bin struct {
+	ID       uint32       `json:"id"`
+	ReserveX *uint256.Int `json:"reserveX"`
+	ReserveY *uint256.Int `json:"reserveY"`
+}
+
+func (b Bin) isEmpty() bool {
+	return (b.ReserveX == nil || b.ReserveX.IsZero()) && (b.ReserveY == nil || b.ReserveY.IsZero())
+}
+
+// Extra is the mutable per-pool state refreshed each block. The dynamic fee depends on the
+// volatility accumulator + reference, which the deployed pair exposes via getQuoteState(); the
+// tracker decays the accumulator to the tracked block and the simulator ramps it from the reference
+// as bins are crossed, matching the deployed quoteSwap().
+type Extra struct {
+	ActiveID       uint32        `json:"activeId"`
+	Bins           []Bin         `json:"bins"` // sorted ascending by ID; normalized reserves
+	FeeParameters  FeeParameters `json:"feeParameters"`
+	VariableFeeCap uint16        `json:"variableFeeCap"` // from Factory.getVariableFeeCap(binStep, baseFactor)
+	// Volatility state for the dynamic-fee ramp. VolatilityAccumulator is already decayed to the
+	// tracked block, and VolatilityReference is the reference bin (== activeId when idle).
+	VolatilityAccumulator uint64 `json:"volatilityAccumulator"`
+	VolatilityReference   uint32 `json:"volatilityReference"`
+	// Native (un-normalized) total reserves; feed the min-swap-for-volatility threshold exactly as
+	// the deployed _getMinSwapForVolatility does (native sum * minSwapBps / 10000).
+	NativeReserveX string `json:"nativeReserveX"`
+	NativeReserveY string `json:"nativeReserveY"`
+}
+
+// binUpdate records a post-swap bin reserve (normalized) for UpdateBalance to apply by index,
+// so UpdateBalance consumes CalcAmountOut's result rather than recomputing it.
+type binUpdate struct {
+	index    int
+	reserveX *uint256.Int
+	reserveY *uint256.Int
+}
+
+type SwapInfo struct {
+	newActiveID uint32
+	binUpdates  []binUpdate
+}
+
+type PoolMeta struct {
+	BlockNumber uint64 `json:"blockNumber"`
+}
+
+// decimalsResult decodes the pair's getDecimals() two-value return (ABI multi-returns unpack into
+// a single struct by position).
+type decimalsResult struct {
+	DecimalsX uint8
+	DecimalsY uint8
+}

--- a/pkg/liquidity-source/umbrae-dlmm/verification_test.go
+++ b/pkg/liquidity-source/umbrae-dlmm/verification_test.go
@@ -1,0 +1,228 @@
+package umbraedlmm
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+// Canonical Base mainnet U1/WETH DLMM pair (binStep 25), its factory and the PairViewer.
+const (
+	verifyPair     = "0x697b72320656e6dc60db7a4bfb95084c9d9c55a0"
+	verifyFactory  = "0x17Da44dcbdffD8c715be7A368E19F252C2940Fee"
+	verifyViewer   = "0xbA3A5400A95b055b1412e18ad1978EdF32Fc3F05"
+	verifyRouter   = "0x4965DD6877ca9DE77caca2f57996651e7AF23c93"
+	multicall3Base = "0xcA11bde05977b3631167028862bE2a173976CA11"
+)
+
+// TestVerifyAgainstChain is the end-to-end gate: real PoolTracker -> PoolSimulator -> compared to
+// the pair's on-chain quoteSwap (via PairViewer) across a spread of amounts in both directions, all
+// pinned to the tracked block. Set UMBRAE_BASE_RPC_URL to run.
+func TestVerifyAgainstChain(t *testing.T) {
+	rpcURL := os.Getenv("UMBRAE_BASE_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("UMBRAE_BASE_RPC_URL not set; skipping live verification")
+	}
+	client := ethrpc.New(rpcURL).SetMulticallContract(common.HexToAddress(multicall3Base))
+	ctx := context.Background()
+
+	// Full ingestion pipeline: static config (as the lister persists it) -> tracker -> simulator.
+	sim, tokenX, tokenY, pinBlock := buildLiveSimulator(t, ctx, client)
+	require.Equal(t, verifyRouter, sim.GetApprovalAddress(tokenX, tokenY),
+		"approval address must be the DLMM Router, not the pair")
+
+	amounts := []*big.Int{exp10(14), exp10(15), exp10(16), exp10(17), exp10(18), mul(exp10(18), 10), mul(exp10(18), 1000)}
+	var total, matched int
+	for _, swapForY := range []bool{true, false} {
+		tokenIn, tokenOut := tokenX, tokenY
+		if !swapForY {
+			tokenIn, tokenOut = tokenY, tokenX
+		}
+		for _, amt := range amounts {
+			chainOut, binsTrav, _ := viewerQuoteSwap(t, ctx, client, pinBlock, swapForY, amt)
+			var simOut *big.Int = big.NewInt(0)
+			if res, cerr := sim.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{Token: tokenIn, Amount: amt}, TokenOut: tokenOut,
+			}); cerr == nil {
+				simOut = res.TokenAmountOut.Amount
+			}
+			total++
+			ok := chainOut.Cmp(simOut) == 0
+			if ok {
+				matched++
+			}
+			dir := "X->Y"
+			if !swapForY {
+				dir = "Y->X"
+			}
+			t.Logf("%s in=%-24s | chain=%-24s sim=%-24s bins=%-3s match=%v", dir, amt, chainOut, simOut, binsTrav, ok)
+		}
+	}
+	t.Logf("MATCHED %d/%d", matched, total)
+	require.Equal(t, total, matched, "simulator diverged from on-chain quoteSwap")
+}
+
+// TestVerifyListerLive exercises the real PoolsListUpdater against the live DLMM factory: enumerate
+// pairs, then assert the canonical U1/WETH pair is discovered with correctly-persisted StaticExtra
+// (binStep, decimals, router). This is the on-chain discovery path the verification test skips (it
+// builds the entity.Pool inline). Set UMBRAE_BASE_RPC_URL to run.
+func TestVerifyListerLive(t *testing.T) {
+	rpcURL := os.Getenv("UMBRAE_BASE_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("UMBRAE_BASE_RPC_URL not set; skipping live lister verification")
+	}
+	client := ethrpc.New(rpcURL).SetMulticallContract(common.HexToAddress(multicall3Base))
+	ctx := context.Background()
+
+	lister := NewPoolsListUpdater(&Config{
+		DexID: DexType, FactoryAddress: verifyFactory, ViewerAddress: verifyViewer,
+		RouterAddress: verifyRouter,
+	}, client)
+
+	pools, _, err := lister.GetNewPools(ctx, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, pools, "factory enumeration returned no pairs")
+	t.Logf("lister discovered %d pair(s)", len(pools))
+
+	var found *entity.Pool
+	for i := range pools {
+		if strings.EqualFold(pools[i].Address, verifyPair) {
+			found = &pools[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "canonical U1/WETH pair not enumerated by the factory lister")
+
+	var se StaticExtra
+	require.NoError(t, json.Unmarshal([]byte(found.StaticExtra), &se))
+	require.Equal(t, uint16(25), se.BinStep, "binStep")
+	require.Equal(t, verifyRouter, se.Router, "router persisted into StaticExtra")
+	require.Len(t, found.Tokens, 2)
+	require.NotEmpty(t, found.Tokens[0].Address)
+	require.NotEmpty(t, found.Tokens[1].Address)
+	require.Equal(t, entity.PoolReserves{"0", "0"}, found.Reserves, "lister leaves reserves at 0 for the tracker")
+	t.Logf("canonical pair OK: binStep=%d decX=%d decY=%d router=%s tokens=[%s,%s]",
+		se.BinStep, se.DecimalsX, se.DecimalsY, se.Router, found.Tokens[0].Address, found.Tokens[1].Address)
+}
+
+func viewerQuoteSwap(t *testing.T, ctx context.Context, client *ethrpc.Client, block *big.Int, swapForY bool, amountIn *big.Int) (amountOut, binsTrav, finalBinID *big.Int) {
+	t.Helper()
+	var out struct {
+		AmountOut        *big.Int
+		ConsumedAmountIn *big.Int
+		FinalBinId       *big.Int
+		BinsTraversed    *big.Int
+		TotalFee         *big.Int
+	}
+	_, err := client.R().SetContext(ctx).SetBlockNumber(block).AddCall(&ethrpc.Call{
+		ABI: viewerABI, Target: verifyViewer, Method: viewerMethodQuoteSwap,
+		Params: []any{common.HexToAddress(verifyPair), swapForY, amountIn},
+	}, []any{&out}).Call()
+	require.NoError(t, err)
+	return out.AmountOut, out.BinsTraversed, out.FinalBinId
+}
+
+// TestVerifyUpdateBalance proves the post-swap state transition KyberSwap relies on for multi-hop /
+// split routing: (1) CalcAmountOut's SwapInfo.newActiveID matches the pair's on-chain finalBinId,
+// (2) after UpdateBalance the bins the swap fully crossed are emptied on the output side, and (3) a
+// second CalcAmountOut reads the advanced book (starts at the new active bin, never re-quotes the
+// already-consumed liquidity). Set UMBRAE_BASE_RPC_URL to run.
+func TestVerifyUpdateBalance(t *testing.T) {
+	rpcURL := os.Getenv("UMBRAE_BASE_RPC_URL")
+	if rpcURL == "" {
+		t.Skip("UMBRAE_BASE_RPC_URL not set; skipping live update-balance verification")
+	}
+	client := ethrpc.New(rpcURL).SetMulticallContract(common.HexToAddress(multicall3Base))
+	ctx := context.Background()
+	sim, tokenX, tokenY, pinBlock := buildLiveSimulator(t, ctx, client)
+
+	// Y->X is the liquid direction for this pool; pick amounts that cross several bins.
+	for _, amt := range []*big.Int{exp10(15), exp10(16), exp10(17)} {
+		_, _, chainFinalBin := viewerQuoteSwap(t, ctx, client, pinBlock, false, amt)
+
+		hop := sim.CloneState() // never mutate the shared base
+		res, err := hop.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: amt}, TokenOut: tokenX,
+		})
+		require.NoError(t, err)
+		si := res.SwapInfo.(SwapInfo)
+		require.Equal(t, chainFinalBin.Uint64(), uint64(si.newActiveID),
+			"post-swap active bin must match the pair's finalBinId (amt=%s)", amt)
+
+		// Apply the trade, then assert UpdateBalance wrote back CalcAmountOut's own per-bin deltas
+		// verbatim (consumes SwapInfo, never recomputes) and advanced the active bin.
+		hop.UpdateBalance(pool.UpdateBalanceParams{SwapInfo: si})
+		mutated := hop.(*PoolSimulator)
+		require.Equal(t, si.newActiveID, mutated.activeID, "UpdateBalance must advance activeID")
+		for _, u := range si.binUpdates {
+			require.Equal(t, u.reserveX, mutated.bins[u.index].ReserveX, "bin %d reserveX after update", mutated.bins[u.index].ID)
+			require.Equal(t, u.reserveY, mutated.bins[u.index].ReserveY, "bin %d reserveY after update", mutated.bins[u.index].ID)
+		}
+
+		// A second swap must start from the advanced book: the same input now yields no more than the
+		// first hop did (consumed liquidity is gone) and still lands at-or-beyond the new active bin.
+		res2, err := hop.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: amt}, TokenOut: tokenX,
+		})
+		if err == nil {
+			require.LessOrEqual(t, res2.TokenAmountOut.Amount.Cmp(res.TokenAmountOut.Amount), 0,
+				"second hop must not out-quote the first on a depleted book (amt=%s)", amt)
+			si2 := res2.SwapInfo.(SwapInfo)
+			require.GreaterOrEqual(t, uint64(si2.newActiveID), uint64(si.newActiveID),
+				"second hop must continue from the advanced active bin (amt=%s)", amt)
+		}
+		t.Logf("Y->X amt=%-22s finalBin chain=%d sim=%d out1=%s", amt, chainFinalBin, si.newActiveID, res.TokenAmountOut.Amount)
+	}
+}
+
+// buildLiveSimulator runs the real lister-equivalent static config + tracker -> simulator pipeline
+// against the canonical pair, returning the simulator, its token addresses and the pinned block.
+func buildLiveSimulator(t *testing.T, ctx context.Context, client *ethrpc.Client) (*PoolSimulator, string, string, *big.Int) {
+	t.Helper()
+	var (
+		tokenXAddr, tokenYAddr common.Address
+		dec                    decimalsResult
+		binStep                uint16
+	)
+	_, err := client.R().SetContext(ctx).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodTokenX}, []any{&tokenXAddr}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodTokenY}, []any{&tokenYAddr}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodBinStep}, []any{&binStep}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: verifyPair, Method: pairMethodGetDecimals}, []any{&dec}).
+		Aggregate()
+	require.NoError(t, err)
+
+	se, _ := json.Marshal(StaticExtra{BinStep: binStep, DecimalsX: dec.DecimalsX, DecimalsY: dec.DecimalsY, Router: verifyRouter})
+	ep := entity.Pool{
+		Address: verifyPair, Exchange: DexType, Type: DexType,
+		Reserves:    entity.PoolReserves{"0", "0"},
+		Tokens:      []*entity.PoolToken{{Address: tokenXAddr.Hex()}, {Address: tokenYAddr.Hex()}},
+		StaticExtra: string(se), Extra: "{}",
+	}
+	tracker := NewPoolTracker(&Config{DexID: DexType, FactoryAddress: verifyFactory, ViewerAddress: verifyViewer, RouterAddress: verifyRouter}, client)
+	ep, err = tracker.GetNewPoolState(ctx, ep, pool.GetNewPoolStateParams{})
+	require.NoError(t, err)
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+	return sim, tokenXAddr.Hex(), tokenYAddr.Hex(), new(big.Int).SetUint64(ep.BlockNumber)
+}
+
+func parseExtra(t *testing.T, s string) Extra {
+	t.Helper()
+	var e Extra
+	require.NoError(t, json.Unmarshal([]byte(s), &e))
+	return e
+}
+
+func exp10(n uint) *big.Int            { return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(n)), nil) }
+func mul(a *big.Int, n int64) *big.Int { return new(big.Int).Mul(a, big.NewInt(n)) }

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -157,6 +157,8 @@ import (
 	pkg_liquiditysource_syncswapv2_classic "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/classic"
 	pkg_liquiditysource_syncswapv2_stable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/stable"
 	pkg_liquiditysource_tessera "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tessera"
+	pkg_liquiditysource_umbraedamm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae-damm"
+	pkg_liquiditysource_umbraedlmm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae-dlmm"
 	pkg_liquiditysource_unipool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/unipool"
 	pkg_liquiditysource_uniswap_lo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/lo"
 	pkg_liquiditysource_uniswap_v1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v1"
@@ -394,6 +396,8 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_syncswapv2_classic.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_syncswapv2_stable.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_tessera.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_umbraedamm.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_umbraedlmm.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_unipool.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_lo.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v1.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -141,6 +141,8 @@ import (
 	syncswapv2classic "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/classic"
 	syncswapv2stable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/stable"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tessera"
+	umbraedamm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae-damm"
+	umbraedlmm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae-dlmm"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/unipool"
 	uniswaplo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/lo"
 	uniswapv1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v1"
@@ -406,6 +408,8 @@ type Types struct {
 	Infinifi                   string
 	Nabla                      string
 	Tessera                    string
+	UmbraeDamm                 string
+	UmbraeDlmm                 string
 	LiquidCore                 string
 	LunarBase                  string
 	FrxUSD                     string
@@ -632,6 +636,8 @@ var (
 		Infinifi:                   infinifi.DexType,
 		Nabla:                      nabla.DexType,
 		Tessera:                    tessera.DexType,
+		UmbraeDamm:                 umbraedamm.DexType,
+		UmbraeDlmm:                 umbraedlmm.DexType,
 		LiquidCore:                 liquidcore.DexType,
 		LunarBase:                  lunarbase.DexType,
 		FrxUSD:                     frxusd.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -257,6 +257,8 @@ const (
 	ExchangeSynthetix                  = "synthetix"
 	ExchangeTessera                    = "tessera"
 	ExchangeThenaFusionV3              = "thena-fusion-v3"
+	ExchangeUmbraeDamm                 = "umbrae-damm"
+	ExchangeUmbraeDlmm                 = "umbrae-dlmm"
 	ExchangeUniPool                    = "unipool"
 	ExchangeUniSwap                    = "uniswap"
 	ExchangeUniswapLO                  = "uniswap-lo"


### PR DESCRIPTION
## Why did we need it?

This PR integrates **Umbrae**'s two on-chain venues on **Base (chainId 8453)** into the aggregator so routes can discover, track and price them:

- **Umbrae DLMM** — a Liquidity-Book–style **bin AMM** (concentrated liquidity per discrete price bin) with a dynamic, volatility-based fee. This is Umbrae's flagship venue.
- **Umbrae DAMM** — a constant-product (x*y=k) AMM with a single fee tier.

Both are live on Base with real liquidity (U1/WETH).

### DEX background & docs
- Umbrae is a sovereign DEX on Base. Public docs: https://umbrae.io
- DLMM is structurally similar to Trader Joe LB v2.1 (bins, `binStep`, volatility accumulator), **but the on-chain price and per-bin swap math differ** — this integration ports Umbrae's deployed math, not the LB v2.1 reference (see Pricing below).

### Pricing / fee logic

**DLMM** (`pkg/liquidity-source/umbrae-dlmm`)
- Bin price = `(1 + binStep/10000)^(binId − 2^23)` computed in **1e18 fixed point via exponentiation-by-squaring** (matches the deployed `BinHelper.getPriceFromId`; not the 128.128 algorithm in the LB reference), then adjusted for `decimalsY`.
- Swap traverses bins from the active id — selling X walks **down** bin ids, selling Y walks **up** — consuming each bin's output reserve at its fixed price until the input is spent or liquidity runs out (partial fill returns leftover input).
- Dynamic fee = base fee + quadratic variable fee; the volatility accumulator ramps by `|binId − reference|` (capped) as bins are crossed and decays over time. The tracker reads fee state from the pair's `getQuoteState()` and decays the accumulator to the tracked block; the simulator ramps it during traversal, reproducing the pair's `quoteSwap()` exactly.
- Pools are discovered on-chain from the DLMM **Factory** (`allPairsLength`/`allPairs`); the tracker pulls bins via the **PairViewer** and pins all reads to one block.

**DAMM** (`pkg/liquidity-source/umbrae-damm`)
- `out = floor(inAfterFee * reserveOut / (reserveIn + inAfterFee))`.
- **feeToken model**: the fee is always charged in a fixed `feeToken` (WETH) — on the input when `tokenIn == feeToken`, otherwise on the output. The tracker snapshots `getReserves()`, `currentFeeBps()` and `feeToken()`.

### Important contract addresses (Base, 8453)
| Contract | Address |
|---|---|
| DLMM Factory | [`0x17Da44dcbdffD8c715be7A368E19F252C2940Fee`](https://basescan.org/address/0x17Da44dcbdffD8c715be7A368E19F252C2940Fee) |
| DLMM PairViewer (quotes/bins) | [`0xbA3A5400A95b055b1412e18ad1978EdF32Fc3F05`](https://basescan.org/address/0xbA3A5400A95b055b1412e18ad1978EdF32Fc3F05) |
| DLMM Router (swap entry / token spender) | [`0x4965DD6877ca9DE77caca2f57996651e7AF23c93`](https://basescan.org/address/0x4965DD6877ca9DE77caca2f57996651e7AF23c93) |
| DLMM U1/WETH pair (binStep 25) | [`0x697b72320656e6dc60db7a4bfb95084c9d9c55a0`](https://basescan.org/address/0x697b72320656e6dc60db7a4bfb95084c9d9c55a0) |
| DAMM U1/WETH pair | [`0x296964C34a571fCf85d3F74FB815ee871F5A08d4`](https://basescan.org/address/0x296964C34a571fCf85d3F74FB815ee871F5A08d4) |
| U1 token | [`0x14a4e80d633af55ace1160c320f5a36d41cced3e`](https://basescan.org/address/0x14a4e80d633af55ace1160c320f5a36d41cced3e) |
| WETH | [`0x4200000000000000000000000000000000000006`](https://basescan.org/address/0x4200000000000000000000000000000000000006) |

> Note on approvals: the DLMM pair is a BeaconProxy that reverts on direct swap calls, so swaps execute through the **DLMM Router** — `GetApprovalAddress` returns the router. DAMM has no router; its `GetApprovalAddress` returns the pair.

## Related Issue
N/A — integration requested directly by the KyberSwap team (Ken Tran).

## Release Note
- Two new exchanges: `umbrae-dlmm`, `umbrae-damm` (both Base / 8453).
- Config required per source: DLMM needs `factoryAddress`, `viewerAddress`, `routerAddress`; DAMM is config-driven pool list. No breaking changes to existing components.
- Exact-out (`CalcAmountIn`) is **not** implemented in this PR (exact-in only); the DLMM router supports it on-chain, so it can be added as a fast-follow if needed.

## How Has This Been Tested?

Each venue has an end-to-end test that runs the **real PoolTracker → PoolSimulator** pipeline and compares `CalcAmountOut` to the **live on-chain quote** (DLMM `PairViewer.quoteSwap`, DAMM `getAmountOut`), across a spread of input amounts in both directions, all pinned to one block. Set `UMBRAE_BASE_RPC_URL` to run:

```
go test ./pkg/liquidity-source/umbrae-dlmm/... ./pkg/liquidity-source/umbrae-damm/...
```

**Results — wei-exact:**
- **DAMM 10/10** both directions (block-pinned). e.g. `Y->X in=1e18 → chain=13863105192902239344606 == sim`.
- **DLMM 14/14** both directions (block-pinned). e.g. `Y->X in=1e17 → chain=140819484247252194769 == sim`; multi-bin traversal (14→100 bins) matches exactly.

Additional live tests: `TestVerifyListerLive` (factory enumeration discovers the U1/WETH pair with correct static config) and `TestVerifyUpdateBalance` (post-swap `newActiveID` matches the pair's on-chain `finalBinId`; `UpdateBalance` applies `CalcAmountOut`'s per-bin deltas verbatim). Offline unit tests cover single-bin arithmetic, fee math, decimal scaling (synthetic 6/18-decimal pool) and clone isolation.

`go build ./...` and `go generate ./pkg/msgpack/...` are clean.
