### PR TITLE
fix(litepsm): stamp BlockNumber from RPC block on state read

### DIFF
--- a/pkg/liquidity-source/litepsm/pool_tracker.go
+++ b/pkg/liquidity-source/litepsm/pool_tracker.go
@@ -67,7 +67,7 @@ func (t *PoolTracker) getNewPoolState(
 			Info("finished GetNewPoolState")
 	}(time.Now())
 
-	reserves, extra, err := t.fetchRPCData(ctx, &pool, overrides)
+	reserves, extra, blockNumber, err := t.fetchRPCData(ctx, &pool, overrides)
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"exchange": pool.Exchange,
@@ -88,6 +88,14 @@ func (t *PoolTracker) getNewPoolState(
 	pool.Reserves = []string{reserves[0].String(), reserves[1].String()}
 	pool.Extra = string(extraBytes)
 	pool.Timestamp = time.Now().Unix()
+	// Stamp the block the state was read at. PSM wrapper pools emit no swap event under
+	// their own address, so the log-driven update path never sets BlockNumber for them;
+	// without this an interval refresh would leave BlockNumber at 0 and downstream
+	// staleness guards would treat the pool as inactive. When this update IS log-driven,
+	// the caller overwrites BlockNumber with the triggering log's block, which is finer.
+	if blockNumber > 0 {
+		pool.BlockNumber = blockNumber
+	}
 	return pool, nil
 }
 
@@ -95,14 +103,14 @@ func (t *PoolTracker) fetchRPCData(
 	ctx context.Context,
 	pool *entity.Pool,
 	overrides map[common.Address]gethclient.OverrideAccount,
-) ([]*big.Int, *Extra, error) {
+) ([]*big.Int, *Extra, uint64, error) {
 	var staticExtra StaticExtra
 	if err := json.Unmarshal([]byte(pool.StaticExtra), &staticExtra); err != nil {
 		logger.WithFields(logger.Fields{
 			"exchange": pool.Exchange,
 			"error":    err,
 		}).Error("can not unmarshal static extra")
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	psm := common.HexToAddress(pool.Address)
@@ -134,12 +142,18 @@ func (t *PoolTracker) fetchRPCData(
 			Params: []any{*lo.CoalesceOrEmpty(staticExtra.GemJoin, &psm)},
 		}, []any{&reserves[0]})
 	}
-	if _, err := req.Aggregate(); err != nil {
+	resp, err := req.Aggregate()
+	if err != nil {
 		logger.WithFields(logger.Fields{
 			"dexID": DexTypeLitePSM,
 			"error": err,
 		}).Error("[fetchRPCData] eth rpc call error")
-		return nil, nil, err
+		return nil, nil, 0, err
+	}
+
+	var blockNumber uint64
+	if resp.BlockNumber != nil {
+		blockNumber = resp.BlockNumber.Uint64()
 	}
 
 	if staticExtra.IsMint {
@@ -153,5 +167,5 @@ func (t *PoolTracker) fetchRPCData(
 	if tOut.Sign() > 0 {
 		extra.TOut = big256.FromBig(tOut)
 	}
-	return reserves, &extra, nil
+	return reserves, &extra, blockNumber, nil
 }


### PR DESCRIPTION
Litepsm `GetNewPoolState` set `Reserves`/`Extra`/`Timestamp` nhưng **không set `BlockNumber`**. Pool-service chỉ stamp `BlockNumber` từ event log của pool (`pool_update.go:169`, gated `len(msg.Logs)>0`); interval refresh không mang log.

Hệ quả: PSM **wrapper** pools phát 0 event dưới address của mình (vd USDS/USDC `UsdsPsmWrapper` `0xA188EEC8` — verified 0 logs/7d on-chain; state thực đổi ở inner Maker LitePSM `0xf6e72db5`). Chúng không bao giờ nhận log-update → `BlockNumber` kẹt ở `0` → downstream staleness guard coi là inactive vĩnh viễn và drop pool.

## Change
- `fetchRPCData`: capture `resp` từ `req.Aggregate()`, trả về `resp.BlockNumber` (guard nil).
- `getNewPoolState`: `pool.BlockNumber = blockNumber` khi `>0`.

Interaction đúng: log-driven update vẫn bị caller ghi đè bằng block của triggering log (mịn hơn) → **event-based pools không đổi hành vi**; chỉ no-log/interval refresh mới được stamp block từ multicall. Mirror pattern của `valantis-stex/pool_tracker.go:151`.

## Test
`go build` / `go vet` / `go test ./pkg/liquidity-source/litepsm/...` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01D8wVw8SMmsw9FESKwCSudx