### PR TITLE
fix(curve): resolve base pool via MetaRegistry for legacy curve-meta pools

### DIFF
--- a/pkg/source/curve/config.go
+++ b/pkg/source/curve/config.go
@@ -10,6 +10,7 @@ type Config struct {
 
 	AddressProvider            string `json:"addressProvider"`
 	MainRegistryAddress        string `json:"mainRegistryAddress"`
+	MetaRegistryAddress        string `json:"metaRegistryAddress"`
 	MetaPoolsFactoryAddress    string `json:"metaPoolsFactoryAddress"`
 	CryptoPoolsRegistryAddress string `json:"cryptoPoolsRegistryAddress"`
 	CryptoPoolsFactoryAddress  string `json:"cryptoPoolsFactoryAddress"`

--- a/pkg/source/curve/helper.go
+++ b/pkg/source/curve/helper.go
@@ -13,7 +13,7 @@ import (
 
 func initConfig(config *Config, ethrpcClient *ethrpc.Client) error {
 	var (
-		mainRegistryAddress, metaFactoryAddress, cryptoRegistryAddress, cryptoFactoryAddress common.Address
+		mainRegistryAddress, metaRegistryAddress, metaFactoryAddress, cryptoRegistryAddress, cryptoFactoryAddress common.Address
 	)
 	calls := ethrpcClient.NewRequest().AddCall(&ethrpc.Call{
 		ABI:    addressProviderABI,
@@ -21,6 +21,14 @@ func initConfig(config *Config, ethrpcClient *ethrpc.Client) error {
 		Method: addressProviderMethodGetAddress,
 		Params: []any{big.NewInt(0)},
 	}, []any{&mainRegistryAddress}).AddCall(&ethrpc.Call{
+		ABI:    addressProviderABI,
+		Target: config.AddressProvider,
+		Method: addressProviderMethodGetAddress,
+		// id 7 = MetaRegistry per Curve's AddressProvider (get_id_info(7).description
+		// == "Metaregistry"). Returns the zero address on chains without one, in which
+		// case base-pool resolution falls back to the pool's own base_pool() getter.
+		Params: []any{big.NewInt(7)},
+	}, []any{&metaRegistryAddress}).AddCall(&ethrpc.Call{
 		ABI:    addressProviderABI,
 		Target: config.AddressProvider,
 		Method: addressProviderMethodGetAddress,
@@ -46,6 +54,7 @@ func initConfig(config *Config, ethrpcClient *ethrpc.Client) error {
 	}
 
 	config.MainRegistryAddress = mainRegistryAddress.Hex()
+	config.MetaRegistryAddress = metaRegistryAddress.Hex()
 	config.MetaPoolsFactoryAddress = metaFactoryAddress.Hex()
 	config.CryptoPoolsRegistryAddress = cryptoRegistryAddress.Hex()
 	config.CryptoPoolsFactoryAddress = cryptoFactoryAddress.Hex()

--- a/pkg/source/curve/pool_meta.go
+++ b/pkg/source/curve/pool_meta.go
@@ -22,30 +22,46 @@ func (d *PoolsListUpdater) getNewPoolsTypeMeta(
 	poolAndRegistries []PoolAndRegistries,
 ) ([]entity.Pool, error) {
 	var (
-		basePools       = make([]common.Address, len(poolAndRegistries))
-		coins           = make([][8]common.Address, len(poolAndRegistries))
-		underlyingCoins = make([][8]common.Address, len(poolAndRegistries))
-		decimals        = make([][8]*big.Int, len(poolAndRegistries))
-		aList           = make([]*big.Int, len(poolAndRegistries))
-		aPreciseList    = make([]*big.Int, len(poolAndRegistries))
+		basePools         = make([]common.Address, len(poolAndRegistries))
+		poolBasePools     = make([]common.Address, len(poolAndRegistries))
+		registryBasePools = make([]common.Address, len(poolAndRegistries))
+		coins             = make([][8]common.Address, len(poolAndRegistries))
+		underlyingCoins   = make([][8]common.Address, len(poolAndRegistries))
+		decimals          = make([][8]*big.Int, len(poolAndRegistries))
+		aList             = make([]*big.Int, len(poolAndRegistries))
+		aPreciseList      = make([]*big.Int, len(poolAndRegistries))
 	)
 
 	calls := d.ethrpcClient.NewRequest().SetContext(ctx)
 
 	for i, poolAndRegistry := range poolAndRegistries {
+		// Base pool is resolved from up to two candidates; we pick the first non-zero
+		// after aggregation (see below), so coverage is the union of all sources.
+		// Candidate A: the pool's own base_pool() getter. Newer templates (e.g.
+		// GUSD/3Crv) implement it; legacy metapools (MIM/FRAX/LUSD/TUSD-3Crv) do not,
+		// so this call may revert and leave the slot zero (TryAggregate tolerates it).
+		calls.AddCall(&ethrpc.Call{
+			ABI:    metaABI,
+			Target: poolAndRegistry.PoolAddress.Hex(),
+			Method: poolMethodBasePool,
+		}, []any{&poolBasePools[i]})
+
+		// Candidate B: a registry that indexes base pools — the meta factory for
+		// factory-listed pools, otherwise the MetaRegistry (which covers legacy pools
+		// lacking base_pool()). Skipped when neither is configured (e.g. some chains).
+		registryTarget := ""
 		if strings.EqualFold(poolAndRegistry.RegistryOrFactoryAddress, d.config.MetaPoolsFactoryAddress) {
+			registryTarget = d.config.MetaPoolsFactoryAddress
+		} else if d.config.MetaRegistryAddress != "" && !strings.EqualFold(d.config.MetaRegistryAddress, addressZero) {
+			registryTarget = d.config.MetaRegistryAddress
+		}
+		if registryTarget != "" {
 			calls.AddCall(&ethrpc.Call{
 				ABI:    metaPoolFactoryABI,
-				Target: d.config.MetaPoolsFactoryAddress,
+				Target: registryTarget,
 				Method: registryOrFactoryMethodGetBasePool,
 				Params: []any{poolAndRegistry.PoolAddress},
-			}, []any{&basePools[i]})
-		} else {
-			calls.AddCall(&ethrpc.Call{
-				ABI:    metaABI,
-				Target: poolAndRegistry.PoolAddress.Hex(),
-				Method: poolMethodBasePool,
-			}, []any{&basePools[i]})
+			}, []any{&registryBasePools[i]})
 		}
 
 		calls.AddCall(&ethrpc.Call{
@@ -76,6 +92,15 @@ func (d *PoolsListUpdater) getNewPoolsTypeMeta(
 	if _, err := calls.TryAggregate(); err != nil {
 		logger.Errorf("failed to aggregate call to get pool data, err: %v", err)
 		return nil, err
+	}
+
+	// Prefer the registry answer, fall back to the pool's own base_pool() getter.
+	// A base pool stays zero only if none of the sources know it.
+	for i := range poolAndRegistries {
+		basePools[i] = registryBasePools[i]
+		if basePools[i] == (common.Address{}) {
+			basePools[i] = poolBasePools[i]
+		}
 	}
 
 	aPrecisions, err := getAPrecisions(aList, aPreciseList)


### PR DESCRIPTION
## The bug

Legacy Curve stable metapools (`type: "curve-meta"`) are listed with `staticExtra.basePool = 0x0000000000000000000000000000000000000000`, which is always wrong — a curve-meta pool MUST reference its base pool (the 3pool `0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7`). A meta pool with a zero base pool can't build a simulator and is silently dropped, so it's unroutable.

Affected pools (all systematically broken):
- MIM/3Crv `0x5a6a4d54456819380173272a5e8e9b9904bdf41b`
- FRAX/3Crv `0xd632f22692fac7611d2aa1c0d552930d43caed3b`
- LUSD/3Crv `0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca`
- TUSD/3Crv `0xecd5e75afb02efa118af914515d6521aabd189f1`

GUSD/3Crv `0x4f062658eaaf2c1ccf8c8e36d6824cdf41167956` works, which masked the systemic nature of the bug.

### Root cause

`getNewPoolsTypeMeta` (`pkg/source/curve/pool_meta.go`) picks the base-pool source based on **where the pool is listed**:
- factory-listed pools → `MetaPoolsFactory.get_base_pool(pool)`
- main-registry-listed pools → the **pool contract's own `base_pool()`** getter

Legacy metapools (MIM/FRAX/LUSD/TUSD) are listed via the main registry, so they hit the `base_pool()` branch — but these older Vyper templates do **not** implement `base_pool()`. The call reverts, `TryAggregate` tolerates it, and `basePools[i]` stays the zero address. GUSD happens to implement `base_pool()`, which is why only it worked.

## The fix

Resolve the base pool from the **union of all available sources, first non-zero**, instead of a single per-listing source:
- **Candidate A** — the pool's own `base_pool()` getter (works for newer templates like GUSD).
- **Candidate B** — `get_base_pool(pool)` on a registry: the meta factory for factory-listed pools, otherwise the Curve **MetaRegistry** (which indexes every pool, including legacy ones).

Both calls are issued in the same `TryAggregate` batch (individual reverts tolerated); after aggregation `basePool = firstNonZero(registry, poolGetter)`. Coverage becomes `factory.get_base_pool ∪ MetaRegistry.get_base_pool ∪ pool.base_pool()`, so a base pool is left zero only when none of the sources know it — never worse than before on any chain.

The MetaRegistry address is resolved from the Curve AddressProvider via `get_address(7)` (id 7 = "Metaregistry" per `AddressProvider.get_id_info(7)`), mirroring the existing id 0/3/5/6 lookups. On chains without a MetaRegistry it resolves to `0x0` and the code falls back to `base_pool()` — no behavior change there.

Files: `config.go` (+`MetaRegistryAddress`), `helper.go` (`initConfig` fetches id 7), `pool_meta.go` (union resolution).

## How to manually reproduce & verify (Etherscan `Read Contract`)

Take MIM/3Crv `0x5a6a4d54456819380173272a5e8e9b9904bdf41b`:

| call | on | result |
|---|---|---|
| `base_pool()` | the pool `0x5a6a…` | ❌ method absent → reverts → `0x0` (the bug) |
| `coins(1)` | the pool `0x5a6a…` | `0x6c3F90f0…E6E490` (3Crv LP) — proves a base pool must exist |
| `get_base_pool(0x5a6a…)` | MetaRegistry `0xF98B45FA17DE75FB1aD0e7aFD971b0ca00e379fC` | ✅ `0xbEbc4478…` (the fix) |
| `get_id_info(7)` | AddressProvider `0x0000000022D53366457F9d5E68Ec105046FC4383` | `addr=0xF98B45FA…, description="Metaregistry"` |
| `base_pool()` | GUSD `0x4f062658…` | ✅ `0xbEbc4478…` (why GUSD was never broken) |

The same `get_base_pool` returns `0xbEbc4478…` for FRAX / LUSD / TUSD as well.

## Verification

- `go build ./pkg/source/curve/...` — OK
- `go vet ./pkg/source/curve/...` — OK
- `go test ./pkg/source/curve/...` — all pass
- `golangci-lint run ./pkg/source/curve/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8wVw8SMmsw9FESKwCSudx
