### PR TITLE
feat(lgl-clob): implement CalcAmountIn for exact-out swaps

### DIFF
--- a/pkg/liquidity-source/lgl-clob/constant.go
+++ b/pkg/liquidity-source/lgl-clob/constant.go
@@ -22,8 +22,9 @@ var (
 	bMaxPriceLevels       = big.NewInt(maxPriceLevels)
 	uPriceLimitMultiplier = new(uint256.Int).AddUint64(big256.UBasisPoint, 12)
 
-	ErrInvalidToken         = errors.New("invalid token")
-	ErrInvalidAmount        = errors.New("invalid amount")
-	ErrEmptyOrders          = errors.New("empty orders")
-	ErrExceededSafetyBuffer = errors.New("exceed safety buffer")
+	ErrInvalidToken          = errors.New("invalid token")
+	ErrInvalidAmount         = errors.New("invalid amount")
+	ErrEmptyOrders           = errors.New("empty orders")
+	ErrExceededSafetyBuffer  = errors.New("exceed safety buffer")
+	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
 )

--- a/pkg/liquidity-source/lgl-clob/pool_simulator.go
+++ b/pkg/liquidity-source/lgl-clob/pool_simulator.go
@@ -171,6 +171,157 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (swapResul
 	}, nil
 }
 
+func (p *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
+	tokenAmountOut, tokenIn := param.TokenAmountOut, param.TokenIn
+	amtOut, overflow := uint256.FromBig(tokenAmountOut.Amount)
+	if overflow || amtOut.IsZero() {
+		return nil, ErrInvalidAmount
+	}
+	indexIn, indexOut := p.GetTokenIndex(tokenIn), p.GetTokenIndex(tokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 {
+		return nil, ErrInvalidToken
+	}
+
+	isBuy := indexOut == 0
+	var levels *OrderBookLevels
+	var scalingFactorIn, scalingFactorOut *uint256.Int
+	if isBuy {
+		levels = &p.Asks
+		scalingFactorIn = p.ScalingFactorY
+		scalingFactorOut = p.ScalingFactorX
+	} else {
+		levels = &p.Bids
+		scalingFactorIn = p.ScalingFactorX
+		scalingFactorOut = p.ScalingFactorY
+	}
+	if len(levels.ArrayPrices) == 0 {
+		return nil, ErrEmptyOrders
+	}
+
+	var executedScaledAmountIn, executedScaledAmountOut, executedShares, executedValue, tmp uint256.Int
+	var uOne uint256.Int
+	uOne.SetUint64(1)
+	var executedLevels int
+	var executionDone bool
+
+	if isBuy {
+		// Buy tokenX with tokenY: find min Y to receive at least amtOut tokenX.
+		// scaledTarget = ceil(amtOut / sfX): minimum scaled X units to produce >= amtOut
+		var scaledTarget uint256.Int
+		big256.MulDivUp(&scaledTarget, amtOut, &uOne, scalingFactorOut)
+
+		for i, price := range levels.ArrayPrices {
+			shares := levels.ArrayShares[i]
+			executedLevels++
+			executedShares.Set(&scaledTarget)
+			if executionDone = !executedShares.Gt(shares); !executionDone {
+				executedShares.Set(shares)
+			}
+			executedValue.Mul(&executedShares, price) // cost in scaled Y
+			scaledTarget.Sub(&scaledTarget, &executedShares)
+			executedScaledAmountOut.Add(&executedScaledAmountOut, &executedShares)
+			executedScaledAmountIn.Add(&executedScaledAmountIn, &executedValue)
+			if executionDone {
+				break
+			}
+		}
+		if !executionDone {
+			return nil, ErrInsufficientLiquidity
+		}
+	} else {
+		// Sell tokenX for tokenY: find min X to receive at least amtOut net tokenY.
+		// Find minimum scaledGrossOut such that grossOut - ceil(grossOut * fee / BONE) >= amtOut.
+		var scaledGrossOut, boneMinusFee uint256.Int
+		boneMinusFee.Sub(big256.BONE, p.swapFee)
+		big256.MulDivUp(&tmp, amtOut, big256.BONE, &boneMinusFee)
+		big256.MulDivUp(&scaledGrossOut, &tmp, &uOne, scalingFactorOut)
+		for {
+			var grossOut, fee, net uint256.Int
+			grossOut.Mul(&scaledGrossOut, scalingFactorOut)
+			big256.MulWadUp(&fee, &grossOut, p.swapFee)
+			net.Sub(&grossOut, &fee)
+			if !net.Lt(amtOut) {
+				break
+			}
+			scaledGrossOut.AddUint64(&scaledGrossOut, 1)
+		}
+
+		remaining := new(uint256.Int).Set(&scaledGrossOut)
+		for i, price := range levels.ArrayPrices {
+			shares := levels.ArrayShares[i]
+			executedLevels++
+			executedValue.Mul(shares, price) // max scaled Y output at this level
+			if !executedValue.Lt(remaining) {
+				// Partial fill: ceil(remaining / price) shares to get >= remaining scaled Y
+				big256.MulDivUp(&executedShares, remaining, &uOne, price)
+				if executedShares.Gt(shares) {
+					executedShares.Set(shares)
+				}
+				executedValue.Mul(&executedShares, price)
+				remaining.Clear()
+				executionDone = true
+			} else {
+				executedShares.Set(shares)
+				remaining.Sub(remaining, &executedValue)
+			}
+			executedScaledAmountIn.Add(&executedScaledAmountIn, &executedShares)
+			executedScaledAmountOut.Add(&executedScaledAmountOut, &executedValue)
+			if executionDone {
+				break
+			}
+		}
+		if !executionDone {
+			return nil, ErrInsufficientLiquidity
+		}
+	}
+
+	gas := int64(197346*math.Log(float64(executedLevels+1)/2) + 494222)
+	if executedShares.Eq(levels.ArrayShares[executedLevels-1]) {
+		executedShares.Clear()
+		executedLevels++
+	}
+
+	executedAmountIn := executedScaledAmountIn.Mul(&executedScaledAmountIn, scalingFactorIn)
+	executedAmountOut := executedScaledAmountOut.Mul(&executedScaledAmountOut, scalingFactorOut)
+
+	reserveOutF, _ := p.GetReserves()[indexOut].Float64()
+	if p.cumAmtOutF+executedAmountOut.Float64() > reserveOutF*safetyBuffer {
+		return nil, ErrExceededSafetyBuffer
+	}
+
+	var feesTokenY *uint256.Int
+	var amtIn *uint256.Int
+	if isBuy {
+		feesTokenY = big256.MulWadUp(&tmp, executedAmountIn, p.swapFee)
+		amtIn = new(uint256.Int).Add(executedAmountIn, feesTokenY)
+	} else {
+		feesTokenY = big256.MulWadUp(&tmp, executedAmountOut, p.swapFee)
+		executedAmountOut.Sub(executedAmountOut, feesTokenY)
+		amtIn = executedAmountIn
+	}
+
+	priceLimit := levels.ArrayPrices[len(levels.ArrayPrices)-1]
+	if isBuy {
+		priceLimit = big256.MulDivUp(&executedValue, priceLimit, uPriceLimitMultiplier, big256.UBasisPoint)
+	} else {
+		priceLimit = big256.MulDivDown(&executedValue, priceLimit, big256.UBasisPoint, uPriceLimitMultiplier)
+	}
+	priceLimit = round(priceLimit, priceLimitPrecision, isBuy)
+
+	return &pool.CalcAmountInResult{
+		TokenAmountIn:           &pool.TokenAmount{Token: tokenIn, Amount: amtIn.ToBig()},
+		RemainingTokenAmountOut: &pool.TokenAmount{Token: tokenAmountOut.Token, Amount: big.NewInt(0)},
+		Fee:                     &pool.TokenAmount{Token: p.Info.Tokens[1], Amount: feesTokenY.ToBig()},
+		Gas:                     gas,
+		SwapInfo: SwapInfo{
+			executedLevels:     executedLevels,
+			lastExecutedShares: &executedShares,
+			HasNative:          p.SupportsNativeEth,
+			PriceLimit:         priceLimit,
+		},
+	}, nil
+}
+
 func (p *PoolSimulator) CloneState() pool.IPoolSimulator {
 	cloned := *p
 	cloned.OrderBook = lo.ToPtr(*p.OrderBook)

--- a/pkg/liquidity-source/lgl-clob/pool_simulator_test.go
+++ b/pkg/liquidity-source/lgl-clob/pool_simulator_test.go
@@ -432,6 +432,178 @@ func TestPoolSimulator_UpdateBalance(t *testing.T) {
 	assert.Equal(t, "3116", poolSim.Bids.ArrayPrices[0].String())
 }
 
+// CalcAmountIn tests — exact-out direction, verifying inverse of CalcAmountOut.
+
+func TestPoolSimulator_CalcAmountIn_Y_To_X(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	// Want 3.2 S (tokenX). From CalcAmountOut: amtIn=998380 USDC produces 3.2 S.
+	result, err := poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{
+			Token:  "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+			Amount: bignumber.NewBig10("3200000000000000000"),
+		},
+		TokenIn: "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "998380", result.TokenAmountIn.Amount.String())
+	assert.Equal(t, "0x29219dd400f2bf60e5a23d13be72b486d4038894", result.TokenAmountIn.Token)
+	assert.Equal(t, "300", result.Fee.Amount.String())
+	assert.Equal(t, "0", result.RemainingTokenAmountOut.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.GtUint64(100000000))
+}
+
+func TestPoolSimulator_CalcAmountIn_X_To_Y(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	// Want 311606 USDC (tokenY). From CalcAmountOut: amtIn=1e18 S produces 311606 USDC.
+	result, err := poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{
+			Token:  "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+			Amount: bignumber.NewBig10("311606"),
+		},
+		TokenIn: "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "1000000000000000000", result.TokenAmountIn.Amount.String())
+	assert.Equal(t, "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38", result.TokenAmountIn.Token)
+	assert.Equal(t, "94", result.Fee.Amount.String())
+	assert.Equal(t, "0", result.RemainingTokenAmountOut.Amount.String())
+	assert.True(t, result.SwapInfo.(SwapInfo).PriceLimit.LtUint64(890))
+}
+
+func TestPoolSimulator_CalcAmountIn_Y_To_X_FillLevel(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	// Want exactly 9334.70 S (fills all of asks level 0).
+	// From CalcAmountOut: amtIn=2912366378 USDC produces 9334700000000000000000 S, fee=873448.
+	result, err := poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{
+			Token:  "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+			Amount: bignumber.NewBig10("9334700000000000000000"),
+		},
+		TokenIn: "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "2912366378", result.TokenAmountIn.Amount.String())
+	assert.Equal(t, "873448", result.Fee.Amount.String())
+	assert.Equal(t, "0", result.RemainingTokenAmountOut.Amount.String())
+}
+
+func TestPoolSimulator_CalcAmountIn_InsufficientLiquidity(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPool), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	// Ask for more S than the entire ask book can provide.
+	_, err = poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{
+			Token:  "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+			Amount: bignumber.NewBig10("9999999999999999999999999"),
+		},
+		TokenIn: "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+	})
+	require.ErrorIs(t, err, ErrInsufficientLiquidity)
+}
+
+func TestPoolSimulator_CalcAmountIn_EmptyPool(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	err := json.Unmarshal([]byte(susdcPoolEmpty), poolEntity)
+	require.NoError(t, err)
+
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	_, err = poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{
+			Token:  "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+			Amount: bignumber.NewBig10("1000000000000000000"),
+		},
+		TokenIn: "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+	})
+	require.ErrorIs(t, err, ErrEmptyOrders)
+}
+
+// CalcAmountIn → CalcAmountOut round-trip: amtOut from CalcAmountOut must be >= desired.
+func TestPoolSimulator_CalcAmountIn_RoundTrip_Y_To_X(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	require.NoError(t, json.Unmarshal([]byte(susdcPool), poolEntity))
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	desiredOut := bignumber.NewBig10("5000000000000000000") // 5 S
+
+	inResult, err := poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38", Amount: desiredOut},
+		TokenIn:        "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+	})
+	require.NoError(t, err)
+
+	outResult, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: "0x29219dd400f2bf60e5a23d13be72b486d4038894", Amount: inResult.TokenAmountIn.Amount},
+		TokenOut:      "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+	})
+	require.NoError(t, err)
+	assert.True(t, outResult.TokenAmountOut.Amount.Cmp(desiredOut) >= 0, "CalcAmountOut must produce at least desired")
+}
+
+func TestPoolSimulator_CalcAmountIn_RoundTrip_X_To_Y(t *testing.T) {
+	t.Parallel()
+
+	poolEntity := new(entity.Pool)
+	require.NoError(t, json.Unmarshal([]byte(susdcPool), poolEntity))
+	poolSim, err := NewPoolSimulator(*poolEntity)
+	require.NoError(t, err)
+
+	desiredOut := bignumber.NewBig10("500000") // 0.5 USDC
+
+	inResult, err := poolSim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: "0x29219dd400f2bf60e5a23d13be72b486d4038894", Amount: desiredOut},
+		TokenIn:        "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38",
+	})
+	require.NoError(t, err)
+
+	outResult, err := poolSim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: "0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38", Amount: inResult.TokenAmountIn.Amount},
+		TokenOut:      "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+	})
+	require.NoError(t, err)
+	assert.True(t, outResult.TokenAmountOut.Amount.Cmp(desiredOut) >= 0, "CalcAmountOut must produce at least desired")
+}
+
 // BenchmarkRoundFloat-16    14106196    123.6  ns/op
 // BenchmarkRound-16         96619128     12.32 ns/op
 func BenchmarkRound(b *testing.B) {

--- a/pkg/liquidity-source/lgl-clob/pool_simulator_testutil_test.go
+++ b/pkg/liquidity-source/lgl-clob/pool_simulator_testutil_test.go
@@ -1,0 +1,115 @@
+package lglclob
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+)
+
+// pools p etherlink hanji (block 46540073)
+const wxtzUsdcPoolJSON = `{
+	"address": "0xc0ba6913a5703e0c8ce0338cf952accfeebcecf9",
+	"swapFee": 0.0002,
+	"exchange": "hanji",
+	"type": "lgl-clob",
+	"reserves": ["299115400000000000000000","8336539359"],
+	"tokens": [
+		{"address":"0xc9b53ab2679f573e480d01e0f49e2b5cfb7a3eab","symbol":"WXTZ","decimals":18,"swappable":true},
+		{"address":"0x796ea11fa2dd751ed01b53c372ffdb4aaa8f00f9","symbol":"USDC","decimals":6,"swappable":true}
+	],
+	"extra": "{\"b\":{\"p\":[\"21769\",\"21767\",\"21758\",\"21750\",\"15000\",\"10000\",\"5000\",\"100\",\"10\"],\"s\":[\"18826\",\"56483\",\"113013\",\"188425\",\"2338\",\"5000\",\"10000\",\"1\",\"500000\"]},\"a\":{\"p\":[\"21816\",\"21818\",\"21827\",\"21835\",\"125000\"],\"s\":[\"45837\",\"229168\",\"916296\",\"1797852\",\"2001\"]}}",
+	"staticExtra": "{\"sX\":\"100000000000000000\",\"sY\":\"1\",\"n\":true}"
+}`
+
+// pools p etherlink hanji (block 46540079)
+const wxtzWethPoolJSON = `{
+	"address": "0x0521767cdd2517b3133f0b102ee7d9988413a86a",
+	"swapFee": 0.0003,
+	"exchange": "hanji",
+	"type": "lgl-clob",
+	"reserves": ["298923873079000000000000","2738660660507160000"],
+	"tokens": [
+		{"address":"0xc9b53ab2679f573e480d01e0f49e2b5cfb7a3eab","symbol":"WXTZ","decimals":18,"swappable":true},
+		{"address":"0xfc24f770f94edbca6d6f885e12d4317320bcb401","symbol":"WETH","decimals":18,"swappable":true}
+	],
+	"extra": "{\"b\":{\"p\":[\"1376000\",\"1375860\",\"1375040\",\"1374490\"],\"s\":[\"995152856\",\"2985762353\",\"5975085802\",\"9962461206\"]},\"a\":{\"p\":[\"1378660\",\"1378800\",\"1379630\",\"1380180\"],\"s\":[\"4584823480\",\"22921789743\",\"91631999011\",\"179785260845\"]}}",
+	"staticExtra": "{\"sX\":\"1000000000000\",\"sY\":\"100\",\"n\":true}"
+}`
+
+func mustNewSim(t *testing.T, rawJSON string) *PoolSimulator {
+	t.Helper()
+	var ep entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(rawJSON), &ep))
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+	return sim
+}
+
+// WXTZ/USDC: sfX=1e17 (0.1 WXTZ/share), sfY=1 (1 USDC/share), fee=0.0002
+func TestCalcAmountOut_WXTZ_USDC(t *testing.T) {
+	t.Parallel()
+
+	sim := mustNewSim(t, wxtzUsdcPoolJSON)
+
+	// token0=WXTZ, token1=USDC
+	testutil.TestCalcAmountOut(t, sim, map[int]map[int]map[string]string{
+		0: {1: {
+			// sell 0.1 WXTZ (1 share at bid 21769): gross=21769, fee=ceil(21769*0.0002)=5, net=21764
+			"100000000000000000": "21764",
+			// sell 1 WXTZ (10 shares at bid 21769): gross=217690, fee=44, net=217646
+			"1000000000000000000": "217646",
+			// sell 10 WXTZ (100 shares at bid 21769): gross=2176900, fee=ceil(435.38)=436, net=2176464
+			"10000000000000000000": "2176464",
+		}},
+		1: {0: {
+			// buy 0.1 WXTZ (1 share at ask 21816, net cost 21816, fee=ceil(21816*0.0002)=5, amtIn=21821)
+			// availableAmtIn = floor(21821/1.0002)=21816, scaledAmtIn=21816, shares=floor(21816/21816)=1
+			"21821": "100000000000000000",
+			// buy 1 WXTZ (10 shares at ask 21816, net cost 218160, fee=ceil(218160*0.0002)=44, amtIn=218204)
+			"218204": "1000000000000000000",
+		}},
+	})
+}
+
+func TestCalcAmountIn_WXTZ_USDC(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountIn(t, mustNewSim(t, wxtzUsdcPoolJSON))
+}
+
+// WXTZ/WETH: sfX=1e12 (1e-6 WXTZ/share), sfY=100 (100 wei WETH/share), fee=0.0003
+func TestCalcAmountOut_WXTZ_WETH(t *testing.T) {
+	t.Parallel()
+
+	sim := mustNewSim(t, wxtzWethPoolJSON)
+
+	// token0=WXTZ, token1=WETH
+	testutil.TestCalcAmountOut(t, sim, map[int]map[int]map[string]string{
+		0: {1: {
+			// sell 1 WXTZ = 1e18 wei → 1e6 shares at bid 1376000
+			// gross = 1e6 * 1376000 = 1376000000000 scaled Y, * sfY=100 → 137600000000000 wei WETH
+			// fee = ceil(137600000000000 * 0.0003) = ceil(41280000000000) = wait
+			// Actually fee = ceil(137600000000000 * 3e14 / 1e18) = ceil(137600000000000 * 3e-4)
+			// = ceil(41280000000) = 41280000001? no: 137600000000000 * 3e-4 = 41280000000
+			// fee = 41280000000
+			// net = 137600000000000 - 41280000000 = 137558720000000
+			"1000000000000000000": "137558720000000",
+		}},
+		1: {0: {
+			// buy 1 WXTZ = 1e18 wei → 1e6 shares at ask 1378660
+			// cost = 1e6 * 1378660 scaled Y = 1378660000000 scaled Y * 100 = 137866000000000 wei WETH
+			// fee = ceil(137866000000000 * 3e-4) = ceil(41359800000) = 41359800000
+			// amtIn = 137866000000000 + 41359800000 = 137907359800000
+			// availableAmtIn = floor(137907359800000 / 1.0003) = floor(137866000000000) = 137866000000000 ✓
+			"137907359800000": "1000000000000000000",
+		}},
+	})
+}
+
+func TestCalcAmountIn_WXTZ_WETH(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountIn(t, mustNewSim(t, wxtzWethPoolJSON))
+}


### PR DESCRIPTION
Walk the ask book (buy) or bid book (sell) from the desired output
amount to find the minimum tokenIn required. Fee inversion for the sell
direction finds the smallest gross output multiple that yields at least
the requested net amount after fee deduction.

Adds ErrInsufficientLiquidity for when the book cannot fill the request,
unit tests mirroring CalcAmountOut fixtures, and testutil round-trip
tests against live hanji/etherlink pool snapshots (WXTZ/USDC, WXTZ/WETH).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
