### PR TITLE
fix(euler-swap): stop dropping pools on factory unregister reorder

### DIFF
--- a/pkg/liquidity-source/elfomofi/pool_simulator_test.go
+++ b/pkg/liquidity-source/elfomofi/pool_simulator_test.go
@@ -16,7 +16,7 @@ var (
 	entityPool entity.Pool
 	_          = json.Unmarshal([]byte("{\"address\":\"elfomofi_0x4200000000000000000000000000000000000006_0x833589fcd6edb6e08f4c7c32d4f71b54bda02913\",\"exchange\":\"elfomofi\",\"type\":\"elfomofi\",\"timestamp\":1768382669,\"reserves\":[\"6950940416823151180\",\"133555180156\"],\"tokens\":[{\"address\":\"0x4200000000000000000000000000000000000006\",\"symbol\":\"WETH\",\"decimals\":18,\"swappable\":true},{\"address\":\"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913\",\"symbol\":\"USDC\",\"decimals\":6,\"swappable\":true}],\"extra\":\"{\\\"l\\\":[[[0,0],[1e-07,3310.0000000000005],[9e-07,3330],[9e-06,3328.8888888888887],[9e-05,3328.8999999999996],[0.0009,3328.9133333333334],[0.009000000000000001,3328.9141111111107],[0.09000000000000001,3328.9139],[0.9,3328.91391],[9,391.44381699999997],[90,1407.8141321666665]],[[0,0],[1e-06,0.000300043335],[9e-06,0.00030004333700000006],[9e-05,0.0003000433371222222],[0.0009,0.0003000433371122222],[0.009000000000000001,0.0003000433371111111],[0.09000000000000001,0.00030004333711128886],[0.9,0.00030004333711128225],[9,0.00030004333711128247],[90,0.0003000433371112823],[900,0.0003000433371112824],[9000,0.00030000999562856614],[90000,4.389785687838637e-05]]]}\",\"staticExtra\":\"{\\\"factoryAddress\\\":\\\"0x0000000000000000000000000000000000000001\\\"}\"}"),
 		&entityPool)
-	poolSim = lo.Must(NewPoolSimulator(entityPool))
+	poolSim = lo.Must(NewPoolSimulator(pool.FactoryParams{EntityPool: entityPool}))
 )
 
 func TestPoolSimulator_CalcAmountOut(t *testing.T) {
@@ -42,7 +42,7 @@ func TestPoolSimulator_CalcAmountOut(t *testing.T) {
 func TestPoolSimulator_GreedyMatchesBatch(t *testing.T) {
 	t.Parallel()
 
-	greedy := lo.Must(NewPoolSimulator(entityPool))
+	greedy := lo.Must(NewPoolSimulator(pool.FactoryParams{EntityPool: entityPool}))
 	chunk, _ := new(big.Int).SetString("100000000000000000", 10) // 0.1 WETH
 	weth, usdc := entityPool.Tokens[0].Address, entityPool.Tokens[1].Address
 
@@ -62,7 +62,7 @@ func TestPoolSimulator_GreedyMatchesBatch(t *testing.T) {
 		total.Add(total, res.TokenAmountOut.Amount)
 	}
 
-	batch := lo.Must(NewPoolSimulator(entityPool))
+	batch := lo.Must(NewPoolSimulator(pool.FactoryParams{EntityPool: entityPool}))
 	full, _ := new(big.Int).SetString("1000000000000000000", 10) // 1 WETH
 	res, err := batch.CalcAmountOut(pool.CalcAmountOutParams{
 		TokenAmountIn: pool.TokenAmount{Token: weth, Amount: full},

--- a/pkg/liquidity-source/euler-swap/shared/constant.go
+++ b/pkg/liquidity-source/euler-swap/shared/constant.go
@@ -44,6 +44,12 @@ const (
 	RouterMethodGetQuotes = "getQuotes"
 
 	BatchSize = 100
+
+	// BackupTailWindow bounds how many of the most-recently-appended pools
+	// PoolsListUpdater rechecks each cycle. It's a backup for the primary
+	// PoolFactory block-subscription flow, catching pools missed if a block was
+	// skipped - not a full historical scan, so it only needs to look at the tail.
+	BackupTailWindow = 5
 )
 
 var (

--- a/pkg/liquidity-source/euler-swap/v1/abis/EulerSwapFactory.json
+++ b/pkg/liquidity-source/euler-swap/v1/abis/EulerSwapFactory.json
@@ -313,6 +313,37 @@
     "type": "function"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset0",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset1",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "eulerAccount",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolDeployed",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "protocolFee",
     "outputs": [

--- a/pkg/liquidity-source/euler-swap/v1/pool_factory.go
+++ b/pkg/liquidity-source/euler-swap/v1/pool_factory.go
@@ -1,0 +1,86 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/poolfactory"
+)
+
+var _ = poolfactory.RegisterFactoryCE(DexType, NewPoolFactory)
+
+type PoolFactory struct {
+	config       *shared.Config
+	ethrpcClient *ethrpc.Client
+}
+
+func NewPoolFactory(config *shared.Config, ethrpcClient *ethrpc.Client) *PoolFactory {
+	return &PoolFactory{
+		config:       config,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (f *PoolFactory) IsEventSupported(event common.Hash) bool {
+	return event == factoryABI.Events["PoolDeployed"].ID
+}
+
+// DecodePoolCreated decodes the factory's PoolDeployed event. The event only
+// carries the tokens and pool address, so the pool's immutable params (vaults,
+// EulerAccount, EVC, ...) are still fetched via RPC, same as PoolsListUpdater.
+func (f *PoolFactory) DecodePoolCreated(event types.Log) (*entity.Pool, error) {
+	if len(event.Topics) != 4 || !strings.EqualFold(event.Address.Hex(), f.config.FactoryAddress) ||
+		event.Topics[0] != factoryABI.Events["PoolDeployed"].ID {
+		return nil, errors.New("event is not supported")
+	}
+
+	var deployed struct {
+		Pool common.Address `abi:"pool"`
+	}
+	if err := factoryABI.UnpackIntoInterface(&deployed, "PoolDeployed", event.Data); err != nil {
+		return nil, err
+	}
+
+	asset0 := common.BytesToAddress(event.Topics[1].Bytes())
+	asset1 := common.BytesToAddress(event.Topics[2].Bytes())
+
+	staticExtra, err := getPoolStaticData(context.Background(), f.ethrpcClient, deployed.Pool.Hex())
+	if err != nil {
+		return nil, err
+	}
+
+	extraBytes, err := json.Marshal(&staticExtra)
+	if err != nil {
+		return nil, err
+	}
+
+	token0 := &entity.PoolToken{
+		Address:   hexutil.Encode(asset0[:]),
+		Swappable: true,
+	}
+	token1 := &entity.PoolToken{
+		Address:   hexutil.Encode(asset1[:]),
+		Swappable: true,
+	}
+
+	return &entity.Pool{
+		Address:     hexutil.Encode(deployed.Pool[:]),
+		Exchange:    f.config.DexID,
+		Type:        DexType,
+		Timestamp:   time.Now().Unix(),
+		Reserves:    []string{"0", "0"},
+		Tokens:      []*entity.PoolToken{token0, token1},
+		StaticExtra: string(extraBytes),
+		BlockNumber: event.BlockNumber,
+	}, nil
+}

--- a/pkg/liquidity-source/euler-swap/v1/pool_factory_test.go
+++ b/pkg/liquidity-source/euler-swap/v1/pool_factory_test.go
@@ -1,0 +1,65 @@
+package v1
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
+)
+
+// TestPoolFactoryDecodePoolCreated decodes a real PoolDeployed log
+// (tx 0xf8bd06384ffcb61d8946778f4047b6d744a404cc1d9109fec178a1e27c4698e2, Unichain) and checks the result matches
+// what PoolsListUpdater.initPools produces for the same pool via plain RPC,
+// confirming the event-driven decode path stays in sync with the RPC-driven
+// backup path.
+func TestPoolFactoryDecodePoolCreated(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	ethrpcClient := ethrpc.New("https://unichain.drpc.org").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+
+	config := &shared.Config{
+		DexID:          DexType,
+		FactoryAddress: "0x45b146bc07c9985589b52df651310e75c6be066a",
+	}
+
+	log := types.Log{
+		Address: common.HexToAddress("0x45b146bc07c9985589b52df651310e75c6be066a"),
+		Topics: []common.Hash{
+			common.HexToHash("0x5f7560a5797edc6f72421362defa094d690eb9f7ced3cc5a5c13383502e4fcc5"),
+			common.HexToHash("0x000000000000000000000000078d782b760474a361dda0af3839290b0ef57ad6"),
+			common.HexToHash("0x0000000000000000000000004200000000000000000000000000000000000006"),
+			common.HexToHash("0x0000000000000000000000003eb6f25a0a879e5a11270d3bc3c17efb6d41b519"),
+		},
+		Data:        common.FromHex("0x000000000000000000000000cfe91b0b6412e1c8197650c7f28d741fbaaaa8a8"),
+		BlockNumber: 18914816,
+	}
+
+	factory := NewPoolFactory(config, ethrpcClient)
+	require.True(t, factory.IsEventSupported(log.Topics[0]))
+
+	pool, err := factory.DecodePoolCreated(log)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+
+	listUpdater := NewPoolsListUpdater(config, ethrpcClient)
+	rpcPools, err := listUpdater.initPools(context.Background(), []common.Address{
+		common.HexToAddress(pool.Address),
+	})
+	require.NoError(t, err)
+	require.Len(t, rpcPools, 1)
+
+	require.Equal(t, rpcPools[0].Address, pool.Address)
+	require.Equal(t, rpcPools[0].StaticExtra, pool.StaticExtra)
+	require.Equal(t, rpcPools[0].Tokens[0].Address, pool.Tokens[0].Address)
+	require.Equal(t, rpcPools[0].Tokens[1].Address, pool.Tokens[1].Address)
+}

--- a/pkg/liquidity-source/euler-swap/v1/pool_list_updater.go
+++ b/pkg/liquidity-source/euler-swap/v1/pool_list_updater.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/KyberNetwork/ethrpc"
@@ -23,9 +24,16 @@ type (
 		ethrpcClient *ethrpc.Client
 	}
 
+	// PoolsListUpdaterMetadata tracks the last shared.BackupTailWindow pool
+	// addresses seen at the tail of the factory's pool list. The factory stores
+	// pools in an OpenZeppelin EnumerableSet: unregistering a pool swaps the
+	// last element into the removed slot, reshuffling indices, so a numeric
+	// offset can't be trusted to page through the list safely. This is only a
+	// backup for the primary PoolFactory block-subscription flow though, so it
+	// just needs to notice pools appended since the last check, not replay the
+	// whole history.
 	PoolsListUpdaterMetadata struct {
-		Offset     int            `json:"offset"`
-		LatestPool common.Address `json:"lp"`
+		LastPools []common.Address `json:"lp"`
 	}
 )
 
@@ -73,41 +81,8 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		return nil, metadataBytes, nil
 	}
 
-	needResetOffset := metadata.Offset > allPoolsLength
-
-	if metadata.Offset == allPoolsLength {
-		poolList, err := u.listPoolAddresses(ctx, allPoolsLength-1, 1)
-		if err != nil {
-			logger.
-				WithFields(logger.Fields{"dex_id": dexID, "err": err}).
-				Error("getLatestPool failed")
-
-			return nil, metadataBytes, err
-		}
-
-		latestPool := poolList[0]
-
-		if latestPool.Cmp(metadata.LatestPool) == 0 {
-			return nil, metadataBytes, nil
-		}
-
-		metadata.LatestPool = latestPool
-
-		needResetOffset = true
-	}
-
-	if needResetOffset {
-		logger.WithFields(logger.Fields{
-			"dex_id": dexID,
-			"offset": metadata.Offset,
-			"length": allPoolsLength,
-		}).Info("Resetting offset to 0 due to factory uninstall pools")
-		metadata.Offset = 0
-	}
-
-	batchSize := u.getBatchSize(allPoolsLength, metadata.Offset)
-
-	poolAddresses, err := u.listPoolAddresses(ctx, metadata.Offset, batchSize)
+	tailSize := min(shared.BackupTailWindow, allPoolsLength)
+	tailAddresses, err := u.listPoolAddresses(ctx, allPoolsLength-tailSize, tailSize)
 	if err != nil {
 		logger.
 			WithFields(logger.Fields{"dex_id": dexID, "err": err}).
@@ -116,7 +91,24 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		return nil, metadataBytes, err
 	}
 
-	pools, err := u.initPools(ctx, poolAddresses)
+	newAddresses := make([]common.Address, 0)
+	for _, addr := range tailAddresses {
+		if !slices.Contains(metadata.LastPools, addr) {
+			newAddresses = append(newAddresses, addr)
+		}
+	}
+
+	metadata.LastPools = tailAddresses
+
+	if len(newAddresses) == 0 {
+		newMetadataBytes, err := u.newMetadata(metadata)
+		if err != nil {
+			return nil, metadataBytes, err
+		}
+		return nil, newMetadataBytes, nil
+	}
+
+	pools, err := u.initPools(ctx, newAddresses)
 	if err != nil {
 		logger.
 			WithFields(logger.Fields{"dex_id": dexID, "err": err}).
@@ -125,8 +117,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		return nil, metadataBytes, err
 	}
 
-	newOffset := metadata.Offset + batchSize
-	newMetadataBytes, err := u.newMetadata(newOffset, metadata.LatestPool)
+	newMetadataBytes, err := u.newMetadata(metadata)
 	if err != nil {
 		logger.
 			WithFields(logger.Fields{"dex_id": dexID, "err": err}).
@@ -179,7 +170,7 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, poolAddresses []common
 	pools := make([]entity.Pool, 0, len(poolAddresses))
 
 	for i, poolAddress := range poolAddresses {
-		staticPoolData, err := u.getPoolStaticData(ctx, poolAddress.Hex())
+		staticPoolData, err := getPoolStaticData(ctx, u.ethrpcClient, poolAddress.Hex())
 		if err != nil {
 			return nil, err
 		}
@@ -235,8 +226,12 @@ func (u *PoolsListUpdater) listPoolTokens(ctx context.Context, poolAddresses []c
 	return poolTokens, nil
 }
 
-func (d *PoolsListUpdater) getPoolStaticData(
+// getPoolStaticData fetches a pool's immutable params directly, so it can be
+// reused both by the batch backfill (PoolsListUpdater) and the per-pool decode
+// on the PoolDeployed event (PoolFactory).
+func getPoolStaticData(
 	ctx context.Context,
+	ethrpcClient *ethrpc.Client,
 	poolAddress string,
 ) (StaticExtra, error) {
 	var (
@@ -244,7 +239,7 @@ func (d *PoolsListUpdater) getPoolStaticData(
 		evc    common.Address
 	)
 
-	req := d.ethrpcClient.NewRequest().SetContext(ctx)
+	req := ethrpcClient.NewRequest().SetContext(ctx)
 	req.AddCall(&ethrpc.Call{
 		ABI:    poolABI,
 		Target: poolAddress,
@@ -299,12 +294,7 @@ func (u *PoolsListUpdater) getAllPoolsLength(ctx context.Context) (int, error) {
 	return int(allPoolsLength.Int64()), nil
 }
 
-func (u *PoolsListUpdater) newMetadata(newOffset int, newLatestPool common.Address) ([]byte, error) {
-	metadata := PoolsListUpdaterMetadata{
-		Offset:     newOffset,
-		LatestPool: newLatestPool,
-	}
-
+func (u *PoolsListUpdater) newMetadata(metadata PoolsListUpdaterMetadata) ([]byte, error) {
 	metadataBytes, err := json.Marshal(metadata)
 	if err != nil {
 		return nil, err
@@ -324,16 +314,4 @@ func (u *PoolsListUpdater) getMetadata(metadataBytes []byte) (PoolsListUpdaterMe
 	}
 
 	return metadata, nil
-}
-
-func (u *PoolsListUpdater) getBatchSize(length int, offset int) int {
-	if offset >= length {
-		return 0
-	}
-
-	if offset+shared.BatchSize >= length {
-		return length - offset
-	}
-
-	return shared.BatchSize
 }

--- a/pkg/liquidity-source/euler-swap/v2/pool_factory.go
+++ b/pkg/liquidity-source/euler-swap/v2/pool_factory.go
@@ -1,0 +1,112 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/poolfactory"
+)
+
+var _ = poolfactory.RegisterFactoryCE(DexType, NewPoolFactory)
+
+type PoolFactory struct {
+	config       *shared.Config
+	ethrpcClient *ethrpc.Client
+}
+
+func NewPoolFactory(config *shared.Config, ethrpcClient *ethrpc.Client) *PoolFactory {
+	return &PoolFactory{
+		config:       config,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (f *PoolFactory) IsEventSupported(event common.Hash) bool {
+	return event == registryABI.Events["PoolRegistered"].ID
+}
+
+// DecodePoolCreated decodes the registry's PoolRegistered event. Unlike v1,
+// the event already carries the pool's static params, so only the dynamic
+// params and EVC address (not part of the event) need an RPC round trip.
+func (f *PoolFactory) DecodePoolCreated(event types.Log) (*entity.Pool, error) {
+	if len(event.Topics) != 4 || !strings.EqualFold(event.Address.Hex(), f.config.FactoryAddress) ||
+		event.Topics[0] != registryABI.Events["PoolRegistered"].ID {
+		return nil, errors.New("event is not supported")
+	}
+
+	var registered struct {
+		Pool         common.Address     `abi:"pool"`
+		SParams      StaticParamsFields `abi:"sParams"`
+		ValidityBond *big.Int           `abi:"validityBond"`
+	}
+	if err := registryABI.UnpackIntoInterface(&registered, "PoolRegistered", event.Data); err != nil {
+		return nil, err
+	}
+
+	asset0 := common.BytesToAddress(event.Topics[1].Bytes())
+	asset1 := common.BytesToAddress(event.Topics[2].Bytes())
+
+	var (
+		evc           common.Address
+		dynamicParams DynamicParamsRPC
+	)
+
+	req := f.ethrpcClient.NewRequest().SetContext(context.Background())
+	req.AddCall(&ethrpc.Call{
+		ABI:    poolABI,
+		Target: registered.Pool.Hex(),
+		Method: shared.PoolMethodEVC,
+	}, []any{&evc})
+	req.AddCall(&ethrpc.Call{
+		ABI:    poolABI,
+		Target: registered.Pool.Hex(),
+		Method: shared.PoolMethodGetDynamicParams,
+	}, []any{&dynamicParams})
+
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+
+	staticExtra := buildStaticExtra(registered.SParams, evc)
+	staticExtraBytes, err := json.Marshal(&staticExtra)
+	if err != nil {
+		return nil, err
+	}
+
+	extra := Extra{
+		Pause:         1, // unlocked
+		DynamicParams: buildDynamicParams(dynamicParams.Data),
+	}
+	extraBytes, err := json.Marshal(&extra)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := []*entity.PoolToken{
+		{Address: hexutil.Encode(asset0[:]), Swappable: true},
+		{Address: hexutil.Encode(asset1[:]), Swappable: true},
+	}
+
+	return &entity.Pool{
+		Address:     hexutil.Encode(registered.Pool[:]),
+		Exchange:    f.config.DexID,
+		Type:        DexType,
+		Timestamp:   time.Now().Unix(),
+		Reserves:    entity.PoolReserves{"0", "0"},
+		Tokens:      tokens,
+		Extra:       string(extraBytes),
+		StaticExtra: string(staticExtraBytes),
+		BlockNumber: event.BlockNumber,
+	}, nil
+}

--- a/pkg/liquidity-source/euler-swap/v2/pool_factory_test.go
+++ b/pkg/liquidity-source/euler-swap/v2/pool_factory_test.go
@@ -1,0 +1,65 @@
+package v2
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
+)
+
+// TestPoolFactoryDecodePoolCreated decodes a real PoolRegistered log
+// (tx 0x99afdf7e73c3eea928c8a6b816dc4e91c74a42813dcca25a652622687d4ec058, mainnet) and checks the result matches
+// what PoolsListUpdater.initPools produces for the same pool via plain RPC,
+// confirming the event-driven decode path stays in sync with the RPC-driven
+// backup path.
+func TestPoolFactoryDecodePoolCreated(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	ethrpcClient := ethrpc.New("https://rpc.mevblocker.io").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+
+	config := &shared.Config{
+		DexID:          DexType,
+		FactoryAddress: "0x5fccb84363f020c0cade052c9c654aabf932814a",
+	}
+
+	log := types.Log{
+		Address: common.HexToAddress("0x5fccb84363f020c0cade052c9c654aabf932814a"),
+		Topics: []common.Hash{
+			common.HexToHash("0x119fbab0d994e1e8e8de13032b258cc20a84d8da97757668fe40686cebb47ac4"),
+			common.HexToHash("0x00000000000000000000000008efcc2f3e61185d0ea7f8830b3fec9bfa2ee313"),
+			common.HexToHash("0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+			common.HexToHash("0x000000000000000000000000006d9f269695ad9eb8f727f042ee380684332917"),
+		},
+		Data:        common.FromHex("0x0000000000000000000000004ddccfda0cdf6e60866e5fe3e11995fe4ad0e8a8000000000000000000000000c073abfcaa318157340bda9afceaf749f9c1a43e000000000000000000000000797dd80692c3b2dadabce8e30c07fde5307d48a9000000000000000000000000c073abfcaa318157340bda9afceaf749f9c1a43e000000000000000000000000797dd80692c3b2dadabce8e30c07fde5307d48a9000000000000000000000000006d9f269695ad9eb8f727f042ee38068433291700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+		BlockNumber: 25450344,
+	}
+
+	factory := NewPoolFactory(config, ethrpcClient)
+	require.True(t, factory.IsEventSupported(log.Topics[0]))
+
+	pool, err := factory.DecodePoolCreated(log)
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+
+	listUpdater := NewPoolsListUpdater(config, ethrpcClient)
+	rpcPools, err := listUpdater.initPools(context.Background(), []common.Address{
+		common.HexToAddress(pool.Address),
+	})
+	require.NoError(t, err)
+	require.Len(t, rpcPools, 1)
+
+	require.Equal(t, rpcPools[0].Address, pool.Address)
+	require.Equal(t, rpcPools[0].StaticExtra, pool.StaticExtra)
+	require.Equal(t, rpcPools[0].Tokens[0].Address, pool.Tokens[0].Address)
+	require.Equal(t, rpcPools[0].Tokens[1].Address, pool.Tokens[1].Address)
+}

--- a/pkg/liquidity-source/euler-swap/v2/pool_list_updater.go
+++ b/pkg/liquidity-source/euler-swap/v2/pool_list_updater.go
@@ -3,19 +3,17 @@ package v2
 import (
 	"context"
 	"math/big"
-	"strings"
+	"slices"
 	"time"
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/goccy/go-json"
-	"github.com/holiman/uint256"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
 	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 type (
@@ -24,8 +22,16 @@ type (
 		ethrpcClient *ethrpc.Client
 	}
 
+	// PoolsListUpdaterMetadata tracks the last shared.BackupTailWindow pool
+	// addresses seen at the tail of the registry's pool list. The registry
+	// stores pools in an OpenZeppelin EnumerableSet: unregistering a pool swaps
+	// the last element into the removed slot, reshuffling indices, so a numeric
+	// offset can't be trusted to page through the list safely. This is only a
+	// backup for the primary PoolFactory block-subscription flow though, so it
+	// just needs to notice pools appended since the last check, not replay the
+	// whole history.
 	PoolsListUpdaterMetadata struct {
-		Offset int `json:"offset"`
+		LastPools []common.Address `json:"lp"`
 	}
 )
 
@@ -41,14 +47,12 @@ func NewPoolsListUpdater(
 	}
 }
 
-func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadata []byte) ([]entity.Pool, []byte, error) {
-	var offset int
-	if len(metadata) > 0 {
-		var m PoolsListUpdaterMetadata
-		if err := json.Unmarshal(metadata, &m); err != nil {
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	var metadata PoolsListUpdaterMetadata
+	if len(metadataBytes) > 0 {
+		if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
 			return nil, nil, err
 		}
-		offset = m.Offset
 	}
 
 	length, err := u.getPoolsLength(ctx)
@@ -56,33 +60,44 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadata []byte) ([]
 		return nil, nil, err
 	}
 
-	if offset >= length {
-		return nil, metadata, nil
+	if length == 0 {
+		return nil, metadataBytes, nil
 	}
 
-	batchSizeToUse := shared.BatchSize
-	if offset+batchSizeToUse > length {
-		batchSizeToUse = length - offset
-	}
-
-	poolAddresses, err := u.listPoolAddresses(ctx, offset, batchSizeToUse)
+	tailSize := min(shared.BackupTailWindow, length)
+	tailAddresses, err := u.listPoolAddresses(ctx, length-tailSize, tailSize)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pools, err := u.initPools(ctx, poolAddresses)
+	newAddresses := make([]common.Address, 0)
+	for _, addr := range tailAddresses {
+		if !slices.Contains(metadata.LastPools, addr) {
+			newAddresses = append(newAddresses, addr)
+		}
+	}
+
+	metadata.LastPools = tailAddresses
+
+	if len(newAddresses) == 0 {
+		newMetadataBytes, err := json.Marshal(metadata)
+		if err != nil {
+			return nil, metadataBytes, err
+		}
+		return nil, newMetadataBytes, nil
+	}
+
+	pools, err := u.initPools(ctx, newAddresses)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	newMetadata, err := json.Marshal(PoolsListUpdaterMetadata{
-		Offset: offset + len(pools),
-	})
+	newMetadataBytes, err := json.Marshal(metadata)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return pools, newMetadata, nil
+	return pools, newMetadataBytes, nil
 }
 
 func (u *PoolsListUpdater) getPoolsLength(ctx context.Context) (int, error) {
@@ -101,14 +116,14 @@ func (u *PoolsListUpdater) getPoolsLength(ctx context.Context) (int, error) {
 	return int(length.Int64()), nil
 }
 
-func (u *PoolsListUpdater) listPoolAddresses(ctx context.Context, offset, limit int) ([]common.Address, error) {
+func (u *PoolsListUpdater) listPoolAddresses(ctx context.Context, offset, count int) ([]common.Address, error) {
 	var poolAddresses []common.Address
 	req := u.ethrpcClient.NewRequest().SetContext(ctx)
 	req.AddCall(&ethrpc.Call{
 		ABI:    registryABI,
 		Target: u.config.FactoryAddress,
 		Method: shared.FactoryMethodPoolsSlice,
-		Params: []any{big.NewInt(int64(offset)), big.NewInt(int64(limit))},
+		Params: []any{big.NewInt(int64(offset)), big.NewInt(int64(offset + count))},
 	}, []any{&poolAddresses})
 
 	if _, err := req.Call(); err != nil {
@@ -178,47 +193,16 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, poolAddresses []common
 	pools := make([]entity.Pool, 0, numPools)
 
 	for i, poolAddress := range poolAddresses {
-		staticExtra := StaticExtra{
-			SupplyVault0: staticParams[i].Data.SupplyVault0.Hex(),
-			SupplyVault1: staticParams[i].Data.SupplyVault1.Hex(),
-			EulerAccount: staticParams[i].Data.EulerAccount.Hex(),
-			EVC:          evcAddresses[i].Hex(),
-		}
-
-		if !valueobject.IsZeroAddress(staticParams[i].Data.BorrowVault0) {
-			staticExtra.BorrowVault0 = staticParams[i].Data.BorrowVault0.Hex()
-		}
-		if !valueobject.IsZeroAddress(staticParams[i].Data.BorrowVault1) {
-			staticExtra.BorrowVault1 = staticParams[i].Data.BorrowVault1.Hex()
-		}
-		if !valueobject.IsZeroAddress(staticParams[i].Data.FeeRecipient) {
-			staticExtra.FeeRecipient = staticParams[i].Data.FeeRecipient.Hex()
-		}
+		staticExtra := buildStaticExtra(staticParams[i].Data, evcAddresses[i])
 
 		staticExtraBytes, err := json.Marshal(&staticExtra)
 		if err != nil {
 			return nil, err
 		}
 
-		dParams := DynamicParams{
-			EquilibriumReserve0: uint256.MustFromBig(dynamicParams[i].Data.EquilibriumReserve0),
-			EquilibriumReserve1: uint256.MustFromBig(dynamicParams[i].Data.EquilibriumReserve1),
-			MinReserve0:         uint256.MustFromBig(dynamicParams[i].Data.MinReserve0),
-			MinReserve1:         uint256.MustFromBig(dynamicParams[i].Data.MinReserve1),
-			PriceX:              uint256.MustFromBig(dynamicParams[i].Data.PriceX),
-			PriceY:              uint256.MustFromBig(dynamicParams[i].Data.PriceY),
-			ConcentrationX:      uint256.NewInt(dynamicParams[i].Data.ConcentrationX),
-			ConcentrationY:      uint256.NewInt(dynamicParams[i].Data.ConcentrationY),
-			Fee0:                uint256.NewInt(dynamicParams[i].Data.Fee0),
-			Fee1:                uint256.NewInt(dynamicParams[i].Data.Fee1),
-			Expiration:          dynamicParams[i].Data.Expiration.Uint64(),
-			SwapHookedOps:       dynamicParams[i].Data.SwapHookedOperations,
-			SwapHook:            dynamicParams[i].Data.SwapHook.Hex(),
-		}
-
 		extra := Extra{
 			Pause:         1, // unlocked
-			DynamicParams: dParams,
+			DynamicParams: buildDynamicParams(dynamicParams[i].Data),
 		}
 
 		extraBytes, err := json.Marshal(&extra)
@@ -228,11 +212,11 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, poolAddresses []common
 
 		var tokens []*entity.PoolToken
 		tokens = append(tokens, &entity.PoolToken{
-			Address:   strings.ToLower(tokensByPool[i][0].Hex()),
+			Address:   hexutil.Encode(tokensByPool[i][0][:]),
 			Swappable: true,
 		})
 		tokens = append(tokens, &entity.PoolToken{
-			Address:   strings.ToLower(tokensByPool[i][1].Hex()),
+			Address:   hexutil.Encode(tokensByPool[i][1][:]),
 			Swappable: true,
 		})
 

--- a/pkg/liquidity-source/euler-swap/v2/types.go
+++ b/pkg/liquidity-source/euler-swap/v2/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 type StaticExtra struct {
@@ -54,32 +55,83 @@ type AssetsRPC struct {
 	Asset1 common.Address
 }
 
+// StaticParamsFields mirrors IEulerSwap.StaticParams. It is also the shape of
+// the "sParams" tuple carried inline by the registry's PoolRegistered event,
+// so it's reused for decoding that event without an extra RPC round trip.
+type StaticParamsFields struct {
+	SupplyVault0 common.Address `abi:"supplyVault0"`
+	SupplyVault1 common.Address `abi:"supplyVault1"`
+	BorrowVault0 common.Address `abi:"borrowVault0"`
+	BorrowVault1 common.Address `abi:"borrowVault1"`
+	EulerAccount common.Address `abi:"eulerAccount"`
+	FeeRecipient common.Address `abi:"feeRecipient"`
+}
+
 type StaticParamsRPC struct {
-	Data struct {
-		SupplyVault0 common.Address `abi:"supplyVault0"`
-		SupplyVault1 common.Address `abi:"supplyVault1"`
-		BorrowVault0 common.Address `abi:"borrowVault0"`
-		BorrowVault1 common.Address `abi:"borrowVault1"`
-		EulerAccount common.Address `abi:"eulerAccount"`
-		FeeRecipient common.Address `abi:"feeRecipient"`
-	}
+	Data StaticParamsFields
+}
+
+type DynamicParamsFields struct {
+	EquilibriumReserve0  *big.Int       `abi:"equilibriumReserve0"`
+	EquilibriumReserve1  *big.Int       `abi:"equilibriumReserve1"`
+	MinReserve0          *big.Int       `abi:"minReserve0"`
+	MinReserve1          *big.Int       `abi:"minReserve1"`
+	PriceX               *big.Int       `abi:"priceX"`
+	PriceY               *big.Int       `abi:"priceY"`
+	ConcentrationX       uint64         `abi:"concentrationX"`
+	ConcentrationY       uint64         `abi:"concentrationY"`
+	Fee0                 uint64         `abi:"fee0"`
+	Fee1                 uint64         `abi:"fee1"`
+	Expiration           *big.Int       `abi:"expiration"`
+	SwapHookedOperations uint8          `abi:"swapHookedOperations"`
+	SwapHook             common.Address `abi:"swapHook"`
 }
 
 type DynamicParamsRPC struct {
-	Data struct {
-		EquilibriumReserve0  *big.Int       `abi:"equilibriumReserve0"`
-		EquilibriumReserve1  *big.Int       `abi:"equilibriumReserve1"`
-		MinReserve0          *big.Int       `abi:"minReserve0"`
-		MinReserve1          *big.Int       `abi:"minReserve1"`
-		PriceX               *big.Int       `abi:"priceX"`
-		PriceY               *big.Int       `abi:"priceY"`
-		ConcentrationX       uint64         `abi:"concentrationX"`
-		ConcentrationY       uint64         `abi:"concentrationY"`
-		Fee0                 uint64         `abi:"fee0"`
-		Fee1                 uint64         `abi:"fee1"`
-		Expiration           *big.Int       `abi:"expiration"`
-		SwapHookedOperations uint8          `abi:"swapHookedOperations"`
-		SwapHook             common.Address `abi:"swapHook"`
+	Data DynamicParamsFields
+}
+
+// buildStaticExtra maps a pool's static params (from RPC or the
+// PoolRegistered event log, both share this shape) plus its EVC address into
+// the persisted StaticExtra.
+func buildStaticExtra(sp StaticParamsFields, evc common.Address) StaticExtra {
+	staticExtra := StaticExtra{
+		SupplyVault0: sp.SupplyVault0.Hex(),
+		SupplyVault1: sp.SupplyVault1.Hex(),
+		EulerAccount: sp.EulerAccount.Hex(),
+		EVC:          evc.Hex(),
+	}
+
+	if !valueobject.IsZeroAddress(sp.BorrowVault0) {
+		staticExtra.BorrowVault0 = sp.BorrowVault0.Hex()
+	}
+	if !valueobject.IsZeroAddress(sp.BorrowVault1) {
+		staticExtra.BorrowVault1 = sp.BorrowVault1.Hex()
+	}
+	if !valueobject.IsZeroAddress(sp.FeeRecipient) {
+		staticExtra.FeeRecipient = sp.FeeRecipient.Hex()
+	}
+
+	return staticExtra
+}
+
+// buildDynamicParams maps a pool's dynamic params fetched via RPC into the
+// persisted DynamicParams.
+func buildDynamicParams(dp DynamicParamsFields) DynamicParams {
+	return DynamicParams{
+		EquilibriumReserve0: uint256.MustFromBig(dp.EquilibriumReserve0),
+		EquilibriumReserve1: uint256.MustFromBig(dp.EquilibriumReserve1),
+		MinReserve0:         uint256.MustFromBig(dp.MinReserve0),
+		MinReserve1:         uint256.MustFromBig(dp.MinReserve1),
+		PriceX:              uint256.MustFromBig(dp.PriceX),
+		PriceY:              uint256.MustFromBig(dp.PriceY),
+		ConcentrationX:      uint256.NewInt(dp.ConcentrationX),
+		ConcentrationY:      uint256.NewInt(dp.ConcentrationY),
+		Fee0:                uint256.NewInt(dp.Fee0),
+		Fee1:                uint256.NewInt(dp.Fee1),
+		Expiration:          dp.Expiration.Uint64(),
+		SwapHookedOps:       dp.SwapHookedOperations,
+		SwapHook:            dp.SwapHook.Hex(),
 	}
 }
 


### PR DESCRIPTION
Both EulerSwapFactory (v1) and EulerSwapRegistry (v2) store pools in an
OpenZeppelin EnumerableSet: unregistering a pool swaps the last element
into the removed slot, reshuffling indices. Paging GetNewPools by a
numeric offset could permanently skip a pool that got moved behind an
already-scanned offset.

Add PoolFactory (IPoolFactoryDecoder) for both versions, decoding
PoolDeployed/PoolRegistered directly from the block-subscription flow
so new pools are picked up without depending on array position at all.
v2's PoolRegistered event already carries the static params inline, cut
one RPC round trip. Verified both decoders against real historical
event logs, matching the RPC-based path exactly.

GetNewPools now only rechecks the last shared.BackupTailWindow (5)
pool addresses each cycle as a backup for a missed block, instead of
trusting a growing offset - bounded metadata, no full-history replay
needed since the event flow is now the primary discovery path.

Also fixes a pre-existing bug in v2's listPoolAddresses, which passed
count directly as poolsSlice's end index instead of offset+count,
silently returning empty results for any non-zero offset.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TzaiPGRNky5rA4JLhZqnLn
