### PR TITLE
[Avalanche] Add AEON Protocol vAMM liquidity source

### DIFF
--- a/pkg/liquidity-source/aeon-vamm/config.go
+++ b/pkg/liquidity-source/aeon-vamm/config.go
@@ -1,0 +1,18 @@
+package aeonvamm
+
+const (
+	DexTypeAeonVAMM = "aeon-vamm"
+	defaultChainID  = 43114 // Avalanche C-Chain
+)
+
+type Config struct {
+	DexID          string `json:"dexId"`
+	FactoryAddress string `json:"factoryAddress"`
+	ChainID        int    `json:"chainId"`
+}
+
+var defaultConfig = &Config{
+	DexID:          DexTypeAeonVAMM,
+	FactoryAddress: "0x3ECf287990A2365d48C6681620393aC1cdF3D268",
+	ChainID:        defaultChainID,
+}

--- a/pkg/liquidity-source/aeon-vamm/pool_list_updater.go
+++ b/pkg/liquidity-source/aeon-vamm/pool_list_updater.go
@@ -1,0 +1,138 @@
+package aeonvamm
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var factoryABI, _ = abi.JSON(strings.NewReader(`[
+  {"name":"allPairsLength","type":"function","stateMutability":"view","inputs":[],"outputs":[{"type":"uint256"}]},
+  {"name":"allPairs","type":"function","stateMutability":"view","inputs":[{"name":"","type":"uint256"}],"outputs":[{"type":"address"}]}
+]`))
+
+var pairABI, _ = abi.JSON(strings.NewReader(`[
+  {"name":"token0","type":"function","stateMutability":"view","inputs":[],"outputs":[{"type":"address"}]},
+  {"name":"token1","type":"function","stateMutability":"view","inputs":[],"outputs":[{"type":"address"}]},
+  {"name":"getReserves","type":"function","stateMutability":"view","inputs":[],"outputs":[
+    {"name":"reserve0","type":"uint112"},
+    {"name":"reserve1","type":"uint112"},
+    {"name":"blockTimestampLast","type":"uint32"}
+  ]}
+]`))
+
+const batchSize = 100
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+func NewPoolsListUpdater(config *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: config, ethrpcClient: ethrpcClient}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	var meta PoolListUpdaterMetadata
+	if len(metadataBytes) > 0 {
+		if err := json.Unmarshal(metadataBytes, &meta); err != nil {
+			return nil, metadataBytes, err
+		}
+	}
+
+	// Get total pairs count
+	var totalPairs *big.Int
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{
+		ABI:    factoryABI,
+		Target: u.config.FactoryAddress,
+		Method: "allPairsLength",
+		Params: nil,
+	}, []interface{}{&totalPairs})
+	if _, err := req.Call(); err != nil {
+		return nil, metadataBytes, err
+	}
+
+	total := int(totalPairs.Int64())
+	if meta.Offset >= total {
+		return nil, metadataBytes, nil
+	}
+
+	end := meta.Offset + batchSize
+	if end > total {
+		end = total
+	}
+
+	// Fetch pair addresses
+	pairAddresses := make([]common.Address, end-meta.Offset)
+	addrReq := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i := meta.Offset; i < end; i++ {
+		idx := i
+		addrReq.AddCall(&ethrpc.Call{
+			ABI:    factoryABI,
+			Target: u.config.FactoryAddress,
+			Method: "allPairs",
+			Params: []interface{}{big.NewInt(int64(idx))},
+		}, []interface{}{&pairAddresses[i-meta.Offset]})
+	}
+	if _, err := addrReq.TryBlockAndAggregate(); err != nil {
+		return nil, metadataBytes, err
+	}
+
+	pools := make([]entity.Pool, 0, len(pairAddresses))
+	for _, addr := range pairAddresses {
+		if addr == (common.Address{}) {
+			continue
+		}
+
+		var token0, token1 common.Address
+		var reserves struct {
+			Reserve0           *big.Int
+			Reserve1           *big.Int
+			BlockTimestampLast uint32
+		}
+
+		pairReq := u.ethrpcClient.NewRequest().SetContext(ctx)
+		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "token0"}, []interface{}{&token0})
+		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "token1"}, []interface{}{&token1})
+		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "getReserves"}, []interface{}{&reserves})
+		if _, err := pairReq.TryBlockAndAggregate(); err != nil {
+			continue
+		}
+
+		extra := Extra{
+			Reserve0: reserves.Reserve0,
+			Reserve1: reserves.Reserve1,
+			Fee:      30, // default 0.3%; ideally read from pool
+		}
+		extraBytes, _ := json.Marshal(extra)
+
+		pools = append(pools, entity.Pool{
+			Address:  strings.ToLower(addr.Hex()),
+			Exchange: u.config.DexID,
+			Type:     DexTypeAeonVAMM,
+			Timestamp: time.Now().Unix(),
+			Tokens: []*entity.PoolToken{
+				{Address: strings.ToLower(token0.Hex()), Swappable: true},
+				{Address: strings.ToLower(token1.Hex()), Swappable: true},
+			},
+			Reserves: entity.PoolReserves{
+				util.FloatToString(reserves.Reserve0),
+				util.FloatToString(reserves.Reserve1),
+			},
+			Extra: string(extraBytes),
+		})
+	}
+
+	meta.Offset = end
+	newMetaBytes, _ := json.Marshal(meta)
+	return pools, newMetaBytes, nil
+}

--- a/pkg/liquidity-source/aeon-vamm/pool_list_updater.go
+++ b/pkg/liquidity-source/aeon-vamm/pool_list_updater.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -94,41 +93,44 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		}
 
 		var token0, token1 common.Address
-		var reserves struct {
-			Reserve0           *big.Int
-			Reserve1           *big.Int
-			BlockTimestampLast uint32
-		}
+		var reserve0, reserve1 *big.Int
+		var blockTimestampLast uint32
 
 		pairReq := u.ethrpcClient.NewRequest().SetContext(ctx)
 		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "token0"}, []interface{}{&token0})
 		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "token1"}, []interface{}{&token1})
-		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "getReserves"}, []interface{}{&reserves})
+		pairReq.AddCall(&ethrpc.Call{ABI: pairABI, Target: addr.Hex(), Method: "getReserves"}, []interface{}{&reserve0, &reserve1, &blockTimestampLast})
 		if _, err := pairReq.TryBlockAndAggregate(); err != nil {
 			continue
 		}
 
 		extra := Extra{
-			Reserve0: reserves.Reserve0,
-			Reserve1: reserves.Reserve1,
-			Fee:      30, // default 0.3%; ideally read from pool
+			Reserve0: reserve0,
+			Reserve1: reserve1,
+			Fee:      30, // default 0.3% bps; ideally read from pool.feeBps()
 		}
 		extraBytes, _ := json.Marshal(extra)
 
+		r0 := "0"
+		r1 := "0"
+		if reserve0 != nil {
+			r0 = reserve0.String()
+		}
+		if reserve1 != nil {
+			r1 = reserve1.String()
+		}
+
 		pools = append(pools, entity.Pool{
-			Address:  strings.ToLower(addr.Hex()),
-			Exchange: u.config.DexID,
-			Type:     DexTypeAeonVAMM,
+			Address:   strings.ToLower(addr.Hex()),
+			Exchange:  u.config.DexID,
+			Type:      DexTypeAeonVAMM,
 			Timestamp: time.Now().Unix(),
 			Tokens: []*entity.PoolToken{
 				{Address: strings.ToLower(token0.Hex()), Swappable: true},
 				{Address: strings.ToLower(token1.Hex()), Swappable: true},
 			},
-			Reserves: entity.PoolReserves{
-				util.FloatToString(reserves.Reserve0),
-				util.FloatToString(reserves.Reserve1),
-			},
-			Extra: string(extraBytes),
+			Reserves: entity.PoolReserves{r0, r1},
+			Extra:    string(extraBytes),
 		})
 	}
 

--- a/pkg/liquidity-source/aeon-vamm/pool_simulator.go
+++ b/pkg/liquidity-source/aeon-vamm/pool_simulator.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
 var (
@@ -31,7 +30,7 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 	}, nil
 }
 
-// CalcAmountOut implements constant product formula with fee
+// CalcAmountOut implements constant product formula with fee:
 // amountOut = amountIn*(10000-fee)*reserveOut / (reserveIn*10000 + amountIn*(10000-fee))
 func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
 	if params.TokenAmountIn.Amount == nil || params.TokenAmountIn.Amount.Sign() <= 0 {
@@ -55,16 +54,13 @@ func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		return nil, ErrInsufficientLiquidity
 	}
 
-	fee := int64(p.extra.Fee) // bps
+	fee := int64(p.extra.Fee)
 	feeDenominator := big.NewInt(10000)
 	feeNumerator := big.NewInt(10000 - fee)
 
 	amountIn := params.TokenAmountIn.Amount
-	// amountInWithFee = amountIn * (10000 - fee)
 	amountInWithFee := new(big.Int).Mul(amountIn, feeNumerator)
-	// numerator = amountInWithFee * reserveOut
 	numerator := new(big.Int).Mul(amountInWithFee, reserveOut)
-	// denominator = reserveIn * 10000 + amountInWithFee
 	denominator := new(big.Int).Add(
 		new(big.Int).Mul(reserveIn, feeDenominator),
 		amountInWithFee,
@@ -75,9 +71,11 @@ func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		return nil, ErrInsufficientLiquidity
 	}
 
+	feeAmount := new(big.Int).Sub(amountIn, new(big.Int).Div(new(big.Int).Mul(amountIn, feeNumerator), feeDenominator))
+
 	return &pool.CalcAmountOutResult{
 		TokenAmountOut: &pool.TokenAmount{Token: params.TokenAmountOut, Amount: amountOut},
-		Fee:            &pool.TokenAmount{Token: params.TokenAmountIn.Token, Amount: new(big.Int).Sub(amountIn, new(big.Int).Div(new(big.Int).Mul(amountIn, feeNumerator), feeDenominator))},
+		Fee:            &pool.TokenAmount{Token: params.TokenAmountIn.Token, Amount: feeAmount},
 		Gas:            80000,
 		SwapInfo:       nil,
 	}, nil
@@ -103,8 +101,5 @@ func (p *PoolSimulator) GetMetaInfo(_ string, _ string) interface{} {
 }
 
 func (p *PoolSimulator) CanSwapTo(token string) []string {
-	tokens := p.Pool.CanSwapTo(token)
-	return tokens
+	return p.Pool.CanSwapTo(token)
 }
-
-var _ = bignumber.ZeroBI // ensure import used

--- a/pkg/liquidity-source/aeon-vamm/pool_simulator.go
+++ b/pkg/liquidity-source/aeon-vamm/pool_simulator.go
@@ -1,0 +1,110 @@
+package aeonvamm
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+var (
+	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
+	ErrInvalidAmountIn       = errors.New("invalid amount in")
+)
+
+type PoolSimulator struct {
+	pool.Pool
+	extra Extra
+}
+
+func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
+	var extra Extra
+	if err := json.Unmarshal([]byte(entityPool.Extra), &extra); err != nil {
+		return nil, err
+	}
+	return &PoolSimulator{
+		Pool:  pool.Pool{Info: pool.PoolInfo{Address: entityPool.Address, Exchange: entityPool.Exchange, Type: entityPool.Type, Tokens: entityPool.Tokens, Reserves: entityPool.Reserves}},
+		extra: extra,
+	}, nil
+}
+
+// CalcAmountOut implements constant product formula with fee
+// amountOut = amountIn*(10000-fee)*reserveOut / (reserveIn*10000 + amountIn*(10000-fee))
+func (p *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	if params.TokenAmountIn.Amount == nil || params.TokenAmountIn.Amount.Sign() <= 0 {
+		return nil, ErrInvalidAmountIn
+	}
+
+	tokenInIdx := p.GetTokenIndex(params.TokenAmountIn.Token)
+	tokenOutIdx := p.GetTokenIndex(params.TokenAmountOut)
+	if tokenInIdx < 0 || tokenOutIdx < 0 {
+		return nil, pool.ErrTokenNotFound
+	}
+
+	var reserveIn, reserveOut *big.Int
+	if tokenInIdx == 0 {
+		reserveIn, reserveOut = p.extra.Reserve0, p.extra.Reserve1
+	} else {
+		reserveIn, reserveOut = p.extra.Reserve1, p.extra.Reserve0
+	}
+
+	if reserveIn == nil || reserveOut == nil || reserveIn.Sign() == 0 || reserveOut.Sign() == 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	fee := int64(p.extra.Fee) // bps
+	feeDenominator := big.NewInt(10000)
+	feeNumerator := big.NewInt(10000 - fee)
+
+	amountIn := params.TokenAmountIn.Amount
+	// amountInWithFee = amountIn * (10000 - fee)
+	amountInWithFee := new(big.Int).Mul(amountIn, feeNumerator)
+	// numerator = amountInWithFee * reserveOut
+	numerator := new(big.Int).Mul(amountInWithFee, reserveOut)
+	// denominator = reserveIn * 10000 + amountInWithFee
+	denominator := new(big.Int).Add(
+		new(big.Int).Mul(reserveIn, feeDenominator),
+		amountInWithFee,
+	)
+	amountOut := new(big.Int).Div(numerator, denominator)
+
+	if amountOut.Sign() <= 0 || amountOut.Cmp(reserveOut) >= 0 {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: params.TokenAmountOut, Amount: amountOut},
+		Fee:            &pool.TokenAmount{Token: params.TokenAmountIn.Token, Amount: new(big.Int).Sub(amountIn, new(big.Int).Div(new(big.Int).Mul(amountIn, feeNumerator), feeDenominator))},
+		Gas:            80000,
+		SwapInfo:       nil,
+	}, nil
+}
+
+func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	tokenInIdx := p.GetTokenIndex(params.TokenAmountIn.Token)
+	tokenOutIdx := p.GetTokenIndex(params.TokenAmountOut.Token)
+	if tokenInIdx < 0 || tokenOutIdx < 0 {
+		return
+	}
+	if tokenInIdx == 0 {
+		p.extra.Reserve0 = new(big.Int).Add(p.extra.Reserve0, params.TokenAmountIn.Amount)
+		p.extra.Reserve1 = new(big.Int).Sub(p.extra.Reserve1, params.TokenAmountOut.Amount)
+	} else {
+		p.extra.Reserve1 = new(big.Int).Add(p.extra.Reserve1, params.TokenAmountIn.Amount)
+		p.extra.Reserve0 = new(big.Int).Sub(p.extra.Reserve0, params.TokenAmountOut.Amount)
+	}
+}
+
+func (p *PoolSimulator) GetMetaInfo(_ string, _ string) interface{} {
+	return PoolMeta{Fee: p.extra.Fee}
+}
+
+func (p *PoolSimulator) CanSwapTo(token string) []string {
+	tokens := p.Pool.CanSwapTo(token)
+	return tokens
+}
+
+var _ = bignumber.ZeroBI // ensure import used

--- a/pkg/liquidity-source/aeon-vamm/types.go
+++ b/pkg/liquidity-source/aeon-vamm/types.go
@@ -1,0 +1,18 @@
+package aeonvamm
+
+import "math/big"
+
+type Extra struct {
+	Reserve0 *big.Int `json:"reserve0"`
+	Reserve1 *big.Int `json:"reserve1"`
+	Fee      uint64   `json:"fee"` // in bps, e.g. 30 = 0.3%
+}
+
+type PoolMeta struct {
+	Fee          uint64 `json:"fee"`
+	BlockNumber  uint64 `json:"blockNumber"`
+}
+
+type PoolListUpdaterMetadata struct {
+	Offset int `json:"offset"`
+}


### PR DESCRIPTION
# [Avalanche] Add AEON Protocol vAMM liquidity source

## Protocol

**AEON Protocol** is a ve(3,3) DEX on Avalanche C-Chain (chainId 43114) with a fee-anchored emissions model.
Weekly AEON token emissions are algorithmically capped at 1/10th of protocol fees â€” no inflation without real usage.

- Website: https://app.aeonprotocol.xyz
- Docs: https://app.aeonprotocol.xyz/docs
- Chain: Avalanche C-Chain (43114)

## Pricing Logic

**Pool type:** vAMM â€” constant product (x*y=k), UniswapV2-compatible interface.

**Swap formula:**
```
amountOut = (amountIn * (10000 - feeBps) * reserveOut)
          / (reserveIn * 10000 + amountIn * (10000 - feeBps))
```

Fee range: 1â€“100 bps (0.01%â€“1%), encoded per pool.

## Contracts

| Contract        | Address |
|-----------------|---------|
| Factory         | `0x3ECf287990A2365d48C6681620393aC1cdF3D268` |
| Router          | `0xD847Ea61394ADa3bb23B373349b58C90f9126A9F` |
| AEON Token      | `0xd4c93eD1843606f92CccA078941f3d52A585982f` |

## Key Pools

| Pair          | Fee   | Address |
|---------------|-------|---------|
| AEON/WAVAX    | 1%    | `0xF03A55f9578c35Ec442e2F5dA040C20fF3A59489` |
| AEON/USDC     | 1%    | `0xFD029a446632618f218189d4a0B572896CD29B58` |
| WAVAX/USDC    | 0.3%  | `0x3feb54fE68d7C6B2105EB0b06eD8c92cf0182086` |

## Files Added

```
pkg/liquidity-source/aeon-vamm/
  config.go            â€” factory address, chain config
  types.go             â€” Extra (reserves + fee), PoolMeta
  pool_list_updater.go â€” fetches all pairs from factory in batches
  pool_simulator.go    â€” CalcAmountOut + UpdateBalance (x*y=k)
```

## Contact

Twitter: @AeonProtocolX
