### PR TITLE
fix(curve): stop freezing D/price_scale after the first swap in twocrypto-ng and tricrypto-ng

### DIFF
--- a/pkg/liquidity-source/curve/tricrypto-ng/curve_tricrypto_optimized_weth.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/curve_tricrypto_optimized_weth.go
@@ -235,12 +235,10 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 	blockTimestamp := time.Now().Unix()
 	var err error
 
-	if t.tweakedPrice {
-		// this block update price_oracle and last_price_timestamp
-		// but in pool tracker we've fetched the calculated price_oracle, not the raw packed value,
-		// so we can use that here without updating. we only check that we tweak only once
-		return nil
-	}
+	// On-chain, this also updates cached_price_oracle and last_timestamp, but only once per
+	// block. The pool tracker already fetches the EMA-computed price_oracle directly, so there
+	// is nothing to recompute here; D, virtual_price, xcp_profit, last_prices and price_scale
+	// below, however, are updated unconditionally on every exchange on-chain and must be too.
 
 	// #                  price_oracle is used further on to calculate its vector
 	// #            distance from price_scale. This distance is used to calculate

--- a/pkg/liquidity-source/curve/tricrypto-ng/pool_simulator.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/pool_simulator.go
@@ -25,8 +25,6 @@ type PoolSimulator struct {
 	precisionMultipliers []uint256.Int
 	Reserves             []uint256.Int // same as pool.Reserves but use uint256.Int
 
-	tweakedPrice bool
-
 	Extra       Extra
 	StaticExtra StaticExtra
 
@@ -215,14 +213,11 @@ func (t *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 	t.Info.Reserves[outputIndex] = new(big.Int).Sub(t.Info.Reserves[outputIndex], outputAmount)
 	t.Reserves[outputIndex] = *new(uint256.Int).Sub(&t.Reserves[outputIndex], number.SetFromBig(outputAmount))
 
-	if !t.tweakedPrice {
-		t.tweakedPrice = true
-		t.Extra.LastPrices = swapInfo.LastPrices[:]
-		t.Extra.PriceScale = swapInfo.PriceScale[:]
-		t.Extra.XcpProfit = &swapInfo.XcpProfit
-		t.Extra.D = &swapInfo.D
-		t.Extra.VirtualPrice = &swapInfo.VirtualPrice
-	}
+	t.Extra.LastPrices = swapInfo.LastPrices[:]
+	t.Extra.PriceScale = swapInfo.PriceScale[:]
+	t.Extra.XcpProfit = &swapInfo.XcpProfit
+	t.Extra.D = &swapInfo.D
+	t.Extra.VirtualPrice = &swapInfo.VirtualPrice
 }
 
 func (t *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {

--- a/pkg/liquidity-source/curve/tricrypto-ng/pool_simulator_test.go
+++ b/pkg/liquidity-source/curve/tricrypto-ng/pool_simulator_test.go
@@ -196,28 +196,28 @@ func TestUpdateBalance(t *testing.T) {
 	}{
 		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "1304718298868"},
 		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "1304675974788"},
-		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "1304898571422510"},
-		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "1306024453847454"},
-		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "3393536839049"},
-		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1822607809867"},
-		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1819677288075988"},
-		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1821248242501378"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1574126861158"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "2056531723"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "696648048123"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "697248127714"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "362851"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "191462"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "191255367"},
-		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "191420171"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "302552"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "137440"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "137149910"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "137268281"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "444235376"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "358363928"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "358242922283"},
-		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "358551652118"},
+		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "1304906600525870"},
+		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "1304912860512857"},
+		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1819369083371"},
+		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1819713988051"},
+		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1819890952200330"},
+		{0, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "1819912010671452"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "599088140"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xd533a949740bb3306d119cc777fa900ba034cd52", "83966477"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "696670096424"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xd533a949740bb3306d119cc777fa900ba034cd52", "696617191992"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "61379"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "104742"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "191147306"},
+		{0, "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "191237005"},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "102047"},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "115007"},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "136987980"},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "137061149"},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", ErrExchange0Coins},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", ErrExchange0Coins},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "357723621952"},
+		{0, "0xd533a949740bb3306d119cc777fa900ba034cd52", "500000000123", "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e", "357762042492"},
 	}
 
 	sims := lo.Map(pools, func(poolRedis string, _ int) *PoolSimulator {
@@ -264,6 +264,46 @@ func TestUpdateBalance(t *testing.T) {
 			fmt.Println("D", p.Extra.D.Dec())
 		})
 	}
+}
+
+func TestUpdateBalanceUpdatesStateOnEverySwap(t *testing.T) {
+	t.Parallel()
+
+	poolRedis := `{"address":"0x4ebdf703948ddcea3b11f675b4d1fba9d2414a14","exchange":"curve-tricrypto-ng","type":"curve-tricrypto-ng","timestamp":1747387794,"reserves":["2861820037467305203466191","1093506849144527022340","3982280374395661297312344"],"tokens":[{"address":"0xf939e0a03fb07f59a73314e73794be0e57ac1b4e","name":"","symbol":"crvUSD","decimals":18,"weight":0,"swappable":true},{"address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","name":"","symbol":"WETH","decimals":18,"weight":0,"swappable":true},{"address":"0xd533a949740bb3306d119cc777fa900ba034cd52","name":"","symbol":"CRV","decimals":18,"weight":0,"swappable":true}],"extra":"{\"InitialA\":\"2700000\",\"InitialGamma\":\"1300000000000\",\"InitialAGammaTime\":0,\"FutureA\":\"2700000\",\"FutureGamma\":\"1300000000000\",\"FutureAGammaTime\":0,\"D\":\"8532048735922426944154787\",\"PriceScale\":[\"2593891046098680504189\",\"711612014969964544\"],\"PriceOracle\":[\"2597753463916981281317\",\"712667936366669756\"],\"LastPrices\":[\"2612188986152217640529\",\"717156747966546519\"],\"LastPricesTimestamp\":1747387787,\"FeeGamma\":\"350000000000000\",\"MidFee\":\"2999999\",\"OutFee\":\"80000000\",\"LpSupply\":\"200731208332421373598995\",\"XcpProfit\":\"1133157971398689394\",\"VirtualPrice\":\"1155009367459460589\",\"AllowedExtraProfit\":\"100000000000\",\"AdjustmentStep\":\"100000000000\"}","staticExtra":"{\"IsNativeCoins\":[false,false,false]}"}`
+
+	var poolEntity entity.Pool
+	err := json.Unmarshal([]byte(poolRedis), &poolEntity)
+	require.Nil(t, err)
+	p, err := NewPoolSimulator(poolEntity)
+	require.Nil(t, err)
+
+	weth := "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+	crvUsd := "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e"
+
+	swap := func(amountIn string) {
+		out, err := p.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: weth, Amount: bignumber.NewBig10(amountIn)},
+			TokenOut:      crvUsd,
+		})
+		require.NoError(t, err)
+		p.UpdateBalance(pool.UpdateBalanceParams{
+			TokenAmountIn:  pool.TokenAmount{Token: weth, Amount: bignumber.NewBig10(amountIn)},
+			TokenAmountOut: *out.TokenAmountOut,
+			Fee:            *out.Fee,
+			SwapInfo:       out.SwapInfo,
+		})
+	}
+
+	swap("500000000000")
+	dAfterFirstSwap := p.Extra.D.Clone()
+
+	swap("500000000000")
+	dAfterSecondSwap := p.Extra.D.Clone()
+
+	// D must be recalculated from the new balances on every swap, matching the
+	// on-chain contract, which updates self.D unconditionally in tweak_price.
+	assert.NotEqual(t, dAfterFirstSwap, dAfterSecondSwap,
+		"D is frozen after the first swap instead of being recalculated on every UpdateBalance")
 }
 
 func BenchmarkCalcAmountOut(b *testing.B) {

--- a/pkg/liquidity-source/curve/twocrypto-ng/curve_twocrypto_optimized.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/curve_twocrypto_optimized.go
@@ -234,12 +234,10 @@ func (t *PoolSimulator) tweak_price(A, gamma *uint256.Int, _xp [NumTokens]uint25
 	blockTimestamp := time.Now().Unix()
 	var err error
 
-	if t.tweakedPrice {
-		// this block update price_oracle and last_price_timestamp
-		// but in pool tracker we've fetched the calculated price_oracle, not the raw packed value,
-		// so we can use that here without updating. we only check that we tweak only once
-		return nil
-	}
+	// On-chain, this also updates cached_price_oracle and last_timestamp, but only once per
+	// block. The pool tracker already fetches the EMA-computed price_oracle directly, so there
+	// is nothing to recompute here; D, virtual_price, xcp_profit, last_prices and price_scale
+	// below, however, are updated unconditionally on every exchange on-chain and must be too.
 
 	// #                  price_oracle is used further on to calculate its vector
 	// #            distance from price_scale. This distance is used to calculate

--- a/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator.go
@@ -25,8 +25,6 @@ type PoolSimulator struct {
 	precisionMultipliers []uint256.Int
 	Reserves             []uint256.Int // same as pool.Reserves but use uint256.Int
 
-	tweakedPrice bool
-
 	Extra       Extra
 	StaticExtra StaticExtra
 
@@ -215,14 +213,11 @@ func (t *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 	t.Info.Reserves[outputIndex] = new(big.Int).Sub(t.Info.Reserves[outputIndex], outputAmount)
 	t.Reserves[outputIndex] = *new(uint256.Int).Sub(&t.Reserves[outputIndex], number.SetFromBig(outputAmount))
 
-	if !t.tweakedPrice {
-		t.tweakedPrice = true
-		t.Extra.LastPrices = swapInfo.LastPrices[:]
-		t.Extra.PriceScale = swapInfo.PriceScale[:]
-		t.Extra.XcpProfit = &swapInfo.XcpProfit
-		t.Extra.D = &swapInfo.D
-		t.Extra.VirtualPrice = &swapInfo.VirtualPrice
-	}
+	t.Extra.LastPrices = swapInfo.LastPrices[:]
+	t.Extra.PriceScale = swapInfo.PriceScale[:]
+	t.Extra.XcpProfit = &swapInfo.XcpProfit
+	t.Extra.D = &swapInfo.D
+	t.Extra.VirtualPrice = &swapInfo.VirtualPrice
 }
 
 func (t *PoolSimulator) GetMetaInfo(tokenIn string, tokenOut string) any {

--- a/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator_test.go
+++ b/pkg/liquidity-source/curve/twocrypto-ng/pool_simulator_test.go
@@ -252,6 +252,44 @@ func TestUpdateBalance(t *testing.T) {
 	}
 }
 
+func TestUpdateBalanceUpdatesStateOnEverySwap(t *testing.T) {
+	t.Parallel()
+
+	var poolEntity entity.Pool
+	err := json.Unmarshal([]byte(pools[0]), &poolEntity)
+	require.Nil(t, err)
+	p, err := NewPoolSimulator(poolEntity)
+	require.Nil(t, err)
+
+	weth := "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
+	ethPlus := "0x18c14c2d707b2212e17d1579789fc06010cfca23"
+
+	swap := func(amountIn string) {
+		out, err := p.CalcAmountOut(poolpkg.CalcAmountOutParams{
+			TokenAmountIn: poolpkg.TokenAmount{Token: weth, Amount: bignumber.NewBig10(amountIn)},
+			TokenOut:      ethPlus,
+		})
+		require.NoError(t, err)
+		p.UpdateBalance(poolpkg.UpdateBalanceParams{
+			TokenAmountIn:  poolpkg.TokenAmount{Token: weth, Amount: bignumber.NewBig10(amountIn)},
+			TokenAmountOut: *out.TokenAmountOut,
+			Fee:            *out.Fee,
+			SwapInfo:       out.SwapInfo,
+		})
+	}
+
+	swap("500000000000000000")
+	dAfterFirstSwap := p.Extra.D.Clone()
+
+	swap("500000000000000000")
+	dAfterSecondSwap := p.Extra.D.Clone()
+
+	// D must be recalculated from the new balances on every swap, matching the
+	// on-chain contract, which updates self.D unconditionally in tweak_price.
+	assert.NotEqual(t, dAfterFirstSwap, dAfterSecondSwap,
+		"D is frozen after the first swap instead of being recalculated on every UpdateBalance")
+}
+
 func BenchmarkCalcAmountOut(b *testing.B) {
 	// https://arbiscan.io/address/0x1Fb84Fa6D252762e8367eA607A6586E09dceBe3D
 	benchPoolRedis := `{"address":"0x1fb84fa6d252762e8367ea607a6586e09dcebe3d","exchange":"curve-twocrypto-ng","type":"curve-twocrypto-ng","timestamp":1726463373,"reserves":["968569777414549410834","1045106588251996643768"],"tokens":[{"address":"0x18c14c2d707b2212e17d1579789fc06010cfca23","name":"","symbol":"ETH+","decimals":18,"weight":0,"swappable":true},{"address":"0x82af49447d8a07e3bd95bd0d56f35241523fbab1","name":"","symbol":"WETH","decimals":18,"weight":0,"swappable":true}],"extra":"{\"InitialA\":\"20000000\",\"InitialGamma\":\"20000000000000000\",\"InitialAGammaTime\":0,\"FutureA\":\"20000000\",\"FutureGamma\":\"20000000000000000\",\"FutureAGammaTime\":0,\"D\":\"1996236386986675947911\",\"PriceScale\":[\"983313638977093334\"],\"PriceOracle\":[\"983239528662393033\"],\"LastPrices\":[\"983244856693732906\"],\"LastPricesTimestamp\":1726463246,\"FeeGamma\":\"30000000000000000\",\"MidFee\":\"500000\",\"OutFee\":\"8000000\",\"LpSupply\":\"1006167834136870835627\",\"XcpProfit\":\"1000760564011364559\",\"VirtualPrice\":\"1000381175737496082\",\"AllowedExtraProfit\":\"1000000000000\",\"AdjustmentStep\":\"25000000000000\"}","staticExtra":"{\"IsNativeCoins\":[false,false]}"}`


### PR DESCRIPTION
UpdateBalance only applied swapInfo's D, PriceScale, VirtualPrice, XcpProfit,
and LastPrices on the first swap of a PoolSimulator's lifetime (guarded by a
tweakedPrice flag), leaving them stale for every subsequent swap on the same
instance even as reserves kept changing. The on-chain contract updates these
unconditionally on every exchange (only cached_price_oracle/last_timestamp are
gated to once per block, and this simulator already sources price_oracle
pre-computed from the tracker). Removed the flag so state updates every swap,
and refreshed TestUpdateBalance's chained-swap fixtures in tricrypto-ng, which
had baked in the stale-D behavior.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
