### PR TITLE
fix(lfj-poe): correct quote math and switch to on-chain pool discovery

### DIFF
--- a/pkg/liquidity-source/lfj/poe/abi.go
+++ b/pkg/liquidity-source/lfj/poe/abi.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	poolABI   abi.ABI
-	oracleABI abi.ABI
+	poolABI    abi.ABI
+	oracleABI  abi.ABI
+	factoryABI abi.ABI
 )
 
 func init() {
@@ -18,6 +19,7 @@ func init() {
 	}{
 		{&poolABI, poolABIJson},
 		{&oracleABI, oracleABIJson},
+		{&factoryABI, factoryABIJson},
 	}
 
 	for _, b := range builder {

--- a/pkg/liquidity-source/lfj/poe/abi/Factory.json
+++ b/pkg/liquidity-source/lfj/poe/abi/Factory.json
@@ -1,0 +1,34 @@
+[
+    {
+        "inputs": [],
+        "name": "getPoolsLength",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "index",
+                "type": "uint256"
+            }
+        ],
+        "name": "getPoolAt",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/pkg/liquidity-source/lfj/poe/abi/Pool.json
+++ b/pkg/liquidity-source/lfj/poe/abi/Pool.json
@@ -1,43 +1,17 @@
 [
     {
         "inputs": [],
-        "name": "getTokenX",
+        "name": "getTokens",
         "outputs": [
             {
                 "internalType": "address",
-                "name": "",
+                "name": "tokenX",
                 "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getTokenY",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getReserves",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "reserveX",
-                "type": "uint256"
             },
             {
-                "internalType": "uint256",
-                "name": "reserveY",
-                "type": "uint256"
+                "internalType": "address",
+                "name": "tokenY",
+                "type": "address"
             }
         ],
         "stateMutability": "view",
@@ -102,6 +76,11 @@
             {
                 "internalType": "uint256",
                 "name": "feeIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeOut",
                 "type": "uint256"
             }
         ],

--- a/pkg/liquidity-source/lfj/poe/config.go
+++ b/pkg/liquidity-source/lfj/poe/config.go
@@ -1,6 +1,7 @@
 package poe
 
 type Config struct {
-	DexId string   `json:"dexId"`
-	Pools []string `json:"pools"`
+	DexId          string `json:"dexId"`
+	FactoryAddress string `json:"factoryAddress"`
+	NewPoolLimit   int    `json:"newPoolLimit"`
 }

--- a/pkg/liquidity-source/lfj/poe/constant.go
+++ b/pkg/liquidity-source/lfj/poe/constant.go
@@ -11,13 +11,17 @@ const (
 	DexType = valueobject.ExchangePoe
 
 	defaultGas int64 = 200000
+
+	poolMethodGetTokens   = "getTokens"
+	poolMethodGetBalances = "getBalances"
+	poolMethodGetOracle   = "getOracle"
+
+	factoryMethodGetPoolsLength = "getPoolsLength"
+	factoryMethodGetPoolAt      = "getPoolAt"
 )
 
-var (
-	bps            = u256.UBasisPoint
-	pricePrecision = u256.TenPow(24)
-	feePrecision   = u256.TenPow(6)
-)
+// uBps is alpha's scale (10000 = 1.0x), used to validate the oracle's alpha.
+var uBps = u256.UBasisPoint
 
 var (
 	ErrInvalidToken          = errors.New("invalid token")

--- a/pkg/liquidity-source/lfj/poe/embed.go
+++ b/pkg/liquidity-source/lfj/poe/embed.go
@@ -7,3 +7,6 @@ var poolABIJson []byte
 
 //go:embed abi/Oracle.json
 var oracleABIJson []byte
+
+//go:embed abi/Factory.json
+var factoryABIJson []byte

--- a/pkg/liquidity-source/lfj/poe/math.go
+++ b/pkg/liquidity-source/lfj/poe/math.go
@@ -1,95 +1,232 @@
 package poe
 
 import (
-	"github.com/holiman/uint256"
+	"math/big"
 
-	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
-func computeVirtualReserves(reserveX, reserveY, price, alpha *uint256.Int) *virtualReserves {
-	if reserveX.IsZero() && reserveY.IsZero() {
-		return &virtualReserves{xv: new(uint256.Int), yv: new(uint256.Int)}
-	}
+// Scales matching the on-chain contracts (see native.md): price is tokenY per
+// tokenX scaled 1e24, alpha (concentration) is BPS (10000 = 1.0x), fee is HBPS
+// (1e6 = 100%).
+var (
+	precision = bignumber.TenPowInt(24)
+	bps       = big.NewInt(10_000)
+	hbps      = big.NewInt(1_000_000)
+)
 
-	sqrtPa := u256.MulDiv(price, bps, alpha)
-	sqrtPa.Mul(sqrtPa, pricePrecision).Sqrt(sqrtPa)
-
-	sqrtPb := u256.MulDiv(price, alpha, bps)
-	sqrtPb.Mul(sqrtPb, pricePrecision).Sqrt(sqrtPb)
-
-	if sqrtPa.IsZero() || sqrtPb.IsZero() || sqrtPa.Cmp(sqrtPb) >= 0 {
-		return &virtualReserves{xv: new(uint256.Int).Set(reserveX), yv: new(uint256.Int).Set(reserveY)}
-	}
-
-	SP := pricePrecision
-
-	a := new(uint256.Int).Sub(sqrtPb, sqrtPa)
-	if a.IsZero() {
-		return &virtualReserves{xv: new(uint256.Int).Set(reserveX), yv: new(uint256.Int).Set(reserveY)}
-	}
-
-	tmp := new(uint256.Int)
-
-	b := u256.MulDiv(reserveX, tmp.Mul(sqrtPa, sqrtPb), SP)
-	b.Add(b, tmp.Mul(reserveY, SP))
-
-	disc := new(uint256.Int).Mul(reserveX, reserveY)
-	disc.Mul(disc, sqrtPb).Mul(disc, a).Lsh(disc, 2)
-	disc.Add(disc, tmp.Mul(b, b))
-	disc.Sqrt(disc)
-
-	L := b.Add(b, disc)
-	L.Div(L, tmp.Lsh(a, 1))
-
-	xv := new(uint256.Int).Add(reserveX, u256.MulDivDown(disc, L, SP, sqrtPb))
-	yv := new(uint256.Int).Add(reserveY, u256.MulDivDown(tmp, L, sqrtPa, SP))
-
-	return &virtualReserves{xv: xv, yv: yv}
+// quote is the result of getQuote: the net output, the actual (possibly
+// partial) input consumed, and the fee — always denominated in tokenY,
+// charged off the input on Y->X and off the output on X->Y.
+type quote struct {
+	amountOut *big.Int
+	actualIn  *big.Int
+	feeIn     *big.Int
+	feeOut    *big.Int
 }
 
-func calcAmountOutCPMM(xv, yv, netAmountIn *uint256.Int) *uint256.Int {
-	if xv.IsZero() || netAmountIn.IsZero() {
-		return new(uint256.Int)
-	}
-
-	denom := new(uint256.Int).Add(xv, netAmountIn)
-	if denom.IsZero() {
-		return new(uint256.Int)
-	}
-
-	return u256.MulDivDown(denom, yv, netAmountIn, denom)
+// ceilDiv returns ceil(a/b) into res (a, b > 0). Safe when res aliases a.
+func ceilDiv(res, a, b *big.Int) *big.Int {
+	res.Add(a, b)
+	res.Sub(res, big.NewInt(1))
+	return res.Div(res, b)
 }
 
-func calcAmountInCPMM(xv, yv, amountOut *uint256.Int) *uint256.Int {
-	if yv.Cmp(amountOut) <= 0 {
-		return nil
-	}
-
-	denom := new(uint256.Int).Sub(yv, amountOut)
-	if denom.IsZero() {
-		return nil
-	}
-
-	return u256.MulDivUp(denom, xv, amountOut, denom)
+// feeInclusive returns ceil(amount*fee/HBPS) — fee taken out of a gross amount.
+func feeInclusive(amount, fee *big.Int) *big.Int {
+	num := new(big.Int).Mul(amount, fee)
+	return ceilDiv(num, num, hbps)
 }
 
-func applyFeeCeil(amount, feePPM *uint256.Int) *uint256.Int {
-	if feePPM.IsZero() {
-		return new(uint256.Int)
-	}
-
-	return u256.MulDivUp(new(uint256.Int), amount, feePPM, feePrecision)
+// feeExclusive returns ceil(amount*fee/(HBPS-fee)) — fee added on top of a net amount.
+func feeExclusive(amount, fee *big.Int) *big.Int {
+	denom := new(big.Int).Sub(hbps, fee)
+	num := new(big.Int).Mul(amount, fee)
+	return ceilDiv(num, num, denom)
 }
 
-func deductFeeCeil(amount, feePPM *uint256.Int) *uint256.Int {
-	if feePPM.IsZero() {
-		return new(uint256.Int)
+// liquidity mirrors the on-chain `_liquidity`: the concentrated-curve
+// liquidity L and floor/ceil of sqrt(alpha*price). px_y^2 and delta can
+// exceed 2^256 for extreme reserve/price combinations, hence big.Int.
+func liquidity(x, y, p, alpha *big.Int) (l, sqrtAP, ceilSqrtAP *big.Int) {
+	alphaMinusBps := new(big.Int).Sub(alpha, bps)
+
+	pxTerm := new(big.Int).Mul(p, x)
+	pxY := new(big.Int).Mul(y, precision)
+	pxY.Add(pxY, pxTerm)
+
+	inner := new(big.Int).Mul(y, precision)
+	inner.Mul(inner, alphaMinusBps)
+	inner.Lsh(inner, 2)
+	inner.Div(inner, bps)
+	inner.Mul(inner, pxTerm)
+
+	delta := new(big.Int).Mul(pxY, pxY)
+	delta.Add(delta, inner)
+
+	scaled := new(big.Int).Mul(alpha, p)
+	scaled.Mul(scaled, precision)
+	scaled.Div(scaled, bps)
+
+	sqrtAP = new(big.Int).Sqrt(scaled)
+	ceilSqrtAP = new(big.Int).Set(sqrtAP)
+	check := new(big.Int).Mul(sqrtAP, sqrtAP)
+	if check.Cmp(scaled) < 0 {
+		ceilSqrtAP.Add(ceilSqrtAP, big.NewInt(1))
 	}
 
-	remaining := new(uint256.Int).Sub(feePrecision, feePPM)
-	if remaining.IsZero() {
-		return nil
+	sqrtDelta := new(big.Int).Sqrt(delta)
+	l = pxY.Add(pxY, sqrtDelta)
+	l.Mul(l, alpha)
+	denom := new(big.Int).Mul(ceilSqrtAP, alphaMinusBps)
+	denom.Lsh(denom, 1)
+	l.Div(l, denom)
+
+	return l, sqrtAP, ceilSqrtAP
+}
+
+// virtualReserves mirrors the on-chain `_virtual_reserves`: returns the
+// virtual reserve of the input token, the virtual reserve of the output
+// token, and the real reserve of the output token (rounding is
+// direction-dependent to match the on-chain contract bit-for-bit).
+func virtualReserves(x, y, p, alpha *big.Int, xToY bool) (vin, vout, rout *big.Int) {
+	l, sqrtAP, ceilSqrtAP := liquidity(x, y, p, alpha)
+
+	if xToY {
+		num := new(big.Int).Mul(l, precision)
+		vin = ceilDiv(num, num, sqrtAP)
+		vin.Add(vin, x)
+
+		vout = new(big.Int).Mul(l, sqrtAP)
+		vout.Mul(vout, bps)
+		denom := new(big.Int).Mul(alpha, precision)
+		vout.Div(vout, denom)
+		vout.Add(vout, y)
+
+		return vin, vout, new(big.Int).Set(y)
 	}
 
-	return u256.MulDivUp(remaining, amount, feePPM, remaining)
+	num := new(big.Int).Mul(l, ceilSqrtAP)
+	num.Mul(num, bps)
+	denom := new(big.Int).Mul(alpha, precision)
+	vin = ceilDiv(num, num, denom)
+	vin.Add(vin, y)
+
+	vout = new(big.Int).Mul(l, precision)
+	vout.Div(vout, ceilSqrtAP)
+	vout.Add(vout, x)
+
+	return vin, vout, new(big.Int).Set(x)
+}
+
+func bigMin(a, b *big.Int) *big.Int {
+	if a.Cmp(b) <= 0 {
+		return new(big.Int).Set(a)
+	}
+	return new(big.Int).Set(b)
+}
+
+// stablePhase mirrors the on-chain `_stable`: trades the pool toward 50/50
+// value at the flat oracle price before handing the remainder to the
+// concentrated curve.
+func stablePhase(reserveX, reserveY, amount, price, alpha *big.Int, xToY bool) (
+	vin, vout, rout, stableIn, stableOut *big.Int,
+) {
+	rx, ry := new(big.Int).Set(reserveX), new(big.Int).Set(reserveY)
+	stableIn, stableOut = new(big.Int), new(big.Int)
+
+	pRx := new(big.Int).Mul(price, rx)
+	ryPrecision := new(big.Int).Mul(ry, precision)
+
+	if xToY && pRx.Cmp(ryPrecision) < 0 {
+		target := new(big.Int).Sub(ryPrecision, pRx)
+		target.Div(target, new(big.Int).Lsh(price, 1))
+		stableIn = bigMin(amount, target)
+		stableOut = new(big.Int).Mul(stableIn, price)
+		stableOut.Div(stableOut, precision)
+		rx.Add(rx, stableIn)
+		ry.Sub(ry, stableOut)
+	} else if !xToY && pRx.Cmp(ryPrecision) > 0 {
+		target := new(big.Int).Sub(pRx, ryPrecision)
+		target.Div(target, new(big.Int).Lsh(precision, 1))
+		stableIn = bigMin(amount, target)
+		stableOut = new(big.Int).Mul(stableIn, precision)
+		stableOut.Div(stableOut, price)
+		rx.Sub(rx, stableOut)
+		ry.Add(ry, stableIn)
+	}
+
+	vin, vout, rout = virtualReserves(rx, ry, price, alpha, xToY)
+	return vin, vout, rout, stableIn, stableOut
+}
+
+// getQuote mirrors the on-chain `getQuote` (verified bit-exact against it per
+// native.md): stable-phase + concentrated-curve pricing, with the input
+// capped (partial fill) when the curve would pay out more than the pool
+// holds, and fees always denominated in tokenY.
+func getQuote(reserveX, reserveY, amountIn *big.Int, xToY bool, price, fee, alpha *big.Int) (*quote, error) {
+	if amountIn.Sign() <= 0 {
+		return nil, ErrInvalidAmountIn
+	}
+
+	actualIn := new(big.Int).Set(amountIn)
+	feeIn, feeOut := new(big.Int), new(big.Int)
+
+	netAmountIn := new(big.Int).Set(amountIn)
+	if !xToY {
+		feeIn = feeInclusive(amountIn, fee)
+		netAmountIn.Sub(amountIn, feeIn)
+		if netAmountIn.Sign() <= 0 {
+			return nil, ErrInvalidAmountIn
+		}
+	}
+
+	vin, vout, rout, stableIn, stableOut := stablePhase(reserveX, reserveY, netAmountIn, price, alpha, xToY)
+
+	remaining := new(big.Int).Sub(netAmountIn, stableIn)
+
+	denom := new(big.Int).Add(vin, remaining)
+	if denom.Sign() == 0 {
+		return nil, ErrInvalidAmountOut
+	}
+	curveOut := new(big.Int).Mul(remaining, vout)
+	curveOut.Div(curveOut, denom)
+
+	var amountOut *big.Int
+	if curveOut.Cmp(rout) > 0 {
+		if rout.Sign() == 0 {
+			return nil, ErrInsufficientLiquidity
+		}
+
+		voutMinusRout := new(big.Int).Sub(vout, rout)
+		if voutMinusRout.Sign() <= 0 {
+			return nil, ErrInsufficientLiquidity
+		}
+
+		amountOut = new(big.Int).Add(stableOut, rout)
+
+		num := new(big.Int).Mul(vin, rout)
+		extraIn := ceilDiv(num, num, voutMinusRout)
+		actualIn = new(big.Int).Add(stableIn, extraIn)
+
+		if xToY {
+			feeOut = feeInclusive(amountOut, fee)
+			amountOut.Sub(amountOut, feeOut)
+		} else {
+			feeIn = feeExclusive(actualIn, fee)
+			actualIn.Add(actualIn, feeIn)
+		}
+	} else {
+		amountOut = new(big.Int).Add(stableOut, curveOut)
+		if xToY {
+			feeOut = feeInclusive(amountOut, fee)
+			amountOut.Sub(amountOut, feeOut)
+		}
+	}
+
+	if amountOut.Sign() <= 0 {
+		return nil, ErrInvalidAmountOut
+	}
+
+	return &quote{amountOut: amountOut, actualIn: actualIn, feeIn: feeIn, feeOut: feeOut}, nil
 }

--- a/pkg/liquidity-source/lfj/poe/math_test.go
+++ b/pkg/liquidity-source/lfj/poe/math_test.go
@@ -1,90 +1,107 @@
 package poe
 
 import (
+	"math/big"
 	"testing"
 
-	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
-
-	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
-func TestApplyFeeCeil(t *testing.T) {
-	amount := uint256.NewInt(1_000_000)
+// Reference values below were generated from the Python `get_quote` in
+// native.md (verified bit-exact against on-chain getQuote), so these Go
+// tests must match them exactly, to the last wei.
 
-	require.Equal(t, uint256.NewInt(3000), applyFeeCeil(amount, uint256.NewInt(3000)))
-	require.Equal(t, uint256.NewInt(3001), applyFeeCeil(uint256.NewInt(1_000_001), uint256.NewInt(3000)))
-	require.Equal(t, u256.New0(), applyFeeCeil(amount, u256.New0()))
+func mustBig(s string) *big.Int {
+	v, _ := new(big.Int).SetString(s, 10)
+	return v
 }
 
-func TestComputeVirtualReserves(t *testing.T) {
-	price := uint256.MustFromDecimal("1000000000000000000000000")
-	reserveX := uint256.NewInt(1_000_000_000)
-	reserveY := uint256.NewInt(1_000_000_000)
+func TestGetQuote_XtoY_NotCapped(t *testing.T) {
+	reserveX := mustBig("10000000000000000000")    // 1e19
+	reserveY := big.NewInt(20_000_000_000)         // 2e10
+	price := big.NewInt(2_000_000_000_000_000_000) // 2e18
+	fee := big.NewInt(3000)
+	alpha := big.NewInt(10500)
 
-	vr := computeVirtualReserves(reserveX, reserveY, price, uint256.NewInt(10100))
-
-	require.True(t, vr.xv.Gt(reserveX))
-	require.True(t, vr.yv.Gt(reserveY))
-
-	diff := new(uint256.Int)
-	if vr.xv.Gt(vr.yv) {
-		diff.Sub(vr.xv, vr.yv)
-	} else {
-		diff.Sub(vr.yv, vr.xv)
-	}
-	require.True(t, diff.Lt(new(uint256.Int).Div(vr.xv, uint256.NewInt(100))))
+	q, err := getQuote(reserveX, reserveY, big.NewInt(10_000_000_000), true, price, fee, alpha)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(18991), q.amountOut)
+	require.Equal(t, big.NewInt(10_000_000_000), q.actualIn)
+	require.Equal(t, big.NewInt(0), q.feeIn)
+	require.Equal(t, big.NewInt(58), q.feeOut)
 }
 
-func TestComputeVirtualReserves_ZeroReserves(t *testing.T) {
-	price, _ := uint256.FromDecimal("1000000000000000000000000")
+func TestGetQuote_XtoY_Capped(t *testing.T) {
+	reserveX := mustBig("10000000000000000000")    // 1e19
+	reserveY := big.NewInt(20_000_000_000)         // 2e10
+	price := big.NewInt(2_000_000_000_000_000_000) // 2e18
+	fee := big.NewInt(3000)
+	alpha := big.NewInt(10500)
 
-	vr := computeVirtualReserves(u256.New0(), u256.New0(), price, uint256.NewInt(10100))
+	q, err := getQuote(reserveX, reserveY, big.NewInt(100_000_000_000_000_000), true, price, fee, alpha)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(19_940_000_000), q.amountOut)
+	actualIn, _ := new(big.Int).SetString("10499475576837990", 10)
+	require.Equal(t, actualIn, q.actualIn)
+	require.Equal(t, big.NewInt(0), q.feeIn)
+	require.Equal(t, big.NewInt(60_000_000), q.feeOut)
 
-	require.True(t, vr.xv.IsZero())
-	require.True(t, vr.yv.IsZero())
+	// partial fill: actualIn must be strictly less than the requested amount.
+	require.True(t, q.actualIn.Cmp(big.NewInt(100_000_000_000_000_000)) < 0)
 }
 
-func TestCalcAmountOutCPMM(t *testing.T) {
-	xv := uint256.NewInt(100_000_000_000)
-	yv := uint256.NewInt(100_000_000_000)
-	netIn := uint256.NewInt(1_000_000)
+func TestGetQuote_YtoX_NotCapped(t *testing.T) {
+	reserveX := mustBig("10000000000000000000")    // 1e19
+	reserveY := big.NewInt(20_000_000_000)         // 2e10
+	price := big.NewInt(2_000_000_000_000_000_000) // 2e18
+	fee := big.NewInt(3000)
+	alpha := big.NewInt(10500)
 
-	amountOut := calcAmountOutCPMM(xv, yv, netIn)
-
-	require.True(t, amountOut.Gt(uint256.NewInt(999_000)))
-	require.True(t, amountOut.Lt(netIn))
+	q, err := getQuote(reserveX, reserveY, big.NewInt(5_000_000_000), false, price, fee, alpha)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(2_492_500_000_000_000), q.amountOut)
+	require.Equal(t, big.NewInt(5_000_000_000), q.actualIn)
+	require.Equal(t, big.NewInt(15_000_000), q.feeIn)
+	require.Equal(t, big.NewInt(0), q.feeOut)
 }
 
-func TestCalcAmountInCPMM(t *testing.T) {
-	xv := uint256.NewInt(100_000_000_000)
-	yv := uint256.NewInt(100_000_000_000)
-	desiredOut := uint256.NewInt(999_990)
+func TestGetQuote_YtoX_Capped(t *testing.T) {
+	reserveX := mustBig("10000000000000000000")    // 1e19
+	reserveY := big.NewInt(20_000_000_000)         // 2e10
+	price := big.NewInt(2_000_000_000_000_000_000) // 2e18
+	fee := big.NewInt(3000)
+	alpha := big.NewInt(10500)
 
-	netIn := calcAmountInCPMM(xv, yv, desiredOut)
-	require.NotNil(t, netIn)
+	q, err := getQuote(reserveX, reserveY, big.NewInt(100_000_000_000_000), false, price, fee, alpha)
+	require.NoError(t, err)
+	require.Equal(t, reserveX, q.amountOut) // fully drains the real reserve of X
+	require.Equal(t, big.NewInt(20_308_122_082_975), q.actualIn)
+	require.Equal(t, big.NewInt(60_924_366_249), q.feeIn)
+	require.Equal(t, big.NewInt(0), q.feeOut)
 
-	require.True(t, calcAmountOutCPMM(xv, yv, netIn).Cmp(desiredOut) >= 0)
+	// partial fill: actualIn must be strictly less than the requested amount.
+	require.True(t, q.actualIn.Cmp(big.NewInt(100_000_000_000_000)) < 0)
 }
 
-func TestCalcAmountInCPMM_ExceedsReserve(t *testing.T) {
-	require.Nil(t, calcAmountInCPMM(uint256.NewInt(100_000_000), uint256.NewInt(100_000_000), uint256.NewInt(100_000_001)))
+func TestGetQuote_ZeroAmountIn(t *testing.T) {
+	_, err := getQuote(big.NewInt(1), big.NewInt(1), big.NewInt(0), true, big.NewInt(1), big.NewInt(0), big.NewInt(20000))
+	require.ErrorIs(t, err, ErrInvalidAmountIn)
 }
 
-func TestSwapXtoY(t *testing.T) {
-	price, _ := uint256.FromDecimal("2000000000000000")
-	reserveX := uint256.MustFromDecimal("10000000000000000000")
-	reserveY := uint256.MustFromDecimal("20000000000")
+func TestFeeInclusive(t *testing.T) {
+	require.Equal(t, big.NewInt(3000), feeInclusive(big.NewInt(1_000_000), big.NewInt(3000)))
+	require.Equal(t, big.NewInt(3001), feeInclusive(big.NewInt(1_000_001), big.NewInt(3000)))
+}
 
-	vr := computeVirtualReserves(reserveX, reserveY, price, uint256.NewInt(10500))
-	require.True(t, vr.xv.Gt(reserveX))
-	require.True(t, vr.yv.Gt(reserveY))
+func TestFeeExclusive_RoundTrip(t *testing.T) {
+	// feeExclusive(net, fee) should be the fee that, added on top of net,
+	// makes feeInclusive(gross, fee) recover (approximately) that same fee.
+	net := big.NewInt(1_000_000)
+	fee := big.NewInt(3000)
 
-	amountIn := uint256.MustFromDecimal("100000000000000000")
-	netIn := new(uint256.Int).Sub(amountIn, applyFeeCeil(amountIn, uint256.NewInt(3000)))
-	amountOut := calcAmountOutCPMM(vr.xv, vr.yv, netIn)
+	feeOnTop := feeExclusive(net, fee)
+	gross := new(big.Int).Add(net, feeOnTop)
 
-	t.Logf("Swap 0.1 ETH -> USDC: amountOut = %s (expected ~200e6)", amountOut.String())
-	require.True(t, amountOut.Gt(uint256.NewInt(190_000_000)))
-	require.True(t, amountOut.Lt(uint256.NewInt(210_000_000)))
+	recovered := feeInclusive(gross, fee)
+	require.Equal(t, feeOnTop, recovered)
 }

--- a/pkg/liquidity-source/lfj/poe/pool_list_updater.go
+++ b/pkg/liquidity-source/lfj/poe/pool_list_updater.go
@@ -2,23 +2,29 @@ package poe
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
 )
 
-type PoolsListUpdater struct {
-	config       *Config
-	ethrpcClient *ethrpc.Client
+type (
+	PoolsListUpdater struct {
+		config       *Config
+		ethrpcClient *ethrpc.Client
+	}
 
-	initialized bool
-}
+	PoolsListUpdaterMetadata struct {
+		Offset int `json:"offset"`
+	}
+)
 
 var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
 
@@ -33,15 +39,28 @@ func NewPoolsListUpdater(
 }
 
 func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
-	if u.initialized {
+	logger.Infof("started getting new pools")
+
+	poolsLength, err := u.getPoolsLength(ctx)
+	if err != nil {
+		logger.Errorf("getPoolsLength failed: %v", err)
+		return nil, metadataBytes, err
+	}
+
+	offset, err := u.getOffset(metadataBytes)
+	if err != nil {
+		logger.Warnf("getOffset failed: %v", err)
+	}
+
+	batchSize := u.getBatchSize(poolsLength, u.config.NewPoolLimit, offset)
+	if batchSize == 0 {
 		return nil, metadataBytes, nil
 	}
 
-	logger.Infof("started getting new pools")
-
-	addresses := make([]common.Address, len(u.config.Pools))
-	for i, p := range u.config.Pools {
-		addresses[i] = common.HexToAddress(p)
+	addresses, err := u.listPoolAddresses(ctx, offset, batchSize)
+	if err != nil {
+		logger.Errorf("listPoolAddresses failed: %v", err)
+		return nil, metadataBytes, err
 	}
 
 	pools, err := u.initPools(ctx, addresses)
@@ -50,31 +69,97 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		return nil, metadataBytes, err
 	}
 
-	u.initialized = true
+	newMetadataBytes, err := json.Marshal(PoolsListUpdaterMetadata{Offset: offset + batchSize})
+	if err != nil {
+		return nil, metadataBytes, err
+	}
 
 	logger.Infof("finished getting %d new pools", len(pools))
 
-	return pools, metadataBytes, nil
+	return pools, newMetadataBytes, nil
 }
 
+// getPoolsLength gets the number of pools registered in the factory.
+func (u *PoolsListUpdater) getPoolsLength(ctx context.Context) (int, error) {
+	var poolsLength *big.Int
+
+	req := u.ethrpcClient.R().SetContext(ctx).
+		AddCall(&ethrpc.Call{
+			ABI:    factoryABI,
+			Target: u.config.FactoryAddress,
+			Method: factoryMethodGetPoolsLength,
+		}, []any{&poolsLength})
+
+	if _, err := req.Call(); err != nil {
+		return 0, err
+	}
+
+	return int(poolsLength.Int64()), nil
+}
+
+// getOffset gets the index of the last pool that was fetched.
+func (u *PoolsListUpdater) getOffset(metadataBytes []byte) (int, error) {
+	if len(metadataBytes) == 0 {
+		return 0, nil
+	}
+
+	var metadata PoolsListUpdaterMetadata
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		return 0, err
+	}
+
+	return metadata.Offset, nil
+}
+
+// getBatchSize caps the number of pools fetched in one run to config.NewPoolLimit.
+func (u *PoolsListUpdater) getBatchSize(length, limit, offset int) int {
+	if offset >= length {
+		return 0
+	}
+
+	if limit <= 0 || offset+limit > length {
+		return length - offset
+	}
+
+	return limit
+}
+
+// listPoolAddresses lists pool addresses from the factory starting at offset.
+func (u *PoolsListUpdater) listPoolAddresses(ctx context.Context, offset, batchSize int) ([]common.Address, error) {
+	addresses := make([]common.Address, batchSize)
+
+	req := u.ethrpcClient.R().SetContext(ctx)
+	for i := range batchSize {
+		req.AddCall(&ethrpc.Call{
+			ABI:    factoryABI,
+			Target: u.config.FactoryAddress,
+			Method: factoryMethodGetPoolAt,
+			Params: []any{big.NewInt(int64(offset + i))},
+		}, []any{&addresses[i]})
+	}
+
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+
+	return addresses, nil
+}
+
+// initPools fetches each pool's token order via getTokens() (order is fixed
+// at creation and must be read, never assumed) and builds entity.Pool.
 func (u *PoolsListUpdater) initPools(ctx context.Context, addresses []common.Address) ([]entity.Pool, error) {
 	infos := make([]struct {
-		tokenX common.Address
-		tokenY common.Address
+		TokenX common.Address
+		TokenY common.Address
 	}, len(addresses))
 
 	req := u.ethrpcClient.R().SetContext(ctx)
 	for i, addr := range addresses {
-		target := addr.Hex()
 		req.AddCall(&ethrpc.Call{
 			ABI:    poolABI,
-			Target: target,
-			Method: "getTokenX",
-		}, []any{&infos[i].tokenX}).AddCall(&ethrpc.Call{
-			ABI:    poolABI,
-			Target: target,
-			Method: "getTokenY",
-		}, []any{&infos[i].tokenY})
+			Target: addr.Hex(),
+			Method: poolMethodGetTokens,
+		}, []any{&infos[i]})
 	}
 	if _, err := req.Aggregate(); err != nil {
 		return nil, err
@@ -91,8 +176,8 @@ func (u *PoolsListUpdater) initPools(ctx context.Context, addresses []common.Add
 			Timestamp: time.Now().Unix(),
 			Reserves:  entity.PoolReserves{"0", "0"},
 			Tokens: []*entity.PoolToken{
-				{Address: hexutil.Encode(info.tokenX[:]), Swappable: true},
-				{Address: hexutil.Encode(info.tokenY[:]), Swappable: true},
+				{Address: hexutil.Encode(info.TokenX[:]), Swappable: true},
+				{Address: hexutil.Encode(info.TokenY[:]), Swappable: true},
 			},
 			Extra: "{}",
 		})

--- a/pkg/liquidity-source/lfj/poe/pool_simulator.go
+++ b/pkg/liquidity-source/lfj/poe/pool_simulator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
@@ -61,43 +62,40 @@ func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		return nil, ErrInvalidToken
 	}
 
-	amountIn := uint256.MustFromBig(tokenAmountIn.Amount)
-	if amountIn.Sign() <= 0 {
-		return nil, ErrInvalidAmountIn
-	}
-
 	if err := s.validate(); err != nil {
 		return nil, err
 	}
 
 	isXtoY := indexIn == 0
 
-	vr := computeVirtualReserves(s.reserveX, s.reserveY, s.price, s.alpha)
-	if vr.xv.IsZero() || vr.yv.IsZero() {
-		return nil, ErrZeroVirtualReserve
+	q, err := getQuote(u256.ToBig(s.reserveX), u256.ToBig(s.reserveY), tokenAmountIn.Amount, isXtoY,
+		u256.ToBig(s.price), u256.ToBig(s.feeHbps), u256.ToBig(s.alpha))
+	if err != nil {
+		return nil, err
 	}
 
-	feeIn := applyFeeCeil(amountIn, s.feeHbps)
-	netAmountIn := new(uint256.Int).Sub(amountIn, feeIn)
+	remaining := new(big.Int).Sub(tokenAmountIn.Amount, q.actualIn)
 
-	xvIn, xvOut := lo.Ternary(isXtoY, vr.xv, vr.yv), lo.Ternary(isXtoY, vr.yv, vr.xv)
-	realReserveOut := lo.Ternary(isXtoY, s.reserveY, s.reserveX)
-	amountOut := calcAmountOutCPMM(xvIn, xvOut, netAmountIn)
-	if amountOut.IsZero() {
-		return nil, ErrInvalidAmountOut
-	}
-
-	if amountOut.Gt(realReserveOut) {
-		return nil, ErrInsufficientLiquidity
+	fee := q.feeOut
+	if !isXtoY {
+		fee = q.feeIn
 	}
 
 	return &pool.CalcAmountOutResult{
-		TokenAmountOut: &pool.TokenAmount{Token: tokenOut, Amount: amountOut.ToBig()},
-		Fee:            &pool.TokenAmount{Token: tokenAmountIn.Token, Amount: feeIn.ToBig()},
-		Gas:            defaultGas,
+		TokenAmountOut: &pool.TokenAmount{Token: tokenOut, Amount: q.amountOut},
+		Fee:            &pool.TokenAmount{Token: s.Info.Tokens[1], Amount: fee},
+		RemainingTokenAmountIn: &pool.TokenAmount{
+			Token:  tokenAmountIn.Token,
+			Amount: remaining,
+		},
+		Gas: defaultGas,
 	}, nil
 }
 
+// CalcAmountIn estimates the input required for a desired output. The
+// on-chain pool has no exact-out entrypoint (getQuote/swap only take
+// amountIn), so this binary-searches getQuote — which is monotonic in
+// amountIn — for the smallest input whose quoted output meets the target.
 func (s *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
 	tokenAmountOut := param.TokenAmountOut
 	tokenIn := param.TokenIn
@@ -107,8 +105,7 @@ func (s *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcA
 		return nil, ErrInvalidToken
 	}
 
-	amountOut := uint256.MustFromBig(tokenAmountOut.Amount)
-	if amountOut.Sign() <= 0 {
+	if tokenAmountOut.Amount.Sign() <= 0 {
 		return nil, ErrInvalidAmountOut
 	}
 
@@ -117,33 +114,64 @@ func (s *PoolSimulator) CalcAmountIn(param pool.CalcAmountInParams) (*pool.CalcA
 	}
 
 	isXtoY := indexIn == 0
-
-	realReserveOut := lo.Ternary(isXtoY, s.reserveY, s.reserveX)
-	if amountOut.Cmp(realReserveOut) >= 0 {
+	realReserveOut := u256.ToBig(lo.Ternary(isXtoY, s.reserveY, s.reserveX))
+	if tokenAmountOut.Amount.Cmp(realReserveOut) >= 0 {
 		return nil, ErrInsufficientLiquidity
 	}
 
-	vr := computeVirtualReserves(s.reserveX, s.reserveY, s.price, s.alpha)
-	if vr.xv.IsZero() || vr.yv.IsZero() {
-		return nil, ErrZeroVirtualReserve
+	reserveX, reserveY := u256.ToBig(s.reserveX), u256.ToBig(s.reserveY)
+	price, fee, alpha := u256.ToBig(s.price), u256.ToBig(s.feeHbps), u256.ToBig(s.alpha)
+
+	quoteOut := func(amountIn *big.Int) *big.Int {
+		q, err := getQuote(reserveX, reserveY, amountIn, isXtoY, price, fee, alpha)
+		if err != nil {
+			return new(big.Int)
+		}
+		return q.amountOut
 	}
 
-	xvIn, xvOut := lo.Ternary(isXtoY, vr.xv, vr.yv), lo.Ternary(isXtoY, vr.yv, vr.xv)
-	netAmountIn := calcAmountInCPMM(xvIn, xvOut, amountOut)
-	if netAmountIn == nil {
+	loAmt, hiAmt := new(big.Int), big.NewInt(1)
+	for quoteOut(hiAmt).Cmp(tokenAmountOut.Amount) < 0 {
+		loAmt.Set(hiAmt)
+		hiAmt = new(big.Int).Lsh(hiAmt, 1)
+		if hiAmt.Cmp(realReserveOut) >= 0 {
+			hiAmt = new(big.Int).Set(realReserveOut)
+			break
+		}
+	}
+
+	if quoteOut(hiAmt).Cmp(tokenAmountOut.Amount) < 0 {
 		return nil, ErrInsufficientLiquidity
 	}
 
-	feeForNet := deductFeeCeil(netAmountIn, s.feeHbps)
-	if feeForNet == nil {
-		return nil, ErrInsufficientLiquidity
+	for i := 0; i < 256; i++ {
+		diff := new(big.Int).Sub(hiAmt, loAmt)
+		if diff.Cmp(big.NewInt(1)) <= 0 {
+			break
+		}
+		mid := new(big.Int).Add(loAmt, diff)
+		mid.Rsh(mid, 1)
+
+		if quoteOut(mid).Cmp(tokenAmountOut.Amount) >= 0 {
+			hiAmt = mid
+		} else {
+			loAmt = mid
+		}
 	}
-	amountIn := new(uint256.Int).Add(netAmountIn, feeForNet)
-	feeIn := applyFeeCeil(amountIn, s.feeHbps)
+
+	q, err := getQuote(reserveX, reserveY, hiAmt, isXtoY, price, fee, alpha)
+	if err != nil {
+		return nil, err
+	}
+
+	feeAmt := q.feeOut
+	if !isXtoY {
+		feeAmt = q.feeIn
+	}
 
 	return &pool.CalcAmountInResult{
-		TokenAmountIn: &pool.TokenAmount{Token: tokenIn, Amount: amountIn.ToBig()},
-		Fee:           &pool.TokenAmount{Token: tokenIn, Amount: feeIn.ToBig()},
+		TokenAmountIn: &pool.TokenAmount{Token: tokenIn, Amount: q.actualIn},
+		Fee:           &pool.TokenAmount{Token: s.Info.Tokens[1], Amount: feeAmt},
 		Gas:           defaultGas,
 	}, nil
 }
@@ -159,15 +187,13 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 
 	amountIn := uint256.MustFromBig(params.TokenAmountIn.Amount)
 	amountOut := uint256.MustFromBig(params.TokenAmountOut.Amount)
-	fee := uint256.MustFromBig(params.Fee.Amount)
-	netIn := new(uint256.Int).Sub(amountIn, fee)
 
 	isXtoY := indexIn == 0
 	if isXtoY {
-		s.reserveX.Add(s.reserveX, netIn)
+		s.reserveX.Add(s.reserveX, amountIn)
 		s.reserveY.Sub(s.reserveY, amountOut)
 	} else {
-		s.reserveY.Add(s.reserveY, netIn)
+		s.reserveY.Add(s.reserveY, amountIn)
 		s.reserveX.Sub(s.reserveX, amountOut)
 	}
 }
@@ -188,7 +214,7 @@ func (s *PoolSimulator) GetMetaInfo(tokenIn, _ string) any {
 }
 
 func (s *PoolSimulator) validate() error {
-	if s.alpha.Cmp(bps) <= 0 {
+	if s.alpha.Cmp(uBps) <= 0 {
 		return ErrInvalidAlpha
 	}
 

--- a/pkg/liquidity-source/lfj/poe/pool_simulator_test.go
+++ b/pkg/liquidity-source/lfj/poe/pool_simulator_test.go
@@ -1,0 +1,147 @@
+package poe
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+const (
+	poeTokenX = "0x0000000000000000000000000000000000000001"
+	poeTokenY = "0x0000000000000000000000000000000000000002"
+)
+
+func newTestPoolSimulator(t *testing.T) *PoolSimulator {
+	t.Helper()
+
+	extra := Extra{
+		Price:   uint256.NewInt(2_000_000_000_000_000_000),
+		FeeHbps: uint256.NewInt(3000),
+		Alpha:   uint256.NewInt(10500),
+		Expiry:  uint64(time.Now().Unix()) + 3600,
+	}
+	extraBytes, err := json.Marshal(extra)
+	require.NoError(t, err)
+
+	sim, err := NewPoolSimulator(entity.Pool{
+		Address:  "0xpool",
+		Exchange: string(DexType),
+		Type:     string(DexType),
+		Reserves: entity.PoolReserves{"10000000000000000000", "20000000000"},
+		Tokens: []*entity.PoolToken{
+			{Address: poeTokenX, Swappable: true},
+			{Address: poeTokenY, Swappable: true},
+		},
+		Extra: string(extraBytes),
+	})
+	require.NoError(t, err)
+	return sim
+}
+
+func TestPoolSimulator_CalcAmountOut_XtoY_NotCapped(t *testing.T) {
+	sim := newTestPoolSimulator(t)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: poeTokenX, Amount: mustBig("10000000000")},
+		TokenOut:      poeTokenY,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, mustBig("18991"), res.TokenAmountOut.Amount)
+	require.Equal(t, poeTokenY, res.Fee.Token) // fee always denominated in tokenY
+	require.Equal(t, mustBig("58"), res.Fee.Amount)
+	require.Zero(t, res.RemainingTokenAmountIn.Amount.Sign()) // fully consumed
+}
+
+func TestPoolSimulator_CalcAmountOut_XtoY_Capped_PartialFill(t *testing.T) {
+	sim := newTestPoolSimulator(t)
+
+	amountIn := mustBig("100000000000000000")
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: poeTokenX, Amount: amountIn},
+		TokenOut:      poeTokenY,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, mustBig("19940000000"), res.TokenAmountOut.Amount)
+	require.Equal(t, poeTokenY, res.Fee.Token)
+	require.Equal(t, mustBig("60000000"), res.Fee.Amount)
+
+	// partial fill: some of the requested amountIn must be returned as remaining.
+	require.True(t, res.RemainingTokenAmountIn.Amount.Sign() > 0)
+	consumed := new(big.Int).Sub(amountIn, res.RemainingTokenAmountIn.Amount)
+	require.Equal(t, mustBig("10499475576837990"), consumed)
+}
+
+func TestPoolSimulator_CalcAmountOut_YtoX_FeeInTokenY(t *testing.T) {
+	sim := newTestPoolSimulator(t)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: poeTokenY, Amount: mustBig("5000000000")},
+		TokenOut:      poeTokenX,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, mustBig("2492500000000000"), res.TokenAmountOut.Amount)
+	require.Equal(t, poeTokenY, res.Fee.Token) // fee always denominated in tokenY, even for Y->X
+	require.Equal(t, mustBig("15000000"), res.Fee.Amount)
+}
+
+func TestPoolSimulator_UpdateBalance_ConsumesActualIn(t *testing.T) {
+	sim := newTestPoolSimulator(t)
+
+	amountIn := mustBig("100000000000000000")
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: poeTokenX, Amount: amountIn},
+		TokenOut:      poeTokenY,
+	})
+	require.NoError(t, err)
+
+	consumed := new(big.Int).Sub(amountIn, res.RemainingTokenAmountIn.Amount)
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: poeTokenX, Amount: consumed},
+		TokenAmountOut: pool.TokenAmount{Token: poeTokenY, Amount: res.TokenAmountOut.Amount},
+		Fee:            *res.Fee,
+	})
+
+	require.Equal(t, new(big.Int).Add(mustBig("10000000000000000000"), consumed), sim.Info.Reserves[0])
+	require.Equal(t, new(big.Int).Sub(mustBig("20000000000"), res.TokenAmountOut.Amount), sim.Info.Reserves[1])
+}
+
+func TestPoolSimulator_CalcAmountIn_MatchesCalcAmountOut(t *testing.T) {
+	sim := newTestPoolSimulator(t)
+
+	desiredOut := mustBig("18991")
+	inRes, err := sim.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: poeTokenY, Amount: desiredOut},
+		TokenIn:        poeTokenX,
+	})
+	require.NoError(t, err)
+
+	outRes, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: poeTokenX, Amount: inRes.TokenAmountIn.Amount},
+		TokenOut:      poeTokenY,
+	})
+	require.NoError(t, err)
+
+	require.True(t, outRes.TokenAmountOut.Amount.Cmp(desiredOut) >= 0)
+}
+
+func TestPoolSimulator_ExpiredOracle(t *testing.T) {
+	sim := newTestPoolSimulator(t)
+	sim.expiry = uint64(time.Now().Unix()) - 1
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: poeTokenX, Amount: mustBig("1000000")},
+		TokenOut:      poeTokenY,
+	})
+	require.ErrorIs(t, err, ErrExpiredOracle)
+}

--- a/pkg/liquidity-source/lfj/poe/pool_tracker.go
+++ b/pkg/liquidity-source/lfj/poe/pool_tracker.go
@@ -45,8 +45,8 @@ func (t *PoolTracker) GetNewPoolState(
 	var (
 		oracle   common.Address
 		reserves struct {
-			ReserveX *big.Int
-			ReserveY *big.Int
+			AmountX *big.Int
+			AmountY *big.Int
 		}
 	)
 
@@ -54,12 +54,12 @@ func (t *PoolTracker) GetNewPoolState(
 		AddCall(&ethrpc.Call{
 			ABI:    poolABI,
 			Target: p.Address,
-			Method: "getOracle",
+			Method: poolMethodGetOracle,
 		}, []any{&oracle}).
 		AddCall(&ethrpc.Call{
 			ABI:    poolABI,
 			Target: p.Address,
-			Method: "getReserves",
+			Method: poolMethodGetBalances,
 		}, []any{&reserves})
 	_, err := req.Aggregate()
 	if err != nil {
@@ -99,8 +99,8 @@ func (t *PoolTracker) GetNewPoolState(
 
 	p.Extra = string(extraBytes)
 	p.Reserves = entity.PoolReserves{
-		reserves.ReserveX.String(),
-		reserves.ReserveY.String(),
+		reserves.AmountX.String(),
+		reserves.AmountY.String(),
 	}
 	p.BlockNumber = resp.BlockNumber.Uint64()
 	p.Timestamp = time.Now().Unix()

--- a/pkg/liquidity-source/lfj/poe/types.go
+++ b/pkg/liquidity-source/lfj/poe/types.go
@@ -16,8 +16,3 @@ type PoolMeta struct {
 	BlockNumber uint64 `json:"bN"`
 	IsXtoY      bool   `json:"isXtoY,omitempty"`
 }
-
-type virtualReserves struct {
-	xv *uint256.Int
-	yv *uint256.Int
-}


### PR DESCRIPTION
The Poe contracts were updated (per LFJ's native.md integration doc):
getTokenX/getTokenY and getReserves now revert on the Pool contract, and
the Factory added on-chain pool discovery (getPoolsLength/getPoolAt).

- Rewrite getQuote to match the on-chain algorithm bit-exact: stable-phase
  + concentrated-curve pricing, direction-dependent virtual reserve
  rounding, fees always in tokenY, and partial-fill capping when the curve
  would exceed real reserves.
- Switch CalcAmountIn to a monotonic binary search over getQuote (the
  protocol has no on-chain exact-out entrypoint).
- Replace getTokenX/getTokenY with getTokens(), and getReserves with
  getBalances(), matching the updated Pool ABI.
- Switch pool listing from a static config address list to on-chain
  Factory discovery (getPoolsLength/getPoolAt), following this repo's
  standard factory-listing pattern.

Verified the new getQuote against the reference Python implementation
(bit-exact), and the updated lister/tracker end-to-end against the live
Monad Factory and Pool contracts.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
