### PR TITLE
feat: add RingSwap backing liquidity source

### DIFF
--- a/pkg/liquidity-source/ringswap-backing/abis.go
+++ b/pkg/liquidity-source/ringswap-backing/abis.go
@@ -1,0 +1,17 @@
+package ringswapbacking
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var routerABI abi.ABI
+
+func init() {
+	parsed, err := abi.JSON(bytes.NewReader(routerABIData))
+	if err != nil {
+		panic(err)
+	}
+	routerABI = parsed
+}

--- a/pkg/liquidity-source/ringswap-backing/abis/FewBackingAwareV2Router.json
+++ b/pkg/liquidity-source/ringswap-backing/abis/FewBackingAwareV2Router.json
@@ -1,0 +1,79 @@
+[
+  {
+    "type": "function",
+    "name": "backingSourceState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "state",
+        "type": "tuple",
+        "components": [
+          {"name": "reserve0", "type": "uint112"},
+          {"name": "reserve1", "type": "uint112"},
+          {"name": "wrapperBuffer0", "type": "uint256"},
+          {"name": "wrapperBuffer1", "type": "uint256"},
+          {"name": "recallCapacity0", "type": "uint256"},
+          {"name": "recallCapacity1", "type": "uint256"}
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "origin0",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "origin1",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "token0",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "token1",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pair",
+    "inputs": [],
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "routeQuote",
+    "inputs": [
+      {"name": "originIn", "type": "address"},
+      {"name": "amountIn", "type": "uint256"}
+    ],
+    "outputs": [
+      {
+        "name": "quote",
+        "type": "tuple",
+        "components": [
+          {"name": "amountOut", "type": "uint256"},
+          {"name": "wrapperBuffer", "type": "uint256"},
+          {"name": "recallCapacity", "type": "uint256"},
+          {"name": "recallRequired", "type": "bool"},
+          {"name": "executable", "type": "bool"}
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/pkg/liquidity-source/ringswap-backing/config.go
+++ b/pkg/liquidity-source/ringswap-backing/config.go
@@ -1,0 +1,39 @@
+package ringswapbacking
+
+import "github.com/ethereum/go-ethereum/common"
+
+type RouterConfig struct {
+	Address             string `json:"address"`
+	ReplaceOrdinaryPair bool   `json:"replaceOrdinaryPair"`
+	NoRecallGasToken0   int64  `json:"noRecallGasToken0"`
+	NoRecallGasToken1   int64  `json:"noRecallGasToken1"`
+	RecallGasToken0     int64  `json:"recallGasToken0"`
+	RecallGasToken1     int64  `json:"recallGasToken1"`
+}
+
+type Config struct {
+	DexID   string         `json:"dexID"`
+	Routers []RouterConfig `json:"routers"`
+}
+
+func (c *Config) validate() error {
+	if c == nil || c.DexID == "" || len(c.Routers) == 0 {
+		return ErrInvalidConfig
+	}
+	seen := make(map[common.Address]struct{}, len(c.Routers))
+	for _, router := range c.Routers {
+		address := common.HexToAddress(router.Address)
+		if !common.IsHexAddress(router.Address) || address == (common.Address{}) ||
+			!router.ReplaceOrdinaryPair || router.NoRecallGasToken0 <= 0 ||
+			router.NoRecallGasToken1 <= 0 || router.RecallGasToken0 <= 0 ||
+			router.RecallGasToken1 <= 0 || router.RecallGasToken0 < router.NoRecallGasToken0 ||
+			router.RecallGasToken1 < router.NoRecallGasToken1 {
+			return ErrInvalidConfig
+		}
+		if _, exists := seen[address]; exists {
+			return ErrInvalidConfig
+		}
+		seen[address] = struct{}{}
+	}
+	return nil
+}

--- a/pkg/liquidity-source/ringswap-backing/constant.go
+++ b/pkg/liquidity-source/ringswap-backing/constant.go
@@ -1,0 +1,22 @@
+package ringswapbacking
+
+import "errors"
+
+const (
+	DexType = "ringswap-backing"
+
+	feeNumerator   uint64 = 997
+	feeDenominator uint64 = 1_000
+)
+
+var (
+	ErrInvalidConfig       = errors.New("invalid ringswap-backing config")
+	ErrInvalidToken        = errors.New("invalid token")
+	ErrInvalidState        = errors.New("invalid ringswap-backing state")
+	ErrInsufficientOutput  = errors.New("insufficient output")
+	ErrInsufficientBacking = errors.New("insufficient deliverable backing")
+	ErrNoSwapLimit         = errors.New("backing swap limit is required")
+	ErrSourceAlreadyUsed   = errors.New("ringswap-backing source already used")
+	ErrDuplicatePair       = errors.New("ringswap-backing pair configured more than once")
+	ErrInvalidMetadata     = errors.New("invalid ringswap-backing metadata")
+)

--- a/pkg/liquidity-source/ringswap-backing/embed.go
+++ b/pkg/liquidity-source/ringswap-backing/embed.go
@@ -1,0 +1,6 @@
+package ringswapbacking
+
+import _ "embed"
+
+//go:embed abis/FewBackingAwareV2Router.json
+var routerABIData []byte

--- a/pkg/liquidity-source/ringswap-backing/pool_list_updater.go
+++ b/pkg/liquidity-source/ringswap-backing/pool_list_updater.go
@@ -1,0 +1,188 @@
+package ringswapbacking
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(config *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: config, ethrpcClient: ethrpcClient}
+}
+
+func (u *PoolsListUpdater) GetNewPools(
+	ctx context.Context,
+	metadataBytes []byte,
+) ([]entity.Pool, []byte, error) {
+	if err := u.config.validate(); err != nil {
+		return nil, metadataBytes, err
+	}
+
+	metadata := PoolsListUpdaterMetadata{}
+	if len(metadataBytes) > 0 {
+		if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+			return nil, metadataBytes, err
+		}
+	}
+	known, knownPairs, err := knownSourceSet(metadata)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	candidates := make([]RouterConfig, 0, len(u.config.Routers))
+	seen := make(map[string]struct{}, len(known)+len(u.config.Routers))
+	for router := range known {
+		seen[router] = struct{}{}
+	}
+	for _, configured := range u.config.Routers {
+		router := strings.ToLower(common.HexToAddress(configured.Address).Hex())
+		if _, exists := seen[router]; exists {
+			continue
+		}
+		configured.Address = router
+		candidates = append(candidates, configured)
+		seen[router] = struct{}{}
+	}
+	if len(candidates) == 0 {
+		return nil, metadataBytes, nil
+	}
+
+	origin0s := make([]common.Address, len(candidates))
+	origin1s := make([]common.Address, len(candidates))
+	wrapper0s := make([]common.Address, len(candidates))
+	wrapper1s := make([]common.Address, len(candidates))
+	pairs := make([]common.Address, len(candidates))
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+	for i, configured := range candidates {
+		router := configured.Address
+		req.AddCall(&ethrpc.Call{ABI: routerABI, Target: router, Method: "origin0"}, []any{&origin0s[i]})
+		req.AddCall(&ethrpc.Call{ABI: routerABI, Target: router, Method: "origin1"}, []any{&origin1s[i]})
+		req.AddCall(&ethrpc.Call{ABI: routerABI, Target: router, Method: "token0"}, []any{&wrapper0s[i]})
+		req.AddCall(&ethrpc.Call{ABI: routerABI, Target: router, Method: "token1"}, []any{&wrapper1s[i]})
+		req.AddCall(&ethrpc.Call{ABI: routerABI, Target: router, Method: "pair"}, []any{&pairs[i]})
+	}
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+
+	zero := common.Address{}
+	pools := make([]entity.Pool, 0, len(candidates))
+	for i, configured := range candidates {
+		callIndex := i * 5
+		if len(resp.Result) <= callIndex+4 || !resp.Result[callIndex] || !resp.Result[callIndex+1] ||
+			!resp.Result[callIndex+2] || !resp.Result[callIndex+3] || !resp.Result[callIndex+4] ||
+			origin0s[i] == zero || origin1s[i] == zero || wrapper0s[i] == zero ||
+			wrapper1s[i] == zero || pairs[i] == zero || origin0s[i] == origin1s[i] ||
+			wrapper0s[i] == wrapper1s[i] {
+			continue
+		}
+
+		pairAddress := strings.ToLower(hexutil.Encode(pairs[i][:]))
+		if _, exists := knownPairs[pairAddress]; exists {
+			return nil, metadataBytes, ErrDuplicatePair
+		}
+		staticExtra, err := json.Marshal(StaticExtra{
+			RouterAddress:       configured.Address,
+			PairAddress:         pairAddress,
+			Wrapper0:            strings.ToLower(hexutil.Encode(wrapper0s[i][:])),
+			Wrapper1:            strings.ToLower(hexutil.Encode(wrapper1s[i][:])),
+			ReplaceOrdinaryPair: configured.ReplaceOrdinaryPair,
+			NoRecallGasToken0:   configured.NoRecallGasToken0,
+			NoRecallGasToken1:   configured.NoRecallGasToken1,
+			RecallGasToken0:     configured.RecallGasToken0,
+			RecallGasToken1:     configured.RecallGasToken1,
+		})
+		if err != nil {
+			return nil, metadataBytes, err
+		}
+		pools = append(pools, entity.Pool{
+			// This source replaces the ordinary Ring source for the configured Pair. It handles
+			// both direct hot-backing execution and recall-backed execution as one inventory.
+			Address:   pairAddress,
+			Exchange:  u.config.DexID,
+			Type:      DexType,
+			Timestamp: time.Now().Unix(),
+			Reserves:  entity.PoolReserves{"0", "0"},
+			Tokens: []*entity.PoolToken{
+				{Address: strings.ToLower(hexutil.Encode(origin0s[i][:])), Swappable: true},
+				{Address: strings.ToLower(hexutil.Encode(origin1s[i][:])), Swappable: true},
+			},
+			Extra:       "{}",
+			StaticExtra: string(staticExtra),
+		})
+		known[configured.Address] = struct{}{}
+		knownPairs[pairAddress] = struct{}{}
+	}
+
+	newMetadata := PoolsListUpdaterMetadata{
+		KnownRouters: make([]string, 0, len(known)),
+		KnownPairs:   make([]string, 0, len(knownPairs)),
+	}
+	for router := range known {
+		newMetadata.KnownRouters = append(newMetadata.KnownRouters, router)
+	}
+	sort.Strings(newMetadata.KnownRouters)
+	for pairAddress := range knownPairs {
+		newMetadata.KnownPairs = append(newMetadata.KnownPairs, pairAddress)
+	}
+	sort.Strings(newMetadata.KnownPairs)
+	newMetadataBytes, err := json.Marshal(newMetadata)
+	if err != nil {
+		return nil, metadataBytes, err
+	}
+	return pools, newMetadataBytes, nil
+}
+
+func knownSourceSet(
+	metadata PoolsListUpdaterMetadata,
+) (map[string]struct{}, map[string]struct{}, error) {
+	if len(metadata.KnownRouters) != len(metadata.KnownPairs) {
+		return nil, nil, ErrInvalidMetadata
+	}
+	knownRouters := make(map[string]struct{}, len(metadata.KnownRouters))
+	for _, routerAddress := range metadata.KnownRouters {
+		if !common.IsHexAddress(routerAddress) {
+			return nil, nil, ErrInvalidMetadata
+		}
+		normalized := strings.ToLower(common.HexToAddress(routerAddress).Hex())
+		if common.HexToAddress(normalized) == (common.Address{}) {
+			return nil, nil, ErrInvalidMetadata
+		}
+		if _, exists := knownRouters[normalized]; exists {
+			return nil, nil, ErrInvalidMetadata
+		}
+		knownRouters[normalized] = struct{}{}
+	}
+	knownPairs := make(map[string]struct{}, len(metadata.KnownPairs))
+	for _, pairAddress := range metadata.KnownPairs {
+		if !common.IsHexAddress(pairAddress) {
+			return nil, nil, ErrInvalidMetadata
+		}
+		normalized := strings.ToLower(common.HexToAddress(pairAddress).Hex())
+		if common.HexToAddress(normalized) == (common.Address{}) {
+			return nil, nil, ErrInvalidMetadata
+		}
+		if _, exists := knownPairs[normalized]; exists {
+			return nil, nil, ErrInvalidMetadata
+		}
+		knownPairs[normalized] = struct{}{}
+	}
+	return knownRouters, knownPairs, nil
+}

--- a/pkg/liquidity-source/ringswap-backing/pool_simulator.go
+++ b/pkg/liquidity-source/ringswap-backing/pool_simulator.go
@@ -1,0 +1,222 @@
+package ringswapbacking
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v2"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+	Extra
+	StaticExtra
+	consumed bool
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+var _ = pool.RegisterUseSwapLimit(DexType)
+
+func NewPoolSimulator(p entity.Pool) (*PoolSimulator, error) {
+	if len(p.Tokens) != 2 || len(p.Reserves) != 2 {
+		return nil, ErrInvalidState
+	}
+	var extra Extra
+	if err := json.Unmarshal([]byte(p.Extra), &extra); err != nil {
+		return nil, err
+	}
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return nil, err
+	}
+	if !validExtra(extra) || !validStaticExtra(p, staticExtra) {
+		return nil, ErrInvalidState
+	}
+	return &PoolSimulator{
+		Pool:        pool.FromEntity(p),
+		Extra:       extra,
+		StaticExtra: staticExtra,
+	}, nil
+}
+
+func (s *PoolSimulator) CalcAmountOut(
+	params pool.CalcAmountOutParams,
+) (*pool.CalcAmountOutResult, error) {
+	if s.consumed {
+		return nil, ErrSourceAlreadyUsed
+	}
+	indexIn := s.GetTokenIndex(strings.ToLower(params.TokenAmountIn.Token))
+	indexOut := s.GetTokenIndex(strings.ToLower(params.TokenOut))
+	if indexIn < 0 || indexOut < 0 || indexIn == indexOut {
+		return nil, ErrInvalidToken
+	}
+	if params.TokenAmountIn.Amount == nil {
+		return nil, uniswapv2.ErrInvalidAmountIn
+	}
+	amountIn, overflow := uint256.FromBig(params.TokenAmountIn.Amount)
+	if overflow || amountIn.Sign() <= 0 {
+		return nil, uniswapv2.ErrInvalidAmountIn
+	}
+
+	reserveIn, reserveOut, err := s.directionalReserves(indexIn)
+	if err != nil {
+		return nil, err
+	}
+	amountOut, err := getAmountOut(amountIn, reserveIn, reserveOut)
+	if err != nil {
+		return nil, err
+	}
+	if amountOut.Sign() <= 0 || amountOut.Cmp(reserveOut) >= 0 {
+		return nil, ErrInsufficientOutput
+	}
+
+	bufferOut, capacityOut, wrapperIn, wrapperOut := s.directionalBacking(indexIn)
+	amountOutBig := amountOut.ToBig()
+	if params.Limit == nil {
+		return nil, ErrNoSwapLimit
+	}
+	deliverable := params.Limit.GetLimit(wrapperOut)
+	if deliverable == nil || amountOutBig.Cmp(deliverable) > 0 {
+		return nil, ErrInsufficientBacking
+	}
+
+	useRecall := amountOutBig.Cmp(bufferOut) > 0
+	if useRecall {
+		shortfall := new(big.Int).Sub(amountOutBig, bufferOut)
+		if shortfall.Cmp(capacityOut) > 0 {
+			return nil, ErrInsufficientBacking
+		}
+	}
+
+	gas := s.NoRecallGasToken1
+	if indexOut == 0 {
+		gas = s.NoRecallGasToken0
+	}
+	if useRecall && indexOut == 0 {
+		gas = s.RecallGasToken0
+	} else if useRecall {
+		gas = s.RecallGasToken1
+	}
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: params.TokenOut, Amount: amountOutBig},
+		Fee: &pool.TokenAmount{
+			Token:  params.TokenAmountIn.Token,
+			Amount: big.NewInt(0),
+		},
+		Gas: gas,
+		SwapInfo: SwapInfo{
+			RouterAddress:  s.RouterAddress,
+			UnderlyingPair: s.PairAddress,
+			WrapperIn:      wrapperIn,
+			WrapperOut:     wrapperOut,
+			UseRecall:      useRecall,
+		},
+	}, nil
+}
+
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	info, ok := params.SwapInfo.(SwapInfo)
+	if !ok || s.consumed {
+		return
+	}
+	if params.SwapLimit != nil {
+		_, _, _ = params.SwapLimit.UpdateLimit(
+			info.WrapperOut,
+			info.WrapperIn,
+			params.TokenAmountOut.Amount,
+			params.TokenAmountIn.Amount,
+		)
+	}
+	s.consumed = true
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	return &cloned
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return PoolMeta{
+		ApprovalAddress:      s.RouterAddress,
+		RouterAddress:        s.RouterAddress,
+		UnderlyingPair:       s.PairAddress,
+		SingleUse:            true,
+		ReplacesOrdinaryPair: true,
+	}
+}
+
+func (s *PoolSimulator) GetApprovalAddress(_, _ string) string {
+	return s.RouterAddress
+}
+
+func (s *PoolSimulator) CalculateLimit() map[string]*big.Int {
+	return map[string]*big.Int{
+		s.Wrapper0: new(big.Int).Add(s.WrapperBuffer0, s.RecallCapacity0),
+		s.Wrapper1: new(big.Int).Add(s.WrapperBuffer1, s.RecallCapacity1),
+	}
+}
+
+func (s *PoolSimulator) directionalReserves(indexIn int) (*uint256.Int, *uint256.Int, error) {
+	reserveIn, overflow := uint256.FromBig(s.Info.Reserves[indexIn])
+	if overflow || reserveIn.Sign() <= 0 {
+		return nil, nil, ErrInvalidState
+	}
+	reserveOut, overflow := uint256.FromBig(s.Info.Reserves[1-indexIn])
+	if overflow || reserveOut.Sign() <= 0 {
+		return nil, nil, ErrInvalidState
+	}
+	return reserveIn, reserveOut, nil
+}
+
+func (s *PoolSimulator) directionalBacking(
+	indexIn int,
+) (bufferOut, capacityOut *big.Int, wrapperIn, wrapperOut string) {
+	if indexIn == 0 {
+		return s.WrapperBuffer1, s.RecallCapacity1, s.Wrapper0, s.Wrapper1
+	}
+	return s.WrapperBuffer0, s.RecallCapacity0, s.Wrapper1, s.Wrapper0
+}
+
+func validExtra(extra Extra) bool {
+	values := []*big.Int{
+		extra.WrapperBuffer0,
+		extra.WrapperBuffer1,
+		extra.RecallCapacity0,
+		extra.RecallCapacity1,
+	}
+	for _, value := range values {
+		if value == nil || value.Sign() < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func getAmountOut(
+	amountIn *uint256.Int,
+	reserveIn *uint256.Int,
+	reserveOut *uint256.Int,
+) (amountOut *uint256.Int, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if recoveredError, ok := recovered.(error); ok {
+				err = recoveredError
+			} else {
+				err = fmt.Errorf("ringswap-backing math panic: %v", recovered)
+			}
+		}
+	}()
+	amountInWithFee := uniswapv2.SafeMul(amountIn, uint256.NewInt(feeNumerator))
+	numerator := uniswapv2.SafeMul(amountInWithFee, reserveOut)
+	denominator := uniswapv2.SafeAdd(
+		uniswapv2.SafeMul(reserveIn, uint256.NewInt(feeDenominator)),
+		amountInWithFee,
+	)
+	return new(uint256.Int).Div(numerator, denominator), nil
+}

--- a/pkg/liquidity-source/ringswap-backing/pool_simulator_test.go
+++ b/pkg/liquidity-source/ringswap-backing/pool_simulator_test.go
@@ -1,0 +1,303 @@
+package ringswapbacking
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v2"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/swaplimit"
+)
+
+const (
+	testToken0   = "0x0000000000000000000000000000000000000010"
+	testToken1   = "0x0000000000000000000000000000000000000020"
+	testWrapper0 = "0x0000000000000000000000000000000000000030"
+	testWrapper1 = "0x0000000000000000000000000000000000000040"
+	testRouter   = "0x0000000000000000000000000000000000000050"
+	testPair     = "0x0000000000000000000000000000000000000060"
+
+	testNoRecallGas0 int64 = 245_000
+	testNoRecallGas1 int64 = 250_000
+	testRecallGas0   int64 = 410_000
+	testRecallGas1   int64 = 390_000
+)
+
+func TestPoolSimulatorUsesDirectHotBackingPathWithoutRecall(t *testing.T) {
+	for _, direction := range []struct {
+		in          string
+		out         string
+		expectedGas int64
+	}{
+		{testToken0, testToken1, testNoRecallGas1},
+		{testToken1, testToken0, testNoRecallGas0},
+	} {
+		simulator := newTestSimulator(t)
+		result, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: direction.in, Amount: units(100)},
+			TokenOut:      direction.out,
+			Limit:         newTestLimit(simulator),
+		})
+		require.NoError(t, err)
+		require.Equal(t, direction.expectedGas, result.Gas)
+		require.False(t, result.SwapInfo.(SwapInfo).UseRecall)
+	}
+}
+
+func TestPoolSimulatorQuotesOriginalPairDepthForRecallInBothDirections(t *testing.T) {
+	for _, direction := range []struct {
+		in          string
+		out         string
+		expectedGas int64
+	}{
+		{testToken0, testToken1, testRecallGas1},
+		{testToken1, testToken0, testRecallGas0},
+	} {
+		simulator := newTestSimulator(t)
+		amountIn := units(20_000)
+		result, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: direction.in, Amount: amountIn},
+			TokenOut:      direction.out,
+			Limit:         newTestLimit(simulator),
+		})
+		require.NoError(t, err)
+		require.Equal(t, direction.expectedGas, result.Gas)
+		require.Equal(
+			t,
+			amountOut(amountIn, units(150_000), units(150_000)),
+			result.TokenAmountOut.Amount,
+			"recall capacity must not be added to AMM reserves",
+		)
+		require.True(t, result.SwapInfo.(SwapInfo).UseRecall)
+	}
+}
+
+func TestPoolSimulatorRejectsOutputAboveSharedDeliverableBacking(t *testing.T) {
+	simulator := newTestSimulator(t)
+	limit := newTestLimit(simulator)
+	limit = swaplimit.NewInventory(DexType, map[string]*big.Int{
+		testWrapper0: units(100_000),
+		testWrapper1: units(15_000),
+	})
+	_, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testToken0, Amount: units(20_000)},
+		TokenOut:      testToken1,
+		Limit:         limit,
+	})
+	require.ErrorIs(t, err, ErrInsufficientBacking)
+}
+
+func TestPoolSimulatorRequiresSharedBackingLimit(t *testing.T) {
+	simulator := newTestSimulator(t)
+	_, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testToken0, Amount: units(20_000)},
+		TokenOut:      testToken1,
+	})
+	require.ErrorIs(t, err, ErrNoSwapLimit)
+}
+
+func TestPoolSimulatorUpdateConsumesSourceAndSharedInventory(t *testing.T) {
+	simulator := newTestSimulator(t)
+	clone := simulator.CloneState().(*PoolSimulator)
+	limit := newTestLimit(simulator)
+	amountIn := units(20_000)
+	result, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testToken0, Amount: amountIn},
+		TokenOut:      testToken1,
+		Limit:         limit,
+	})
+	require.NoError(t, err)
+	simulator.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: testToken0, Amount: amountIn},
+		TokenAmountOut: *result.TokenAmountOut,
+		SwapInfo:       result.SwapInfo,
+		SwapLimit:      limit,
+	})
+
+	require.Equal(
+		t,
+		new(big.Int).Sub(units(100_000), result.TokenAmountOut.Amount),
+		limit.GetLimit(testWrapper1),
+	)
+	require.Equal(t, units(120_000), limit.GetLimit(testWrapper0))
+	_, err = simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testToken0, Amount: amountIn},
+		TokenOut:      testToken1,
+		Limit:         limit,
+	})
+	require.ErrorIs(t, err, ErrSourceAlreadyUsed)
+	_, err = clone.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testToken0, Amount: amountIn},
+		TokenOut:      testToken1,
+		Limit:         newTestLimit(clone),
+	})
+	require.NoError(t, err)
+}
+
+func TestPoolSimulatorMetaExposesOriginalPairAndBackingRouter(t *testing.T) {
+	simulator := newTestSimulator(t)
+	require.Equal(t, testPair, simulator.GetAddress())
+	meta := simulator.GetMetaInfo(testToken0, testToken1).(PoolMeta)
+	require.Equal(t, testRouter, meta.ApprovalAddress)
+	require.Equal(t, testPair, meta.UnderlyingPair)
+	require.True(t, meta.SingleUse)
+	require.True(t, meta.ReplacesOrdinaryPair)
+}
+
+func TestPoolSimulatorRejectsMalformedState(t *testing.T) {
+	_, err := NewPoolSimulator(newTestPoolEntity(t, testRouter))
+	require.ErrorIs(t, err, ErrInvalidState)
+
+	entityPool := newTestPoolEntity(t, testPair)
+	entityPool.Extra = "{}"
+	_, err = NewPoolSimulator(entityPool)
+	require.ErrorIs(t, err, ErrInvalidState)
+}
+
+func TestPoolSimulatorRejectsNilInputAmount(t *testing.T) {
+	simulator := newTestSimulator(t)
+	_, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: testToken0},
+		TokenOut:      testToken1,
+		Limit:         newTestLimit(simulator),
+	})
+	require.ErrorIs(t, err, uniswapv2.ErrInvalidAmountIn)
+}
+
+func TestPoolSimulatorMatchesFixedMainnetPairReserveFixture(t *testing.T) {
+	// Ring fwWETH/fwUSDT reserves at mainnet block 25,503,661. Expected outputs were also
+	// asserted by FewBackingAwareV2RouterForkTest against the Solidity route.
+	tests := []struct {
+		name     string
+		tokenIn  string
+		tokenOut string
+		amountIn *big.Int
+		expected *big.Int
+	}{
+		{"weth-0.1", testToken0, testToken1, big.NewInt(100_000_000_000_000_000), big.NewInt(178_829_383)},
+		{"weth-5", testToken0, testToken1, big.NewInt(5_000_000_000_000_000_000), big.NewInt(8_938_332_759)},
+		{"usdt-5000", testToken1, testToken0, big.NewInt(5_000_000_000), big.NewInt(2_778_635_928_725_029_183)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			simulator := newForkFixtureSimulator(t)
+			result, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{Token: tt.tokenIn, Amount: tt.amountIn},
+				TokenOut:      tt.tokenOut,
+				Limit:         newTestLimit(simulator),
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result.TokenAmountOut.Amount)
+		})
+	}
+}
+
+func TestConfigFailsClosedOnMissingGasOrInvalidRouter(t *testing.T) {
+	config := &Config{DexID: DexType, Routers: []RouterConfig{{Address: testRouter}}}
+	require.ErrorIs(t, config.validate(), ErrInvalidConfig)
+	config.Routers[0] = RouterConfig{
+		Address: "not-an-address", ReplaceOrdinaryPair: true, NoRecallGasToken0: 1,
+		NoRecallGasToken1: 1, RecallGasToken0: 1, RecallGasToken1: 1,
+	}
+	require.ErrorIs(t, config.validate(), ErrInvalidConfig)
+	config.Routers[0].Address = testRouter
+	require.NoError(t, config.validate())
+	config.Routers = append(config.Routers, config.Routers[0])
+	require.ErrorIs(t, config.validate(), ErrInvalidConfig)
+	config.Routers = config.Routers[:1]
+	config.Routers[0].RecallGasToken0 = config.Routers[0].NoRecallGasToken0 - 1
+	require.ErrorIs(t, config.validate(), ErrInvalidConfig)
+}
+
+func TestKnownSourceMetadataRequiresOneUniquePairPerRouter(t *testing.T) {
+	routers, pairs, err := knownSourceSet(PoolsListUpdaterMetadata{
+		KnownRouters: []string{testRouter},
+		KnownPairs:   []string{testPair},
+	})
+	require.NoError(t, err)
+	require.Contains(t, routers, testRouter)
+	require.Contains(t, pairs, testPair)
+
+	_, _, err = knownSourceSet(PoolsListUpdaterMetadata{KnownRouters: []string{testRouter}})
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+	_, _, err = knownSourceSet(PoolsListUpdaterMetadata{
+		KnownRouters: []string{testRouter, "0x0000000000000000000000000000000000000051"},
+		KnownPairs:   []string{testPair, testPair},
+	})
+	require.ErrorIs(t, err, ErrInvalidMetadata)
+}
+
+func newTestSimulator(t *testing.T) *PoolSimulator {
+	t.Helper()
+	simulator, err := NewPoolSimulator(newTestPoolEntity(t, testPair))
+	require.NoError(t, err)
+	return simulator
+}
+
+func newTestPoolEntity(t *testing.T, address string) entity.Pool {
+	t.Helper()
+	extra, err := json.Marshal(Extra{
+		WrapperBuffer0:  units(10_000),
+		WrapperBuffer1:  units(10_000),
+		RecallCapacity0: units(90_000),
+		RecallCapacity1: units(90_000),
+	})
+	require.NoError(t, err)
+	staticExtra, err := json.Marshal(StaticExtra{
+		RouterAddress:       testRouter,
+		PairAddress:         testPair,
+		Wrapper0:            testWrapper0,
+		Wrapper1:            testWrapper1,
+		ReplaceOrdinaryPair: true,
+		NoRecallGasToken0:   testNoRecallGas0,
+		NoRecallGasToken1:   testNoRecallGas1,
+		RecallGasToken0:     testRecallGas0,
+		RecallGasToken1:     testRecallGas1,
+	})
+	require.NoError(t, err)
+	return entity.Pool{
+		Address:     address,
+		Exchange:    DexType,
+		Type:        DexType,
+		Reserves:    entity.PoolReserves{units(150_000).String(), units(150_000).String()},
+		Tokens:      []*entity.PoolToken{{Address: testToken0}, {Address: testToken1}},
+		Extra:       string(extra),
+		StaticExtra: string(staticExtra),
+	}
+}
+
+func newForkFixtureSimulator(t *testing.T) *PoolSimulator {
+	t.Helper()
+	entityPool := newTestPoolEntity(t, testPair)
+	entityPool.Reserves = entity.PoolReserves{"13922377412137157664837", "24972397132732"}
+	extra, err := json.Marshal(Extra{
+		WrapperBuffer0:  big.NewInt(0),
+		WrapperBuffer1:  big.NewInt(0),
+		RecallCapacity0: new(big.Int).SetUint64(^uint64(0)),
+		RecallCapacity1: new(big.Int).SetUint64(^uint64(0)),
+	})
+	require.NoError(t, err)
+	entityPool.Extra = string(extra)
+	simulator, err := NewPoolSimulator(entityPool)
+	require.NoError(t, err)
+	return simulator
+}
+
+func newTestLimit(simulator *PoolSimulator) *swaplimit.Inventory {
+	return swaplimit.NewInventory(DexType, simulator.CalculateLimit())
+}
+
+func units(amount int64) *big.Int {
+	return new(big.Int).Mul(big.NewInt(amount), big.NewInt(1_000_000))
+}
+
+func amountOut(amountIn, reserveIn, reserveOut *big.Int) *big.Int {
+	amountInWithFee := new(big.Int).Mul(amountIn, big.NewInt(997))
+	numerator := new(big.Int).Mul(amountInWithFee, reserveOut)
+	denominator := new(big.Int).Add(new(big.Int).Mul(reserveIn, big.NewInt(1_000)), amountInWithFee)
+	return numerator.Div(numerator, denominator)
+}

--- a/pkg/liquidity-source/ringswap-backing/pool_tracker.go
+++ b/pkg/liquidity-source/ringswap-backing/pool_tracker.go
@@ -1,0 +1,131 @@
+package ringswapbacking
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(config *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
+	return &PoolTracker{config: config, ethrpcClient: ethrpcClient}
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	if err := t.config.validate(); err != nil {
+		return p, err
+	}
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return p, err
+	}
+	configured, ok := t.config.routerConfig(staticExtra.RouterAddress)
+	if !ok {
+		return p, ErrInvalidConfig
+	}
+	staticExtra.ReplaceOrdinaryPair = configured.ReplaceOrdinaryPair
+	staticExtra.NoRecallGasToken0 = configured.NoRecallGasToken0
+	staticExtra.NoRecallGasToken1 = configured.NoRecallGasToken1
+	staticExtra.RecallGasToken0 = configured.RecallGasToken0
+	staticExtra.RecallGasToken1 = configured.RecallGasToken1
+	if !validStaticExtra(p, staticExtra) {
+		return p, ErrInvalidState
+	}
+
+	var stateResult backingSourceStateResult
+	resp, err := t.ethrpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI: routerABI, Target: staticExtra.RouterAddress, Method: "backingSourceState",
+	}, []any{&stateResult}).TryBlockAndAggregate()
+	if err != nil {
+		return p, err
+	}
+	state := stateResult.State
+	if !validState(state) || resp.BlockNumber == nil {
+		return p, ErrInvalidState
+	}
+	if p.BlockNumber > resp.BlockNumber.Uint64() {
+		return p, nil
+	}
+	if len(p.Tokens) != 2 {
+		return p, errors.New("ringswap-backing requires exactly two origin tokens")
+	}
+
+	extraBytes, err := json.Marshal(Extra{
+		WrapperBuffer0:  state.WrapperBuffer0,
+		WrapperBuffer1:  state.WrapperBuffer1,
+		RecallCapacity0: state.RecallCapacity0,
+		RecallCapacity1: state.RecallCapacity1,
+	})
+	if err != nil {
+		return p, err
+	}
+	p.Reserves = entity.PoolReserves{state.Reserve0.String(), state.Reserve1.String()}
+	p.Extra = string(extraBytes)
+	staticExtraBytes, err := json.Marshal(staticExtra)
+	if err != nil {
+		return p, err
+	}
+	p.StaticExtra = string(staticExtraBytes)
+	p.BlockNumber = resp.BlockNumber.Uint64()
+	p.Timestamp = time.Now().Unix()
+	return p, nil
+}
+
+func validStaticExtra(p entity.Pool, extra StaticExtra) bool {
+	return common.IsHexAddress(extra.RouterAddress) && common.IsHexAddress(extra.PairAddress) &&
+		common.IsHexAddress(extra.Wrapper0) && common.IsHexAddress(extra.Wrapper1) &&
+		common.HexToAddress(extra.RouterAddress) != (common.Address{}) &&
+		common.HexToAddress(extra.PairAddress) != (common.Address{}) &&
+		common.HexToAddress(extra.Wrapper0) != (common.Address{}) &&
+		common.HexToAddress(extra.Wrapper1) != (common.Address{}) &&
+		!strings.EqualFold(extra.Wrapper0, extra.Wrapper1) &&
+		strings.EqualFold(p.Address, extra.PairAddress) && extra.ReplaceOrdinaryPair &&
+		extra.NoRecallGasToken0 > 0 && extra.NoRecallGasToken1 > 0 &&
+		extra.RecallGasToken0 > 0 && extra.RecallGasToken1 > 0
+}
+
+func (c *Config) routerConfig(routerAddress string) (RouterConfig, bool) {
+	for _, configured := range c.Routers {
+		if strings.EqualFold(configured.Address, routerAddress) {
+			return configured, true
+		}
+	}
+	return RouterConfig{}, false
+}
+
+func validState(state BackingSourceState) bool {
+	values := []*big.Int{
+		state.Reserve0,
+		state.Reserve1,
+		state.WrapperBuffer0,
+		state.WrapperBuffer1,
+		state.RecallCapacity0,
+		state.RecallCapacity1,
+	}
+	for _, value := range values {
+		if value == nil || value.Sign() < 0 {
+			return false
+		}
+	}
+	return state.Reserve0.Sign() > 0 && state.Reserve1.Sign() > 0
+}

--- a/pkg/liquidity-source/ringswap-backing/type.go
+++ b/pkg/liquidity-source/ringswap-backing/type.go
@@ -1,0 +1,69 @@
+package ringswapbacking
+
+import "math/big"
+
+type BackingSourceState struct {
+	Reserve0        *big.Int
+	Reserve1        *big.Int
+	WrapperBuffer0  *big.Int
+	WrapperBuffer1  *big.Int
+	RecallCapacity0 *big.Int
+	RecallCapacity1 *big.Int
+}
+
+// go-ethereum wraps a function's single tuple output before copying its components.
+type backingSourceStateResult struct {
+	State BackingSourceState
+}
+
+type RouteQuote struct {
+	AmountOut      *big.Int
+	WrapperBuffer  *big.Int
+	RecallCapacity *big.Int
+	RecallRequired bool
+	Executable     bool
+}
+
+type routeQuoteResult struct {
+	Quote RouteQuote
+}
+
+type Extra struct {
+	WrapperBuffer0  *big.Int `json:"wrapperBuffer0"`
+	WrapperBuffer1  *big.Int `json:"wrapperBuffer1"`
+	RecallCapacity0 *big.Int `json:"recallCapacity0"`
+	RecallCapacity1 *big.Int `json:"recallCapacity1"`
+}
+
+type StaticExtra struct {
+	RouterAddress       string `json:"routerAddress"`
+	PairAddress         string `json:"pairAddress"`
+	Wrapper0            string `json:"wrapper0"`
+	Wrapper1            string `json:"wrapper1"`
+	ReplaceOrdinaryPair bool   `json:"replaceOrdinaryPair"`
+	NoRecallGasToken0   int64  `json:"noRecallGasToken0"`
+	NoRecallGasToken1   int64  `json:"noRecallGasToken1"`
+	RecallGasToken0     int64  `json:"recallGasToken0"`
+	RecallGasToken1     int64  `json:"recallGasToken1"`
+}
+
+type SwapInfo struct {
+	RouterAddress  string `json:"routerAddress"`
+	UnderlyingPair string `json:"underlyingPair"`
+	WrapperIn      string `json:"wrapperIn"`
+	WrapperOut     string `json:"wrapperOut"`
+	UseRecall      bool   `json:"useRecall"`
+}
+
+type PoolMeta struct {
+	ApprovalAddress      string `json:"approvalAddress"`
+	RouterAddress        string `json:"routerAddress"`
+	UnderlyingPair       string `json:"underlyingPair"`
+	SingleUse            bool   `json:"singleUse"`
+	ReplacesOrdinaryPair bool   `json:"replacesOrdinaryPair"`
+}
+
+type PoolsListUpdaterMetadata struct {
+	KnownRouters []string `json:"knownRouters"`
+	KnownPairs   []string `json:"knownPairs"`
+}

--- a/pkg/liquidity-source/ringswap-backing/verification_test.go
+++ b/pkg/liquidity-source/ringswap-backing/verification_test.go
@@ -1,0 +1,178 @@
+package ringswapbacking
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/swaplimit"
+)
+
+const (
+	multicall3Mainnet = "0xcA11bde05977b3631167028862bE2a173976CA11"
+	verifyWETH        = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+	verifyUSDT        = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+)
+
+// TestVerifyLocalForkPipeline covers Kyber's lister -> tracker -> simulator path against an
+// actual FewBackingAwareV2Router deployed on a local mainnet fork. The Ring runner funds a real
+// Euler-backed Manager, revokes its minter role, and keeps this opt-in test out of ordinary runs.
+func TestVerifyLocalForkPipeline(t *testing.T) {
+	rpcURL := os.Getenv("RINGSWAP_BACKING_VERIFY_RPC_URL")
+	routerAddress := os.Getenv("RINGSWAP_BACKING_VERIFY_ROUTER")
+	if rpcURL == "" || routerAddress == "" {
+		t.Skip("local fork verification environment is not set")
+	}
+	require.True(t, common.IsHexAddress(routerAddress), "router address")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := ethrpc.New(rpcURL).SetMulticallContract(common.HexToAddress(multicall3Mainnet))
+	config := &Config{
+		DexID: DexType,
+		Routers: []RouterConfig{{
+			Address:             routerAddress,
+			ReplaceOrdinaryPair: true,
+			NoRecallGasToken0:   178_435,
+			NoRecallGasToken1:   181_377,
+			RecallGasToken0:     399_312,
+			RecallGasToken1:     378_580,
+		}},
+	}
+	lister := NewPoolsListUpdater(config, client)
+
+	pools, metadata, err := lister.GetNewPools(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, pools, 1)
+	require.Equal(t, strings.ToLower(verifyWETH), pools[0].Tokens[0].Address)
+	require.Equal(t, strings.ToLower(verifyUSDT), pools[0].Tokens[1].Address)
+	var staticExtra StaticExtra
+	require.NoError(t, json.Unmarshal([]byte(pools[0].StaticExtra), &staticExtra))
+	require.Equal(t, staticExtra.PairAddress, pools[0].Address)
+	require.Equal(t, strings.ToLower(routerAddress), staticExtra.RouterAddress)
+
+	var persisted PoolsListUpdaterMetadata
+	require.NoError(t, json.Unmarshal(metadata, &persisted))
+	require.Equal(t, []string{strings.ToLower(routerAddress)}, persisted.KnownRouters)
+	require.Equal(t, []string{staticExtra.PairAddress}, persisted.KnownPairs)
+	secondPools, secondMetadata, err := lister.GetNewPools(ctx, metadata)
+	require.NoError(t, err)
+	require.Empty(t, secondPools, "persisted routers must not be rediscovered")
+	require.Equal(t, metadata, secondMetadata)
+
+	tracked, err := NewPoolTracker(config, client).GetNewPoolState(
+		ctx, pools[0], pool.GetNewPoolStateParams{},
+	)
+	require.NoError(t, err)
+	require.Positive(t, tracked.BlockNumber)
+	extra := decodeExtra(t, tracked.Extra)
+	require.Positive(t, extra.RecallCapacity1.Sign(), "USDT recall capacity")
+
+	simulator, err := NewPoolSimulator(tracked)
+	require.NoError(t, err)
+	limit := swaplimit.NewInventory(DexType, simulator.CalculateLimit())
+	hotResult, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token: verifyWETH, Amount: big.NewInt(100_000_000_000_000_000),
+		},
+		TokenOut: verifyUSDT,
+		Limit:    limit,
+	})
+	require.NoError(t, err)
+	require.False(t, hotResult.SwapInfo.(SwapInfo).UseRecall)
+	require.Equal(t, int64(181_377), hotResult.Gas)
+
+	verifyRecallQuote(
+		t,
+		ctx,
+		client,
+		simulator,
+		verifyWETH,
+		verifyUSDT,
+		recallTriggerAmountIn(t, tracked.Reserves[0], tracked.Reserves[1], extra),
+		limit,
+	)
+}
+
+func recallTriggerAmountIn(
+	t *testing.T,
+	reserveInRaw string,
+	reserveOutRaw string,
+	extra Extra,
+) *big.Int {
+	t.Helper()
+	reserveIn, ok := new(big.Int).SetString(reserveInRaw, 10)
+	require.True(t, ok, "reserve in")
+	reserveOut, ok := new(big.Int).SetString(reserveOutRaw, 10)
+	require.True(t, ok, "reserve out")
+	require.Positive(t, extra.RecallCapacity1.Sign(), "output recall capacity")
+
+	headroom := new(big.Int).Sub(reserveOut, extra.WrapperBuffer1)
+	require.Positive(t, headroom.Sign(), "Pair output reserve must exceed hot wrapper backing")
+	recall := new(big.Int).Div(new(big.Int).Set(extra.RecallCapacity1), big.NewInt(2))
+	halfHeadroom := new(big.Int).Div(new(big.Int).Set(headroom), big.NewInt(2))
+	if recall.Cmp(halfHeadroom) > 0 {
+		recall = halfHeadroom
+	}
+	if recall.Sign() == 0 {
+		recall.SetInt64(1)
+	}
+	targetOut := new(big.Int).Add(extra.WrapperBuffer1, recall)
+
+	// Exact inverse of the Pair's 997/1000 formula, rounded up like Uniswap v2 getAmountIn.
+	numerator := new(big.Int).Mul(reserveIn, targetOut)
+	numerator.Mul(numerator, big.NewInt(1_000))
+	denominator := new(big.Int).Sub(reserveOut, targetOut)
+	denominator.Mul(denominator, big.NewInt(997))
+	require.Positive(t, denominator.Sign(), "recall target below Pair reserve")
+	return new(big.Int).Add(new(big.Int).Div(numerator, denominator), big.NewInt(1))
+}
+
+func verifyRecallQuote(
+	t *testing.T,
+	ctx context.Context,
+	client *ethrpc.Client,
+	simulator *PoolSimulator,
+	tokenIn string,
+	tokenOut string,
+	amountIn *big.Int,
+	limit pool.SwapLimit,
+) {
+	t.Helper()
+	result, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenIn, Amount: amountIn},
+		TokenOut:      tokenOut,
+		Limit:         limit,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(378_580), result.Gas)
+	require.True(t, result.SwapInfo.(SwapInfo).UseRecall)
+
+	var chainResult routeQuoteResult
+	_, err = client.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI: routerABI, Target: simulator.RouterAddress, Method: "routeQuote",
+		Params: []any{common.HexToAddress(tokenIn), amountIn},
+	}, []any{&chainResult}).TryBlockAndAggregate()
+	require.NoError(t, err)
+	chainQuote := chainResult.Quote
+	require.NotNil(t, chainQuote.AmountOut)
+	require.True(t, chainQuote.RecallRequired)
+	require.True(t, chainQuote.Executable)
+	require.Equal(t, chainQuote.AmountOut, result.TokenAmountOut.Amount)
+}
+
+func decodeExtra(t *testing.T, raw string) Extra {
+	t.Helper()
+	var extra Extra
+	require.NoError(t, json.Unmarshal([]byte(raw), &extra))
+	return extra
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -145,6 +145,7 @@ import (
 	pkg_liquiditysource_ramsesv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ramsesv2"
 	pkg_liquiditysource_renzo_ezeth "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/renzo/ezeth"
 	pkg_liquiditysource_ringswap "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ringswap"
+	pkg_liquiditysource_ringswapbacking "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ringswap-backing"
 	pkg_liquiditysource_rocketpool_reth "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/rocketpool/reth"
 	pkg_liquiditysource_slipstream "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/slipstream"
 	pkg_liquiditysource_smardex "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/smardex"
@@ -388,6 +389,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_ramsesv2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_renzo_ezeth.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_ringswap.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_ringswapbacking.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_rocketpool_reth.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_slipstream.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_smardex.PoolSimulator{})

--- a/pkg/pooltypes/factory_test.go
+++ b/pkg/pooltypes/factory_test.go
@@ -85,7 +85,7 @@ func TestPoolListerFactory(t *testing.T) {
 		"rocketpool-reth", "ethena-susde", "maker-savingsdai", "bancor-v21", "nomiswap-stable", "renzo-ezeth",
 		"bedrock-unieth", "puffer-pufeth", "swell-rsweth", "swell-sweth", "slipstream", "nuri-v2", "ambient",
 		"ether-vista", "maverick-v2", "lite-psm", "mkr-sky", "dai-usds", "fluid-vault-t1", "fluid-dex-t1", "usd0pp",
-		"ringswap", "generic-simple-rate", "primeeth", "staderethx", "meth", "ondo-usdy", "deltaswap-v1", "sfrxeth",
+		"ringswap", "ringswap-backing", "generic-simple-rate", "primeeth", "staderethx", "meth", "ondo-usdy", "deltaswap-v1", "sfrxeth",
 		"sfrxeth-convertor", "etherfi-vampire", "algebra-integral", "virtual-fun", "beets-ss", "swap-x-v2",
 		"etherfi-ebtc", "uniswap-v4", "sky-psm", "honey", "curve-llamma", "curve-lending", "balancer-v3-eclp", "ekubo",
 		"ekubo-v3", "erc4626", "hyeth", "brownfi", "midas", "arbera-den", "cusd", "arbera-zap", "kelp-rseth-l2",
@@ -116,7 +116,7 @@ func TestPoolTrackerFactory(t *testing.T) {
 		"rocketpool-reth", "ethena-susde", "maker-savingsdai", "bancor-v21", "nomiswap-stable", "renzo-ezeth",
 		"bedrock-unieth", "puffer-pufeth", "swell-rsweth", "swell-sweth", "slipstream", "nuri-v2", "ambient",
 		"ether-vista", "maverick-v2", "lite-psm", "mkr-sky", "dai-usds", "fluid-vault-t1", "fluid-dex-t1", "usd0pp",
-		"ringswap", "generic-simple-rate", "primeeth", "staderethx", "meth", "ondo-usdy", "deltaswap-v1", "sfrxeth",
+		"ringswap", "ringswap-backing", "generic-simple-rate", "primeeth", "staderethx", "meth", "ondo-usdy", "deltaswap-v1", "sfrxeth",
 		"sfrxeth-convertor", "etherfi-vampire", "algebra-integral", "virtual-fun", "beets-ss", "swap-x-v2",
 		"etherfi-ebtc", "uniswap-v4", "sky-psm", "honey", "curve-llamma", "curve-lending", "balancer-v3-eclp", "ekubo",
 		"ekubo-v3", "erc4626", "hyeth", "brownfi", "cusd", "kelp-rseth-l2", "unipool", "valantis-stex", "nabla", "lunarbase", "ghost"}

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -130,6 +130,7 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ramsesv2"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/renzo/ezeth"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ringswap"
+	ringswapbacking "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ringswap-backing"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/rocketpool/reth"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/slipstream"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/smardex"
@@ -345,6 +346,7 @@ type Types struct {
 	Dexalot                    string
 	GenericSimpleRate          string
 	RingSwap                   string
+	RingSwapBacking            string
 	PrimeETH                   string
 	CaliberProp                string
 	StaderETHx                 string
@@ -574,6 +576,7 @@ var (
 		Usd0PP:                     usd0pp.DexType,
 		GenericSimpleRate:          genericsimplerate.DexType,
 		RingSwap:                   ringswap.DexType,
+		RingSwapBacking:            ringswapbacking.DexType,
 		PrimeETH:                   primeeth.DexType,
 		CaliberProp:                caliberprop.DexType,
 		StaderETHx:                 staderethx.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -233,6 +233,7 @@ const (
 	ExchangeRamses                     = "ramses"
 	ExchangeRenzoEZETH                 = "renzo-ezeth"
 	ExchangeRingSwap                   = "ringswap"
+	ExchangeRingSwapBacking            = "ringswap-backing"
 	ExchangeRocketPoolRETH             = "rocketpool-reth"
 	ExchangeSafeSwap                   = "safeswap"
 	ExchangeSavingsUSDS                = "savings-usds"


### PR DESCRIPTION
## Summary

Adds `ringswap-backing`, a replacement liquidity source for an existing Ring v2 Pair whose FewToken output backing can be recalled from an ERC-4626 vault.

The source:

- exposes the underlying ERC-20 token pair while preserving the canonical Pair address and 30 bp reserve math;
- uses one block-consistent Router snapshot for Pair reserves, wrapper hot backing, and recall capacity;
- treats recall capacity only as an execution limit, never as extra AMM reserve;
- shares wrapper inventory through the swap limit and is single-use per route;
- fails closed on invalid metadata, duplicate Router/Pair configuration, and missing replacement semantics; and
- emits `SwapInfo.UseRecall` for the companion adapter.

Companion adapter draft: KyberNetwork/ks-dex-adapter-lib#7

## Verification

- `go generate ./pkg/msgpack/...` is idempotent
- targeted source, pooltypes, and msgpack tests pass
- `go test -race ./pkg/liquidity-source/ringswap-backing` passes
- targeted `go vet` passes
- local fixed-block mainnet-fork lister -> tracker -> simulator pipeline passes against an unfunded shadow deployment

Measured fixed-fork execution gas supplied by the source is 178,435/181,377 for hot WETH/USDT output and 399,312/378,580 for recall.

## Integration boundary

This is a draft for Kyber review. Production enablement requires the private backend to exclude the ordinary `ringswap` source for each configured Pair; otherwise the same reserves could be counted twice. This PR does not deploy the adapter/source, move backing, or enable execution. Historical replay currently covers 99.908382% of Pair volume for the underlying-token path; unsupported trades remain excluded rather than credited to the old source.