### PR TITLE
feat(bounce-tech): implement CalcAmountIn for exact-out swaps

### DIFF
--- a/pkg/liquidity-source/bounce-tech/constant.go
+++ b/pkg/liquidity-source/bounce-tech/constant.go
@@ -20,9 +20,12 @@ var (
 	ErrInsufficientBalance = errors.New("insufficient base asset balance")
 	ErrZeroExchangeRate    = errors.New("zero exchange rate")
 	ErrBelowMinAmount      = errors.New("below min transaction size")
+	ErrFeeRateTooHigh      = errors.New("redemption fee rate too high")
 
 	// 1e12 for scaling USDC (6 dec) → 18 dec
 	scaleUp = uint256.NewInt(1e12)
 	// 1e18 for ScaledNumber.mul / ScaledNumber.div precision
 	precision = uint256.NewInt(1e18)
+	// 1e30 = scaleUp * precision, the combined USDC(6dec)<->LT(18dec) conversion scale
+	mintScale = new(uint256.Int).Mul(scaleUp, precision)
 )

--- a/pkg/liquidity-source/bounce-tech/pool_simulator.go
+++ b/pkg/liquidity-source/bounce-tech/pool_simulator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
@@ -131,6 +132,105 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		Gas:            gas,
 		SwapInfo:       SwapInfo{IsMint: isMint},
 	}, nil
+}
+
+// CalcAmountIn computes the input required for a mint (USDC→LT) or redeem (LT→USDC) swap
+// to produce at least tokenAmountOut. It inverts the flooring done by CalcAmountOut, so the
+// returned amountIn is rounded up (ceiling) to guarantee the requested output is met.
+func (s *PoolSimulator) CalcAmountIn(params pool.CalcAmountInParams) (*pool.CalcAmountInResult, error) {
+	tokenAmountOut, tokenIn := params.TokenAmountOut, params.TokenIn
+
+	indexIn := s.GetTokenIndex(tokenIn)
+	indexOut := s.GetTokenIndex(tokenAmountOut.Token)
+	if indexIn < 0 || indexOut < 0 {
+		return nil, ErrInvalidToken
+	}
+	if tokenAmountOut.Amount == nil || tokenAmountOut.Amount.Sign() <= 0 {
+		return nil, ErrZeroAmount
+	}
+	if s.exchangeRate.IsZero() {
+		return nil, ErrZeroExchangeRate
+	}
+
+	amountOut, overflow := uint256.FromBig(tokenAmountOut.Amount)
+	if overflow {
+		return nil, ErrZeroAmount
+	}
+
+	isMint := indexIn == 0
+	if isMint && s.mintPaused {
+		return nil, ErrMintPaused
+	}
+
+	var amountIn *uint256.Int
+	var fee *uint256.Int
+	var gas int64
+
+	if isMint {
+		amountIn = s.calcMintIn(amountOut)
+		fee = new(uint256.Int)
+		gas = mintGas
+
+		if !s.minTxSize.IsZero() && amountIn.Lt(s.minTxSize) {
+			return nil, ErrBelowMinAmount
+		}
+	} else {
+		grossUsdc, err := s.calcRedeemGrossOut(amountOut)
+		if err != nil {
+			return nil, err
+		}
+		gas = redeemGas
+
+		if !s.minTxSize.IsZero() && grossUsdc.Lt(s.minTxSize) {
+			return nil, ErrBelowMinAmount
+		}
+
+		reserve := s.Info.Reserves[0] // USDC reserve = baseAssetBalance
+		if grossUsdc.ToBig().Cmp(reserve) > 0 {
+			return nil, ErrInsufficientBalance
+		}
+
+		fee = new(uint256.Int).Mul(grossUsdc, s.redemptionFee)
+		fee.Div(fee, precision) // / 1e18
+		fee.Mul(fee, s.targetLeverage)
+		fee.Div(fee, precision) // / 1e18
+		if fee.Gt(grossUsdc) {
+			fee.Set(grossUsdc)
+		}
+
+		amountIn = big256.MulDivUp(new(uint256.Int), grossUsdc, mintScale, s.exchangeRate)
+	}
+
+	if amountIn.IsZero() {
+		return nil, ErrZeroAmount
+	}
+
+	return &pool.CalcAmountInResult{
+		TokenAmountIn: &pool.TokenAmount{Token: tokenIn, Amount: amountIn.ToBig()},
+		Fee:           &pool.TokenAmount{Token: s.Info.Tokens[0], Amount: fee.ToBig()},
+		Gas:           gas,
+		SwapInfo:      SwapInfo{IsMint: isMint},
+	}, nil
+}
+
+// calcMintIn inverts calcMintOut: usdcIn = ceil(ltOut * exchangeRate / 1e30)
+func (s *PoolSimulator) calcMintIn(ltOut *uint256.Int) *uint256.Int {
+	return big256.MulDivUp(new(uint256.Int), ltOut, s.exchangeRate, mintScale)
+}
+
+// calcRedeemGrossOut inverts the net side of calcRedeemOut: given the desired net usdcOut,
+// find the gross USDC amount (pre-fee) that yields at least usdcOut after the redemption fee.
+//
+//	netMultiplier = 1e18 - redemptionFee*targetLeverage/1e18
+//	grossUsdc = ceil(usdcOut * 1e18 / netMultiplier)
+func (s *PoolSimulator) calcRedeemGrossOut(usdcOut *uint256.Int) (*uint256.Int, error) {
+	feeRate := big256.MulDivDown(new(uint256.Int), s.redemptionFee, s.targetLeverage, precision)
+	if feeRate.Cmp(precision) >= 0 {
+		return nil, ErrFeeRateTooHigh
+	}
+	netMultiplier := new(uint256.Int).Sub(precision, feeRate)
+
+	return big256.MulDivUp(new(uint256.Int), usdcOut, precision, netMultiplier), nil
 }
 
 // calcMintOut: ltOut = usdcIn.scaleFrom(6).div(exchangeRate)

--- a/pkg/liquidity-source/bounce-tech/pool_simulator_test.go
+++ b/pkg/liquidity-source/bounce-tech/pool_simulator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
 )
 
 const (
@@ -40,34 +41,105 @@ func TestCalcAmountOutRedeemUsesGrossAmountForReserveAndState(t *testing.T) {
 	require.Equal(t, "900000000000000000000", s.Info.Reserves[1].String())
 }
 
-func TestCalcAmountOutRedeemRejectsWhenGrossAmountExceedsBaseBalance(t *testing.T) {
-	s := newBounceTechTestSimulator(t, "99000000")
+func TestCalcAmountOut(t *testing.T) {
+	s := newBounceTechTestSimulator(t, "1000000000") // 1000 USDC base balance
 
-	_, err := s.CalcAmountOut(pool.CalcAmountOutParams{
+	testutil.TestCalcAmountOut(t, s, map[int]map[int]map[string]string{
+		0: { // USDC -> LT (mint)
+			1: {
+				"10000000": "10000000000000000000",    // exactly minTxSize: 10 USDC -> 10 LT
+				"9999999":  ErrBelowMinAmount.Error(), // below minTxSize
+			},
+		},
+		1: { // LT -> USDC (redeem)
+			0: {
+				"100000000000000000000":  "97000000",                     // 100 LT -> 97 USDC net (3% fee)
+				"2000000000000000000000": ErrInsufficientBalance.Error(), // gross exceeds base balance
+			},
+		},
+	})
+}
+
+func TestCloneState(t *testing.T) {
+	s := newBounceTechTestSimulator(t, "1000000000")
+
+	testutil.TestCloneState(t, s, pool.CalcAmountOutParams{
 		TokenAmountIn: pool.TokenAmount{Token: testLT, Amount: mustBig("100000000000000000000")},
 		TokenOut:      testUSDC,
+	}, nil)
+}
+
+func TestCalcAmountIn(t *testing.T) {
+	// minTransactionSize is disabled here: it's a hard floor that testutil's power-of-10
+	// exponent search isn't built to route around given the 18-decimal LT / 1e30 combined
+	// mint-redeem scale, and it's already covered by the dedicated min-size tests below.
+	testutil.TestCalcAmountIn(t, newBounceTechTestSimulator(t, "1000000000", "0"))
+}
+
+// TestCalcAmountInRedeemOnFixturePoolHitsInsufficientBalance documents that the fetched
+// hyperevm fixture pool's real USDC reserve is smaller than its own minTransactionSize,
+// so any redeem large enough to clear the minimum necessarily exceeds the available balance.
+func TestCalcAmountInRedeemOnFixturePoolHitsInsufficientBalance(t *testing.T) {
+	s := newBounceTechFixtureSimulator(t)
+
+	_, err := s.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: testFixtureUSDC, Amount: mustBig("10000000")},
+		TokenIn:        testFixtureLT,
 	})
 	require.ErrorIs(t, err, ErrInsufficientBalance)
 }
 
-func TestCalcAmountOutMintRejectsBelowMinTransactionSize(t *testing.T) {
-	s := newBounceTechTestSimulator(t, "1000000000")
+func TestCalcAmountInMintRejectsBelowMinTransactionSize(t *testing.T) {
+	s := newBounceTechFixtureSimulator(t)
 
-	_, err := s.CalcAmountOut(pool.CalcAmountOutParams{
-		TokenAmountIn: pool.TokenAmount{Token: testUSDC, Amount: big.NewInt(9_999_999)},
-		TokenOut:      testLT,
+	_, err := s.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: testFixtureLT, Amount: big.NewInt(1)},
+		TokenIn:        testFixtureUSDC,
 	})
 	require.ErrorIs(t, err, ErrBelowMinAmount)
 }
 
-func newBounceTechTestSimulator(t *testing.T, baseBalance string) *PoolSimulator {
+const (
+	testFixtureUSDC = "0xb88339cb7199b77e23db6e890353e22632ba630f"
+	testFixtureLT   = "0xdfde51b58e6c143ef41659f66bde4614a4a27786"
+)
+
+// newBounceTechFixtureSimulator builds a simulator from a real hyperevm pool
+// (fetched via the router API) to exercise CalcAmountIn against realistic state.
+func newBounceTechFixtureSimulator(t *testing.T) *PoolSimulator {
 	t.Helper()
+
+	s, err := NewPoolSimulator(entity.Pool{
+		Address:  testFixtureLT,
+		Exchange: DexType,
+		Type:     DexType,
+		Reserves: entity.PoolReserves{
+			"9296560",
+			"10000000000000000000",
+		},
+		Tokens: []*entity.PoolToken{
+			{Address: testFixtureUSDC, Swappable: true},
+			{Address: testFixtureLT, Swappable: true},
+		},
+		Extra: `{"exchangeRate":"929656000000000000","redemptionFee":"3000000000000000","targetLeverage":"2000000000000000000","minTransactionSize":"10000000","mintPaused":false}`,
+	})
+	require.NoError(t, err)
+	return s
+}
+
+func newBounceTechTestSimulator(t *testing.T, baseBalance string, minTxSizeOpt ...string) *PoolSimulator {
+	t.Helper()
+
+	minTxSize := uint256.NewInt(10_000_000)
+	if len(minTxSizeOpt) > 0 {
+		minTxSize = uint256.MustFromDecimal(minTxSizeOpt[0])
+	}
 
 	extraBytes, err := json.Marshal(Extra{
 		ExchangeRate:       uint256.NewInt(1e18),
 		RedemptionFee:      uint256.NewInt(1e16), // 1%
 		TargetLeverage:     uint256.NewInt(3e18),
-		MinTransactionSize: uint256.NewInt(10_000_000),
+		MinTransactionSize: minTxSize,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Invert the mint/redeem math (ceiling MulDivUp/Down) so exact-out quotes
always meet or exceed the requested output, and add fixture-backed
tests (real hyperevm pool data) plus testutil round-trip/CloneState
coverage.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
