### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/pkg/liquidity-source/ambient/tick_range_test.go
+++ b/pkg/liquidity-source/ambient/tick_range_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/big"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -229,7 +230,7 @@ func loadPoolStats(t *testing.T, h *testHarness, pairs []indexerPair) []poolStat
 			}
 			dists[i] = d
 		}
-		sort.Slice(dists, func(i, j int) bool { return dists[i] < dists[j] })
+		slices.Sort(dists)
 
 		totalLots := new(big.Int)
 		ticks := make([]tickLot, 0, len(state.Levels))

--- a/pkg/liquidity-source/ambient/tracker.go
+++ b/pkg/liquidity-source/ambient/tracker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"sort"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -180,7 +180,7 @@ func (t *StateTracker) LoadWindow(
 			activeTicks = append(activeTicks, tick)
 		}
 	}
-	sort.Slice(activeTicks, func(i, j int) bool { return activeTicks[i] < activeTicks[j] })
+	slices.Sort(activeTicks)
 
 	stageC := make([]common.Hash, 0, len(activeTicks))
 	for _, tick := range activeTicks {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->


There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
