### PR TITLE
fix(carbon): use exact match actions and track only top strategies

### DIFF
--- a/pkg/liquidity-source/carbon/constant.go
+++ b/pkg/liquidity-source/carbon/constant.go
@@ -2,6 +2,7 @@ package carbon
 
 import (
 	"errors"
+	"time"
 
 	"github.com/holiman/uint256"
 
@@ -23,12 +24,26 @@ const (
 	defaultTradeBySourceAmountGas = 63037
 
 	maxStrategiesPerBatch = 200
+
+	// dust filter: per side (token0-order / token1-order), an order is only tracked
+	// if it clears both a liquidity floor (relative to the largest order on that side)
+	// and a rate floor (relative to the best-priced order on that side).
+	dustLiquidityPct = 1
+	dustRatePct      = 10
+
+	// full re-scan of every on-chain strategy happens at most this often; between
+	// scans only already-tracked strategies are refreshed plus any newly created ones.
+	fullScanInterval = time.Minute
 )
 
 var (
 	uOne           = uint256.NewInt(one)
 	oneSquared     = new(uint256.Int).Mul(uOne, uOne)
 	uPmmResolution = uint256.NewInt(ppmResolution)
+
+	uHundred          = uint256.NewInt(100)
+	uDustLiquidityPct = uint256.NewInt(dustLiquidityPct)
+	uDustRatePct      = uint256.NewInt(dustRatePct)
 
 	ErrInvalidToken          = errors.New("invalid token")
 	ErrInvalidSwap           = errors.New("invalid swap")

--- a/pkg/liquidity-source/carbon/pool_simulator.go
+++ b/pkg/liquidity-source/carbon/pool_simulator.go
@@ -159,7 +159,7 @@ func (s *PoolSimulator) trade(amountIn *uint256.Int, ordersMap EncodedOrderMap,
 			continue
 		}
 
-		output := s.processMatchActions(amountIn, actions, strategyIdxMap, targetOrderIdx, sourceOrderIdx, isToken0To1, ppmMinusFee)
+		output := s.processMatchActions(actions, strategyIdxMap, targetOrderIdx, sourceOrderIdx, isToken0To1, ppmMinusFee)
 		if output == nil {
 			continue
 		}
@@ -179,12 +179,10 @@ func (s *PoolSimulator) trade(amountIn *uint256.Int, ordersMap EncodedOrderMap,
 	return results, nil
 }
 
-func (s *PoolSimulator) processMatchActions(amountIn *uint256.Int, actions []*MatchAction, strategyIdxMap map[string]int,
+func (s *PoolSimulator) processMatchActions(actions []*MatchAction, strategyIdxMap map[string]int,
 	targetOrderIdx, sourceOrderIdx int, isToken0To1 bool, ppmMinusFee *uint256.Int) *TradeOutput {
 	totalAmountOut := u256.New0()
 
-	var remaining uint256.Int
-	remaining.Set(amountIn)
 	var tradeActions []TradeAction
 	for _, action := range actions {
 		strategyIdStr := action.Id
@@ -197,11 +195,6 @@ func (s *PoolSimulator) processMatchActions(amountIn *uint256.Int, actions []*Ma
 		strategy := &s.Strategies[strategyIdx]
 		targetOrder := &strategy.Orders[targetOrderIdx]
 		sourceOrder := &strategy.Orders[sourceOrderIdx]
-
-		// this step is needed as our current executor doesn't support partial amountIn
-		rate := rateBySourceAmount(&remaining, targetOrder)
-		action.Input, action.Output = rate.Input, rate.Output
-		// remove the above when executor supports amountIn
 
 		newTargetY := new(uint256.Int).Sub(targetOrder.Y, action.Output)
 
@@ -223,9 +216,6 @@ func (s *PoolSimulator) processMatchActions(amountIn *uint256.Int, actions []*Ma
 		})
 
 		totalAmountOut.Add(totalAmountOut, action.Output)
-		if remaining.Sub(&remaining, action.Input).IsZero() {
-			break
-		}
 	}
 
 	if totalAmountOut.Sign() <= 0 {

--- a/pkg/liquidity-source/carbon/pool_tracker.go
+++ b/pkg/liquidity-source/carbon/pool_tracker.go
@@ -46,6 +46,9 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, err
 	}
 
+	var prevExtra Extra
+	_ = json.Unmarshal([]byte(p.Extra), &prevExtra) // best-effort; zero value just forces a full scan
+
 	token0 := common.HexToAddress(staticExtra.Token0)
 	token1 := common.HexToAddress(staticExtra.Token1)
 
@@ -59,14 +62,35 @@ func (t *PoolTracker) GetNewPoolState(
 		tradingFeePpm = defaultTradingFeePpm
 	}
 
-	strategies, blockNumber, err := t.getStrategiesByPair(ctx, token0, token1)
-	if err != nil {
-		logger.WithFields(logger.Fields{
-			"dexId":   t.config.DexId,
-			"address": p.Address,
-			"error":   err,
-		}).Error("failed to get strategies")
-		return p, err
+	now := time.Now()
+	fullScanDue := prevExtra.LastFullScanTime == 0 ||
+		now.Sub(time.Unix(prevExtra.LastFullScanTime, 0)) > fullScanInterval
+
+	var strategies []Strategy
+	var blockNumber *big.Int
+	var lastFullScanTime int64
+	var strategyCount int64
+
+	if fullScanDue {
+		if strategies, strategyCount, blockNumber, err = t.fullScan(ctx, token0, token1); err != nil {
+			logger.WithFields(logger.Fields{
+				"dexId":   t.config.DexId,
+				"address": p.Address,
+				"error":   err,
+			}).Error("failed to full-scan strategies")
+			return p, err
+		}
+		strategies = applyDustFilter(strategies)
+		lastFullScanTime = now.Unix()
+	} else {
+		if strategies, strategyCount, blockNumber, lastFullScanTime, err = t.incrementalScan(ctx, token0, token1, prevExtra); err != nil {
+			logger.WithFields(logger.Fields{
+				"dexId":   t.config.DexId,
+				"address": p.Address,
+				"error":   err,
+			}).Error("failed to incrementally update strategies")
+			return p, err
+		}
 	}
 
 	reserve0, reserve1 := u256.New0(), u256.New0()
@@ -80,8 +104,10 @@ func (t *PoolTracker) GetNewPoolState(
 	}
 
 	extra := Extra{
-		Strategies:    strategies,
-		TradingFeePpm: tradingFeePpm,
+		Strategies:       strategies,
+		TradingFeePpm:    tradingFeePpm,
+		LastFullScanTime: lastFullScanTime,
+		StrategyCount:    strategyCount,
 	}
 	extraBytes, err := json.Marshal(extra)
 	if err != nil {
@@ -90,7 +116,7 @@ func (t *PoolTracker) GetNewPoolState(
 
 	p.Extra = string(extraBytes)
 	p.Reserves = []string{reserve0.String(), reserve1.String()}
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = now.Unix()
 	p.BlockNumber = blockNumber.Uint64()
 
 	logger.WithFields(logger.Fields{
@@ -130,7 +156,92 @@ func (t *PoolTracker) getTradingFee(ctx context.Context, token0, token1 common.A
 	return globalFee, nil
 }
 
-func (t *PoolTracker) getStrategiesByPair(ctx context.Context, token0, token1 common.Address) ([]Strategy, *big.Int, error) {
+// fullScan re-fetches every strategy for the pair from chain and returns the on-chain
+// strategiesByPairCount alongside them - the caller stores that count (not len(strategies),
+// since dust-filtered strategies get dropped) so incrementalScan can detect newly created
+// strategies later by diffing counts instead of re-fetching everything every poll.
+func (t *PoolTracker) fullScan(ctx context.Context, token0, token1 common.Address) ([]Strategy, int64, *big.Int, error) {
+	count, blockNumber, err := t.getStrategyCount(ctx, token0, token1)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	if count == nil || count.Sign() == 0 {
+		return nil, 0, blockNumber, nil
+	}
+
+	totalCount := int(count.Int64())
+	strategies := make([]Strategy, 0, totalCount)
+	for offset := 0; offset < totalCount; offset += maxStrategiesPerBatch {
+		endIndex := min(offset+maxStrategiesPerBatch, totalCount)
+
+		batch, err := t.fetchStrategiesBatch(ctx, token0, token1, offset, endIndex, blockNumber)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+
+		strategies = append(strategies, batch...)
+	}
+
+	return strategies, count.Int64(), blockNumber, nil
+}
+
+// incrementalScan avoids a full strategiesByPair walk on every poll: it only pays for a cheap
+// count check, a fetch of any newly created strategies (detected via that count), and a
+// refresh of the strategies we're actually tracking (dust-filtered ones aren't stored at all),
+// since those are the only ones whose liquidity matters for quoting between full scans.
+func (t *PoolTracker) incrementalScan(
+	ctx context.Context,
+	token0, token1 common.Address,
+	prevExtra Extra,
+) ([]Strategy, int64, *big.Int, int64, error) {
+	count, blockNumber, err := t.getStrategyCount(ctx, token0, token1)
+	if err != nil {
+		return nil, 0, nil, 0, err
+	}
+	if count == nil {
+		count = big.NewInt(0)
+	}
+
+	if count.Int64() < prevExtra.StrategyCount {
+		// a strategy was deleted on-chain; index positions may have shifted underneath us,
+		// so fall back to a full re-scan rather than trying to diff against stale indices.
+		strategies, strategyCount, blockNumber, err := t.fullScan(ctx, token0, token1)
+		if err != nil {
+			return nil, 0, nil, 0, err
+		}
+		strategies = applyDustFilter(strategies)
+		return strategies, strategyCount, blockNumber, time.Now().Unix(), nil
+	}
+
+	strategies := prevExtra.Strategies
+
+	if count.Int64() > prevExtra.StrategyCount {
+		newStrategies, err := t.fetchStrategiesBatch(
+			ctx, token0, token1, int(prevExtra.StrategyCount), int(count.Int64()), blockNumber)
+		if err != nil {
+			return nil, 0, nil, 0, err
+		}
+		newStrategies = applyDustFilter(newStrategies)
+		strategies = append(append(make([]Strategy, 0, len(strategies)+len(newStrategies)), strategies...), newStrategies...)
+	}
+
+	ids := make([]*big.Int, len(strategies))
+	for i, s := range strategies {
+		ids[i] = s.Id
+	}
+
+	if len(ids) > 0 {
+		refreshed, err := t.fetchStrategiesByIDs(ctx, token0, ids, blockNumber)
+		if err != nil {
+			return nil, 0, nil, 0, err
+		}
+		strategies = refreshed
+	}
+
+	return strategies, count.Int64(), blockNumber, prevExtra.LastFullScanTime, nil
+}
+
+func (t *PoolTracker) getStrategyCount(ctx context.Context, token0, token1 common.Address) (*big.Int, *big.Int, error) {
 	var count *big.Int
 	resp, err := t.ethrpcClient.R().SetContext(ctx).
 		AddCall(&ethrpc.Call{
@@ -144,24 +255,7 @@ func (t *PoolTracker) getStrategiesByPair(ctx context.Context, token0, token1 co
 		return nil, nil, err
 	}
 
-	if count == nil || count.Sign() == 0 {
-		return nil, resp.BlockNumber, nil
-	}
-
-	totalCount := int(count.Int64())
-	strategies := make([]Strategy, 0, totalCount)
-	for offset := 0; offset < totalCount; offset += maxStrategiesPerBatch {
-		endIndex := min(offset+maxStrategiesPerBatch, totalCount)
-
-		batchStrategies, err := t.fetchStrategiesBatch(ctx, token0, token1, offset, endIndex, resp.BlockNumber)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		strategies = append(strategies, batchStrategies...)
-	}
-
-	return strategies, resp.BlockNumber, nil
+	return count, resp.BlockNumber, nil
 }
 
 func (t *PoolTracker) fetchStrategiesBatch(
@@ -184,34 +278,133 @@ func (t *PoolTracker) fetchStrategiesBatch(
 
 	strategies := make([]Strategy, 0, len(rawStrategies))
 	for _, raw := range rawStrategies {
-		// Skip no-liquidity strategies
-		if raw.Orders[0].Y.Sign() == 0 && raw.Orders[1].Y.Sign() == 0 {
-			continue
-		}
-
-		i0, i1 := 0, 1
-		if raw.Tokens[0] != token0 {
-			i0, i1 = 1, 0
-		}
-
-		strategies = append(strategies, Strategy{
-			Id: raw.ID,
-			Orders: [2]Order{
-				{
-					Y: uint256.MustFromBig(raw.Orders[i0].Y),
-					Z: uint256.MustFromBig(raw.Orders[i0].Z),
-					A: raw.Orders[i0].A,
-					B: raw.Orders[i0].B,
-				},
-				{
-					Y: uint256.MustFromBig(raw.Orders[i1].Y),
-					Z: uint256.MustFromBig(raw.Orders[i1].Z),
-					A: raw.Orders[i1].A,
-					B: raw.Orders[i1].B,
-				},
-			},
-		})
+		strategies = append(strategies, mapRawStrategy(raw, token0))
 	}
 
 	return strategies, nil
+}
+
+// fetchStrategiesByIDs refreshes a specific, already-known set of strategies (the ones not
+// dust-filtered out) via the single-strategy getter, batched through multicall.
+func (t *PoolTracker) fetchStrategiesByIDs(
+	ctx context.Context,
+	token0 common.Address,
+	ids []*big.Int,
+	blockNumber *big.Int,
+) ([]Strategy, error) {
+	strategies := make([]Strategy, 0, len(ids))
+	for offset := 0; offset < len(ids); offset += maxStrategiesPerBatch {
+		endIndex := min(offset+maxStrategiesPerBatch, len(ids))
+		chunk := ids[offset:endIndex]
+
+		raws := make([]StrategyByPairResp, len(chunk))
+		req := t.ethrpcClient.R().SetContext(ctx).SetBlockNumber(blockNumber)
+		for i, id := range chunk {
+			req.AddCall(&ethrpc.Call{
+				ABI:    controllerABI,
+				Target: t.config.Controller.String(),
+				Method: "strategy",
+				Params: []any{id},
+			}, []any{&raws[i]})
+		}
+		if _, err := req.Aggregate(); err != nil {
+			return nil, err
+		}
+
+		for _, raw := range raws {
+			strategies = append(strategies, mapRawStrategy(raw, token0))
+		}
+	}
+
+	return strategies, nil
+}
+
+func mapRawStrategy(raw StrategyByPairResp, token0 common.Address) Strategy {
+	i0, i1 := 0, 1
+	if raw.Tokens[0] != token0 {
+		i0, i1 = 1, 0
+	}
+
+	return Strategy{
+		Id: raw.ID,
+		Orders: [2]Order{
+			{
+				Y: uint256.MustFromBig(raw.Orders[i0].Y),
+				Z: uint256.MustFromBig(raw.Orders[i0].Z),
+				A: raw.Orders[i0].A,
+				B: raw.Orders[i0].B,
+			},
+			{
+				Y: uint256.MustFromBig(raw.Orders[i1].Y),
+				Z: uint256.MustFromBig(raw.Orders[i1].Z),
+				A: raw.Orders[i1].A,
+				B: raw.Orders[i1].B,
+			},
+		},
+	}
+}
+
+// applyDustFilter clears an order's Y/Z when, on its side (token0-order or token1-order across
+// all strategies), it fails either the liquidity floor (>= 1% of the largest order) or the rate
+// floor (>= 80% of the best-priced order), then compacts out any strategy left dust on both
+// sides. Strategies kept for only one side still occupy a slot (with Id) so incrementalScan's
+// count-diff invariant holds for those; only fully-dust ones are dropped, and StrategyCount -
+// not len(Strategies) - accounts for those in the on-chain index space.
+func applyDustFilter(strategies []Strategy) []Strategy {
+	var maxY, maxLimit [2]*uint256.Int
+	for i := range maxY {
+		maxY[i] = u256.New0()
+		maxLimit[i] = u256.New0()
+	}
+
+	for i := range strategies {
+		for oi := range 2 {
+			order := &strategies[i].Orders[oi]
+			if order.Y == nil || order.Y.Sign() == 0 {
+				continue
+			}
+
+			if order.Y.Gt(maxY[oi]) {
+				maxY[oi] = order.Y.Clone()
+			}
+
+			var limit uint256.Int
+			getLimit(&limit, order)
+			if limit.Gt(maxLimit[oi]) {
+				maxLimit[oi] = limit.Clone()
+			}
+		}
+	}
+
+	out := strategies[:0]
+	for i := range strategies {
+		for oi := range 2 {
+			order := &strategies[i].Orders[oi]
+			if order.Y == nil || order.Y.Sign() == 0 {
+				*order = Order{}
+				continue
+			}
+
+			var lhs, rhs uint256.Int
+			lhs.Mul(order.Y, uHundred)
+			rhs.Mul(maxY[oi], uDustLiquidityPct)
+			passLiquidity := lhs.Cmp(&rhs) >= 0
+
+			var limit uint256.Int
+			getLimit(&limit, order)
+			lhs.Mul(&limit, uHundred)
+			rhs.Mul(maxLimit[oi], uDustRatePct)
+			passRate := lhs.Cmp(&rhs) >= 0
+
+			if !passLiquidity || !passRate {
+				*order = Order{}
+			}
+		}
+
+		if strategies[i].Orders[0] != (Order{}) || strategies[i].Orders[1] != (Order{}) {
+			out = append(out, strategies[i])
+		}
+	}
+
+	return out
 }

--- a/pkg/liquidity-source/carbon/type.go
+++ b/pkg/liquidity-source/carbon/type.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Order struct {
-	Y *uint256.Int `json:"y"`
-	Z *uint256.Int `json:"z"`
-	A uint64       `json:"A"`
-	B uint64       `json:"B"`
+	Y *uint256.Int `json:"y,omitempty"`
+	Z *uint256.Int `json:"z,omitempty"`
+	A uint64       `json:"A,omitempty"`
+	B uint64       `json:"B,omitempty"`
 }
 
 func (o *Order) Clone() Order {
@@ -49,8 +49,13 @@ type Pair struct {
 }
 
 type Extra struct {
-	Strategies    []Strategy `json:"strategies"`
-	TradingFeePpm uint32     `json:"tradingFeePpm"`
+	Strategies       []Strategy `json:"strategies"`
+	TradingFeePpm    uint32     `json:"tradingFeePpm"`
+	LastFullScanTime int64      `json:"u,omitempty"`
+	// StrategyCount is the on-chain strategiesByPairCount as of this state. Strategies
+	// dust-filtered on both sides aren't stored at all, so this - not len(Strategies) - is
+	// what incrementalScan diffs against to detect newly created strategies.
+	StrategyCount int64 `json:"n,omitempty"`
 }
 
 type Meta struct {


### PR DESCRIPTION
pool_simulator: stop re-quoting each match action against a waterfall
fill of the remaining amount. That recompute existed because the old
executor couldn't apply a partial fill per strategy; the new executor
supports it, so the exact-optimal split from matchBest/matchFast can be
used directly.

pool_tracker: avoid re-fetching and re-storing every strategy on every
poll for pools with hundreds of strategies. A full strategiesByPair walk
now only runs once a minute (or immediately if the on-chain count drops,
since indices may have shifted); in between, only newly created
strategies and the ones we're actually quoting get refreshed. Strategies
that are dust relative to the best-priced/largest one on their side
(<1% of max liquidity or <80% of the best rate) are dropped from what's
tracked and quoted, shrinking both stored state and per-swap match cost.
