### PR TITLE
fix(generic-arm): support upgraded ARM withdrawal-queue and Pricable4626 getters

### DIFF
--- a/pkg/liquidity-source/generic-arm/abis/lidoarm.json
+++ b/pkg/liquidity-source/generic-arm/abis/lidoarm.json
@@ -638,6 +638,73 @@
     },
     {
         "inputs": [],
+        "name": "getBaseAssets",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "baseAssetConfigs",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "buyPrice",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "sellPrice",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "buyLiquidityRemaining",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "sellLiquidityRemaining",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "crossPrice",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint120",
+                "name": "pendingRedeemAssets",
+                "type": "uint120"
+            },
+            {
+                "internalType": "bool",
+                "name": "peggedToLiquidityAsset",
+                "type": "bool"
+            },
+            {
+                "internalType": "address",
+                "name": "adapter",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
         "name": "capManager",
         "outputs": [
             {
@@ -1585,6 +1652,32 @@
     {
         "inputs": [],
         "name": "withdrawsQueued",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "withdrawsClaimedShares",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "withdrawsQueuedShares",
         "outputs": [
             {
                 "internalType": "uint128",

--- a/pkg/liquidity-source/generic-arm/constant.go
+++ b/pkg/liquidity-source/generic-arm/constant.go
@@ -5,6 +5,9 @@ import "errors"
 const (
 	DexType         = "generic-arm"
 	defaultReserves = "100000000000000000000000"
+	// priceScale4626 is AbstractARM's PRICE_SCALE (1e36). The upgraded ARM contract used by
+	// Pricable4626 pools no longer exposes PRICE_SCALE() as a getter (it's now an internal constant).
+	priceScale4626 = "1000000000000000000000000000000000000"
 )
 
 var (
@@ -14,4 +17,6 @@ var (
 	ErrInsufficientLiquidity   = errors.New("INSUFFICIENT_LIQUIDITY")
 	ErrUnsupportedSwap         = errors.New("unsupported swap")
 	ErrUnsupportedArmType      = errors.New("unsupported arm type")
+	ErrWithdrawalQueueState    = errors.New("failed to fetch withdrawal queue state")
+	ErrFailedToFetchPoolState  = errors.New("failed to fetch pool state")
 )

--- a/pkg/liquidity-source/generic-arm/pool_simulator.go
+++ b/pkg/liquidity-source/generic-arm/pool_simulator.go
@@ -97,14 +97,17 @@ func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 	case Pricable4626:
 		tokenInIsBaseAsset := strings.EqualFold(p.Info.Tokens[indexIn], p.Vault.BaseAsset.Hex())
 		if tokenInIsBaseAsset {
-			// convertToAssets
+			// Trader sells the base asset for the liquidity asset (ARM buys the base asset).
+			// convertToAssets: base shares -> liquidity-value assets, then apply buyPrice.
 			amountOut.MulDivOverflow(amountIn, p.Vault.TotalAssets, p.Vault.TotalSupply)
+			amountOut.MulDivOverflow(amountOut, p.Vault.BuyPrice, p.PriceScale)
 		} else {
-			// convertToShares
+			// Trader sells the liquidity asset for the base asset (ARM sells the base asset).
+			// convertToShares: liquidity assets -> base-equivalent shares, then apply sellPrice (divide,
+			// since sellPrice is liquidity-per-base and the ARM charges a premium when selling).
 			amountOut.MulDivOverflow(amountIn, p.Vault.TotalSupply, p.Vault.TotalAssets)
+			amountOut.MulDivOverflow(amountOut, p.PriceScale, p.Vault.SellPrice)
 		}
-		price := lo.Ternary(indexIn == 0, p.TradeRate0, p.TradeRate1)
-		amountOut.MulDivOverflow(amountOut, price, p.PriceScale)
 	default:
 		return nil, ErrUnsupportedArmType
 	}

--- a/pkg/liquidity-source/generic-arm/pool_simulator_test.go
+++ b/pkg/liquidity-source/generic-arm/pool_simulator_test.go
@@ -53,6 +53,57 @@ func TestPoolSimulator10(t *testing.T) {
 	assert.Equal(t, big.NewInt(5019014848646185045), amountOut.TokenAmountOut.Amount)
 }
 
+// getEthenaARMPool builds a Pricable4626 pool (USDe/sUSDe) from a live on-chain snapshot of
+// 0xCEDa2d856238aA0D12f6329de20B9115f07C366d taken after the ARM's upgrade to the shared
+// AbstractARM contract (buyPrice/sellPrice via baseAssetConfigs(), no more token0/token1/traderate0/1).
+func getEthenaARMPool() *PoolSimulator {
+	var poolE entity.Pool
+	_ = json.Unmarshal([]byte(`{
+		"address":"0xceda2d856238aa0d12f6329de20b9115f07c366d",
+		"exchange":"ethenaarm",
+		"type":"ethenaarm",
+		"timestamp":1749541899,
+		"reserves":["9719573042480775686418","51606389896075379654910"],
+		"tokens":[
+			{"address":"0x4c9edd5852cd905f086c759e8383e09bff1e68b3","symbol":"USDe","decimals":18,"swappable":true},
+			{"address":"0x9d39a5de30e57443bff2a8307a4256c8797a3497","symbol":"sUSDe","decimals":18,"swappable":true}
+		],
+		"extra":"{\"la\":\"0x4c9edd5852cd905f086c759e8383e09bff1e68b3\",\"ps\":\"1000000000000000000000000000000000000\",\"swapType\":3,\"armType\":2,\"hasWithdrawalQueue\":false,\"v\":{\"ba\":\"0x9d39a5de30e57443bff2a8307a4256c8797a3497\",\"ta\":\"1642140898458895542142337558\",\"ts\":\"1326183113092221454904213555\",\"bp\":\"999600000000000000000000000000000000\",\"sp\":\"999990000000000000000000000000000000\"}}"
+	}`), &poolE)
+	pool, _ := NewPoolSimulator(poolE)
+	return pool
+}
+
+func TestPoolSimulatorPricable4626_USDeToSUSDe(t *testing.T) {
+	p := getEthenaARMPool()
+	amountOut, err := p.CalcAmountOut(
+		pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{
+				Token:  "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+				Amount: bignumber.NewBig("1000000000000000000000"),
+			},
+			TokenOut: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, bignumber.NewBig("807602061613940163083"), amountOut.TokenAmountOut.Amount)
+}
+
+func TestPoolSimulatorPricable4626_SUSDeToUSDe(t *testing.T) {
+	p := getEthenaARMPool()
+	amountOut, err := p.CalcAmountOut(
+		pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{
+				Token:  "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+				Amount: bignumber.NewBig("1000000000000000000000"),
+			},
+			TokenOut: "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, bignumber.NewBig("1237750674016737246720"), amountOut.TokenAmountOut.Amount)
+}
+
 func TestPoolSimulatorErrInsufficientLiquidity(t *testing.T) {
 	p := getPool()
 	// https://etherscan.io/tx/0x332289850d386bef8bc8a90fb6ec31519b6a64a0756e442f2546dc51db87fb32

--- a/pkg/liquidity-source/generic-arm/pool_tracker.go
+++ b/pkg/liquidity-source/generic-arm/pool_tracker.go
@@ -75,6 +75,8 @@ func (t *PoolTracker) getNewPoolState(
 			BaseAsset:   poolState.Vault.BaseAsset,
 			TotalAssets: uint256.MustFromBig(poolState.Vault.TotalAssets),
 			TotalSupply: uint256.MustFromBig(poolState.Vault.TotalSupply),
+			BuyPrice:    uint256FromBigOrNil(poolState.Vault.BuyPrice),
+			SellPrice:   uint256FromBigOrNil(poolState.Vault.SellPrice),
 		},
 		SwapTypes:          t.config.Arms[p.Address].SwapType,
 		ArmType:            t.config.Arms[p.Address].ArmType,

--- a/pkg/liquidity-source/generic-arm/pools_list_updater.go
+++ b/pkg/liquidity-source/generic-arm/pools_list_updater.go
@@ -67,6 +67,13 @@ func (d *PoolsListUpdater) getNewPool(ctx context.Context, armAddr string, armCf
 		SwapTypes:          armCfg.SwapType,
 		ArmType:            armCfg.ArmType,
 		HasWithdrawalQueue: armCfg.HasWithdrawalQueue,
+		Vault: ERC4626Extra{
+			BaseAsset:   poolState.Vault.BaseAsset,
+			TotalAssets: uint256FromBigOrNil(poolState.Vault.TotalAssets),
+			TotalSupply: uint256FromBigOrNil(poolState.Vault.TotalSupply),
+			BuyPrice:    uint256FromBigOrNil(poolState.Vault.BuyPrice),
+			SellPrice:   uint256FromBigOrNil(poolState.Vault.SellPrice),
+		},
 	})
 
 	if err != nil {

--- a/pkg/liquidity-source/generic-arm/types.go
+++ b/pkg/liquidity-source/generic-arm/types.go
@@ -41,6 +41,11 @@ type ERC4626Extra struct {
 	BaseAsset   common.Address `json:"ba"`
 	TotalAssets *uint256.Int   `json:"ta"`
 	TotalSupply *uint256.Int   `json:"ts"`
+	// BuyPrice/SellPrice are only populated for ArmType Pricable4626. The upgraded ARM contract
+	// (AbstractARM) prices each base asset individually via baseAssetConfigs(baseAsset) instead of
+	// the removed traderate0()/traderate1(); PRICE_SCALE is now a fixed 1e36 constant, not a getter.
+	BuyPrice  *uint256.Int `json:"bp"`
+	SellPrice *uint256.Int `json:"sp"`
 }
 
 type PoolState struct {
@@ -61,6 +66,21 @@ type ERC4626 struct {
 	BaseAsset   common.Address
 	TotalAssets *big.Int
 	TotalSupply *big.Int
+	BuyPrice    *big.Int
+	SellPrice   *big.Int
+}
+
+// BaseAssetConfig mirrors AbstractARM's public baseAssetConfigs(address) getter. Only BuyPrice/SellPrice
+// are used today; the remaining fields are decoded to keep the ABI tuple unpacking correct.
+type BaseAssetConfig struct {
+	BuyPrice               *big.Int
+	SellPrice              *big.Int
+	BuyLiquidityRemaining  *big.Int
+	SellLiquidityRemaining *big.Int
+	CrossPrice             *big.Int
+	PendingRedeemAssets    *big.Int
+	PeggedToLiquidityAsset bool
+	Adapter                common.Address
 }
 type Gas struct {
 	ZeroToOne uint64 `json:"z2o,omitempty"`

--- a/pkg/liquidity-source/generic-arm/utils.go
+++ b/pkg/liquidity-source/generic-arm/utils.go
@@ -2,38 +2,87 @@ package genericarm
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
+
+// uint256FromBigOrNil converts a *big.Int to *uint256.Int, returning nil when v is nil. Used for
+// fields like BuyPrice/SellPrice that are only populated for some ArmType values.
+func uint256FromBigOrNil(v *big.Int) *uint256.Int {
+	if v == nil {
+		return nil
+	}
+	return uint256.MustFromBig(v)
+}
 
 func fetchAssetAndState(ctx context.Context, ethrpcClient *ethrpc.Client, armAddr string, armCfg ArmCfg) (*PoolState, error) {
 	var poolState PoolState
+	var withdrawsQueued, withdrawsClaimed, withdrawsQueuedShares, withdrawsClaimedShares *big.Int
 
 	calls := ethrpcClient.NewRequest().SetContext(ctx)
-	calls.AddCall(&ethrpc.Call{
-		ABI:    lidoArmABI,
-		Target: armAddr,
-		Method: "token0",
-	}, []any{&poolState.Token0})
-	calls.AddCall(&ethrpc.Call{
-		ABI:    lidoArmABI,
-		Target: armAddr,
-		Method: "token1",
-	}, []any{&poolState.Token1})
 
-	if armCfg.ArmType == Pricable || armCfg.ArmType == Pricable4626 {
+	type requiredCall struct {
+		idx    int
+		method string
+	}
+	var requiredCalls []requiredCall
+	idx := func() int { return len(calls.Calls) }
+	addRequired := func(method string) { requiredCalls = append(requiredCalls, requiredCall{idx(), method}) }
+
+	var baseAssets []common.Address
+	switch armCfg.ArmType {
+	case Pricable4626:
+		// The upgraded ARM contract (AbstractARM) dropped the fixed token0()/token1() pair in favor of
+		// liquidityAsset() (the quote asset) plus getBaseAssets() (tradeable base assets against it).
+		// Pricable4626 only ever traded a single base asset, so Token0/Token1 keep working as before,
+		// just sourced from the new getters.
+		addRequired("liquidityAsset")
+		calls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "liquidityAsset",
+		}, []any{&poolState.Token0})
+		addRequired("getBaseAssets")
+		calls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "getBaseAssets",
+		}, []any{&baseAssets})
+	default:
+		addRequired("token0")
+		calls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "token0",
+		}, []any{&poolState.Token0})
+		addRequired("token1")
+		calls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "token1",
+		}, []any{&poolState.Token1})
+	}
+
+	if armCfg.ArmType == Pricable {
+		addRequired("traderate0")
 		calls.AddCall(&ethrpc.Call{
 			ABI:    lidoArmABI,
 			Target: armAddr,
 			Method: "traderate0",
 		}, []any{&poolState.TradeRate0})
+		addRequired("traderate1")
 		calls.AddCall(&ethrpc.Call{
 			ABI:    lidoArmABI,
 			Target: armAddr,
 			Method: "traderate1",
 		}, []any{&poolState.TradeRate1})
+		addRequired("PRICE_SCALE")
 		calls.AddCall(&ethrpc.Call{
 			ABI:    lidoArmABI,
 			Target: armAddr,
@@ -41,69 +90,145 @@ func fetchAssetAndState(ctx context.Context, ethrpcClient *ethrpc.Client, armAdd
 		}, []any{&poolState.PriceScale})
 	}
 
-	if armCfg.ArmType == Pricable4626 {
-		calls.AddCall(&ethrpc.Call{
-			ABI:    lidoArmABI,
-			Target: armAddr,
-			Method: "baseAsset",
-		}, []any{&poolState.Vault.BaseAsset})
-	}
-
+	var idxWithdrawsQueued, idxWithdrawsClaimed, idxWithdrawsQueuedShares, idxWithdrawsClaimedShares int
 	if armCfg.HasWithdrawalQueue {
+		addRequired("liquidityAsset")
 		calls.AddCall(&ethrpc.Call{
 			ABI:    lidoArmABI,
 			Target: armAddr,
 			Method: "liquidityAsset",
 		}, []any{&poolState.LiquidityAsset})
+
+		// withdrawsQueued/withdrawsClaimed are asset-denominated getters used by non-upgraded ARMs.
+		// withdrawsQueuedShares/withdrawsClaimedShares are the share-denominated replacements used by
+		// upgraded ARMs (e.g. EthenaARM). Both pairs are requested via TryAggregate so an ARM missing
+		// either pair doesn't fail the whole batch; whichever pair succeeds is used below.
+		idxWithdrawsQueued = idx()
 		calls.AddCall(&ethrpc.Call{
 			ABI:    lidoArmABI,
 			Target: armAddr,
 			Method: "withdrawsQueued",
-		}, []any{&poolState.WithdrawsQueued})
+		}, []any{&withdrawsQueued})
+		idxWithdrawsClaimed = idx()
 		calls.AddCall(&ethrpc.Call{
 			ABI:    lidoArmABI,
 			Target: armAddr,
 			Method: "withdrawsClaimed",
-		}, []any{&poolState.WithdrawsClaimed})
+		}, []any{&withdrawsClaimed})
+		idxWithdrawsQueuedShares = idx()
+		calls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "withdrawsQueuedShares",
+		}, []any{&withdrawsQueuedShares})
+		idxWithdrawsClaimedShares = idx()
+		calls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "withdrawsClaimedShares",
+		}, []any{&withdrawsClaimedShares})
 	}
-	_, err := calls.Aggregate()
+
+	res, err := calls.TryAggregate()
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err,
 		}).Errorf("failed to initPool")
 		return nil, err
 	}
+	for _, rc := range requiredCalls {
+		if !res.Result[rc.idx] {
+			logger.WithFields(logger.Fields{
+				"armAddr": armAddr,
+				"method":  rc.method,
+			}).Errorf("failed to initPool: required call reverted")
+			return nil, ErrFailedToFetchPoolState
+		}
+	}
 
-	calls.AddCall(&ethrpc.Call{
+	if armCfg.ArmType == Pricable4626 {
+		if len(baseAssets) == 0 {
+			logger.WithFields(logger.Fields{
+				"armAddr": armAddr,
+			}).Errorf("failed to initPool: getBaseAssets returned no base asset")
+			return nil, ErrFailedToFetchPoolState
+		}
+		poolState.Token1 = baseAssets[0]
+		poolState.Vault.BaseAsset = baseAssets[0]
+		poolState.PriceScale = bignumber.NewBig(priceScale4626)
+	}
+
+	if armCfg.HasWithdrawalQueue {
+		switch {
+		case res.Result[idxWithdrawsQueued] && res.Result[idxWithdrawsClaimed]:
+			poolState.WithdrawsQueued = withdrawsQueued
+			poolState.WithdrawsClaimed = withdrawsClaimed
+		case res.Result[idxWithdrawsQueuedShares] && res.Result[idxWithdrawsClaimedShares]:
+			convertCalls := ethrpcClient.NewRequest().SetContext(ctx)
+			convertCalls.AddCall(&ethrpc.Call{
+				ABI:    lidoArmABI,
+				Target: armAddr,
+				Method: "convertToAssets",
+				Params: []any{withdrawsQueuedShares},
+			}, []any{&poolState.WithdrawsQueued})
+			convertCalls.AddCall(&ethrpc.Call{
+				ABI:    lidoArmABI,
+				Target: armAddr,
+				Method: "convertToAssets",
+				Params: []any{withdrawsClaimedShares},
+			}, []any{&poolState.WithdrawsClaimed})
+			if _, err := convertCalls.Aggregate(); err != nil {
+				logger.WithFields(logger.Fields{
+					"error": err,
+				}).Errorf("failed to convert withdrawal queue shares to assets")
+				return nil, err
+			}
+		default:
+			return nil, ErrWithdrawalQueueState
+		}
+	}
+
+	balanceCalls := ethrpcClient.NewRequest().SetContext(ctx)
+	balanceCalls.AddCall(&ethrpc.Call{
 		ABI:    lidoArmABI,
 		Target: poolState.Token0.Hex(),
 		Method: "balanceOf",
 		Params: []any{common.HexToAddress(armAddr)},
 	}, []any{&poolState.Reserve0})
-	calls.AddCall(&ethrpc.Call{
+	balanceCalls.AddCall(&ethrpc.Call{
 		ABI:    lidoArmABI,
 		Target: poolState.Token1.Hex(),
 		Method: "balanceOf",
 		Params: []any{common.HexToAddress(armAddr)},
 	}, []any{&poolState.Reserve1})
+	var baseAssetConfig BaseAssetConfig
 	if armCfg.ArmType == Pricable4626 {
-		calls.AddCall(&ethrpc.Call{
+		balanceCalls.AddCall(&ethrpc.Call{
 			ABI:    ERC626ABI,
 			Target: poolState.Vault.BaseAsset.Hex(),
 			Method: "totalAssets",
 		}, []any{&poolState.Vault.TotalAssets})
-		calls.AddCall(&ethrpc.Call{
+		balanceCalls.AddCall(&ethrpc.Call{
 			ABI:    ERC626ABI,
 			Target: poolState.Vault.BaseAsset.Hex(),
 			Method: "totalSupply",
 		}, []any{&poolState.Vault.TotalSupply})
+		balanceCalls.AddCall(&ethrpc.Call{
+			ABI:    lidoArmABI,
+			Target: armAddr,
+			Method: "baseAssetConfigs",
+			Params: []any{poolState.Vault.BaseAsset},
+		}, []any{&baseAssetConfig})
 	}
-	_, err = calls.Aggregate()
-	if err != nil {
+	if _, err := balanceCalls.Aggregate(); err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err,
 		}).Errorf("failed to initPool")
 		return nil, err
+	}
+	if armCfg.ArmType == Pricable4626 {
+		poolState.Vault.BuyPrice = baseAssetConfig.BuyPrice
+		poolState.Vault.SellPrice = baseAssetConfig.SellPrice
 	}
 
 	return &poolState, nil


### PR DESCRIPTION
EthenaARM (0xCEDa2d856238aA0D12f6329de20B9115f07C366d) and other ARMs upgraded to
Origin Protocol's shared AbstractARM contract, which removed withdrawsQueued()/
withdrawsClaimed() (replaced by share-denominated withdrawsQueuedShares()/
withdrawsClaimedShares()) and, for Pricable4626 pools, removed token0()/token1()/
baseAsset()/traderate0()/traderate1()/PRICE_SCALE() in favor of liquidityAsset()/
getBaseAssets()/baseAssetConfigs(address). Calling the removed getters reverted the
whole quoting/simulation batch and broke pool discovery.

- Fetch both old and new withdrawal-queue getters via TryAggregate, preferring the
  asset-denominated pair and falling back to converting the share-denominated pair
  via convertToAssets when only that pair is available.
- For Pricable4626, source Token0/Token1 from liquidityAsset()/getBaseAssets()[0]
  and buyPrice/sellPrice from baseAssetConfigs(), with PRICE_SCALE hardcoded to the
  now-internal 1e36 constant, and apply the correct asymmetric on-chain pricing
  formula (divide by sellPrice buying the base asset, multiply by buyPrice selling
  it) instead of the old single traderate-based multiply.
- Pegged/Pricable ArmTypes are untouched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
