### PR TITLE
fix(lunarbase): stale-price check disabled after StateUpdated log

### DIFF
--- a/pkg/liquidity-source/lunarbase/pool_tracker.go
+++ b/pkg/liquidity-source/lunarbase/pool_tracker.go
@@ -134,7 +134,8 @@ func (t *PoolTracker) processLogs(p entity.Pool, logs []types.Log) (entity.Pool,
 			return p, err
 		}
 		p.Extra = string(extraBytes)
-		if latestLogBlock > 0 {
+		// > LatestUpdateBlock: prevents p.BlockNumber==LatestUpdateBlock (0-diff stale check) when StateUpdated is the only event.
+		if latestLogBlock > extra.LatestUpdateBlock {
 			p.BlockNumber = latestLogBlock
 		}
 		p.Timestamp = time.Now().Unix()

--- a/pkg/liquidity-source/lunarbase/pool_tracker_test.go
+++ b/pkg/liquidity-source/lunarbase/pool_tracker_test.go
@@ -132,13 +132,98 @@ func TestProcessLogsUpdatesLatestUpdateBlock(t *testing.T) {
 	if extra.LatestUpdateBlock != 25 {
 		t.Fatalf("expected latest update block 25, got %d", extra.LatestUpdateBlock)
 	}
-	if got.BlockNumber != 25 {
-		t.Fatalf("expected pool block number 25, got %d", got.BlockNumber)
+	// p.BlockNumber must NOT be set to latestLogBlock when it equals
+	// LatestUpdateBlock; that would make IsStale always return 0-diff.
+	// The old value (10) is kept so subsequent blocks can advance past it.
+	if got.BlockNumber != 10 {
+		t.Fatalf("expected pool block number 10 (unchanged), got %d", got.BlockNumber)
 	}
 	if extra.SqrtPriceX96 == nil || extra.SqrtPriceX96.Uint64() != 123 {
 		t.Fatalf("expected SqrtPriceX96 123, got %v", extra.SqrtPriceX96)
 	}
 	if extra.FeeAskX24 != 456 || extra.FeeBidX24 != 789 {
 		t.Fatalf("expected fees 456/789, got %d/%d", extra.FeeAskX24, extra.FeeBidX24)
+	}
+}
+
+// TestStateUpdatedLogDoesNotDisableStaleCheck is a regression for the bug where
+// processing a StateUpdated-only log set p.BlockNumber == extra.LatestUpdateBlock,
+// making IsStale always return false (0-diff) regardless of how many blocks passed.
+func TestStateUpdatedLogDoesNotDisableStaleCheck(t *testing.T) {
+	const blockDelay = 5
+
+	extraBytes, err := json.Marshal(Extra{
+		SqrtPriceX96:      uint256.NewInt(1),
+		LatestUpdateBlock: 10,
+		BlockDelay:        blockDelay,
+		ConcentrationK:    5000,
+	})
+	if err != nil {
+		t.Fatalf("marshal extra: %v", err)
+	}
+
+	poolEntity := entity.Pool{
+		Address:     "0x00003bf45ce34bf1bea78669f9a40ee630e11b99",
+		Exchange:    DexType,
+		Type:        DexType,
+		BlockNumber: 10,
+		Reserves:    entity.PoolReserves{"100", "200"},
+		Extra:       string(extraBytes),
+	}
+
+	stateData, err := coreABI.Events["StateUpdated"].Inputs.Pack(
+		big.NewInt(999), // anchorPrice
+		big.NewInt(0),   // feeAskX24
+		big.NewInt(0),   // feeBidX24
+	)
+	if err != nil {
+		t.Fatalf("pack state updated event: %v", err)
+	}
+
+	tracker := NewPoolTracker(&Config{DexID: DexType, ChainID: valueobject.ChainIDBase}, nil)
+
+	// Simulate a StateUpdated at block 20 — the only event in this batch.
+	got, err := tracker.processLogs(poolEntity, []types.Log{
+		{Topics: []common.Hash{topicStateUpdated}, Data: stateData, BlockNumber: 20},
+	})
+	if err != nil {
+		t.Fatalf("process logs: %v", err)
+	}
+
+	var extra Extra
+	if err := json.Unmarshal([]byte(got.Extra), &extra); err != nil {
+		t.Fatalf("unmarshal extra: %v", err)
+	}
+	if extra.LatestUpdateBlock != 20 {
+		t.Fatalf("LatestUpdateBlock: want 20, got %d", extra.LatestUpdateBlock)
+	}
+
+	// p.BlockNumber must NOT equal LatestUpdateBlock; that collapses the
+	// stale-check diff to 0 and prevents staleness detection permanently.
+	if got.BlockNumber == extra.LatestUpdateBlock {
+		t.Fatalf("p.BlockNumber (%d) == LatestUpdateBlock (%d): stale check is permanently disabled",
+			got.BlockNumber, extra.LatestUpdateBlock)
+	}
+
+	// Now simulate a Sync log arriving blockDelay+1 blocks after the StateUpdated.
+	// The pool is stale at that point and IsStale must return true.
+	staleBlock := extra.LatestUpdateBlock + blockDelay + 1
+	syncData, err := coreABI.Events["Sync"].Inputs.Pack(big.NewInt(300), big.NewInt(400))
+	if err != nil {
+		t.Fatalf("pack sync event: %v", err)
+	}
+	got2, err := tracker.processLogs(got, []types.Log{
+		{Topics: []common.Hash{topicSync}, Data: syncData, BlockNumber: staleBlock},
+	})
+	if err != nil {
+		t.Fatalf("process logs (sync): %v", err)
+	}
+	var extra2 Extra
+	if err := json.Unmarshal([]byte(got2.Extra), &extra2); err != nil {
+		t.Fatalf("unmarshal extra2: %v", err)
+	}
+	if !extra2.IsStale(got2.BlockNumber) {
+		t.Fatalf("expected pool to be stale at block %d (LatestUpdateBlock=%d, BlockDelay=%d)",
+			got2.BlockNumber, extra2.LatestUpdateBlock, extra2.BlockDelay)
 	}
 }


### PR DESCRIPTION
When processLogs handled a StateUpdated-only batch, latestLogBlock equalled
extra.LatestUpdateBlock, so p.BlockNumber was set to the same value.
IsStale(p.BlockNumber) then always computed a 0-block diff and returned
false, letting the pool serve quotes that would revert on-chain once
BlockDelay blocks had passed since the last operator price update.

Fix: only advance p.BlockNumber when latestLogBlock > extra.LatestUpdateBlock,
so p.BlockNumber can never be pinned equal to LatestUpdateBlock by a
StateUpdated-only batch. As a side effect this also prevents p.BlockNumber
rolling back when delayed/out-of-order logs arrive at an earlier block.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
