### PR TITLE
perf: reduce heap allocations in dodo/libv2, balancer/v2 and v3 math 

### DIFF
--- a/pkg/liquidity-source/balancer/v2/math/math.go
+++ b/pkg/liquidity-source/balancer/v2/math/math.go
@@ -62,6 +62,23 @@ func (m *math) Div(a *uint256.Int, b *uint256.Int, roundUp bool) (*uint256.Int, 
 	return m.DivDown(a, b)
 }
 
+func (m *math) DivUpInto(z, a, b *uint256.Int) error {
+	if b.IsZero() {
+		return ErrZeroDivision
+	}
+	if a.IsZero() {
+		z.Clear()
+		return nil
+	}
+
+	var tmp uint256.Int
+	tmp.SubUint64(a, 1)
+	z.Div(&tmp, b)
+	z.AddUint64(z, 1)
+
+	return nil
+}
+
 func (m *math) Min(a *uint256.Int, b *uint256.Int) *uint256.Int {
 	if a.Lt(b) {
 		return a

--- a/pkg/liquidity-source/balancer/v2/math/stable_math.go
+++ b/pkg/liquidity-source/balancer/v2/math/stable_math.go
@@ -464,46 +464,42 @@ func (l *stableMath) GetTokenBalanceGivenInvariantAndAllOtherBalances(
 		}
 	}
 
+	var bufA, bufB uint256.Int
+	bufA.Set(tokenBalance)
+	prev, next := &bufA, &bufB
+	var u, v uint256.Int
+
 	for i := 0; i < 255; i++ {
-		prevTokenBalance := tokenBalance
+		if _, overflow := u.MulOverflow(prev, prev); overflow {
+			return nil, ErrMulOverflow
+		}
+		if _, overflow := u.AddOverflow(&u, c); overflow {
+			return nil, ErrAddOverflow
+		}
 
-		// calc tokenBalance
-		{
-			u, err := Math.Mul(tokenBalance, tokenBalance)
-			if err != nil {
-				return nil, err
-			}
-			u, err = FixedPoint.Add(u, c)
-			if err != nil {
-				return nil, err
-			}
+		if _, overflow := v.MulOverflow(prev, number.Number_2); overflow {
+			return nil, ErrMulOverflow
+		}
+		if _, overflow := v.AddOverflow(&v, b); overflow {
+			return nil, ErrAddOverflow
+		}
+		if _, underflow := v.SubOverflow(&v, invariant); underflow {
+			return nil, ErrSubOverflow
+		}
 
-			v, err := Math.Mul(tokenBalance, number.Number_2)
-			if err != nil {
-				return nil, err
-			}
-			v, err = FixedPoint.Add(v, b)
-			if err != nil {
-				return nil, err
-			}
-			v, err = FixedPoint.Sub(v, invariant)
-			if err != nil {
-				return nil, err
-			}
-
-			tokenBalance, err = Math.DivUp(u, v)
-			if err != nil {
-				return nil, err
-			}
+		if err := Math.DivUpInto(next, &u, &v); err != nil {
+			return nil, err
 		}
 
 		var diff uint256.Int
-		diff.Sub(tokenBalance, prevTokenBalance)
+		diff.Sub(next, prev)
 		var delta uint256.Int
 		delta.Abs(&diff)
 		if delta.Cmp(number.Number_1) <= 0 {
-			return tokenBalance, nil
+			return new(uint256.Int).Set(next), nil
 		}
+
+		prev, next = next, prev
 	}
 
 	return nil, ErrStableGetBalanceDidntConverge

--- a/pkg/liquidity-source/balancer/v2/math/stable_math_bench_test.go
+++ b/pkg/liquidity-source/balancer/v2/math/stable_math_bench_test.go
@@ -1,0 +1,60 @@
+package math
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+)
+
+func BenchmarkGetTokenBalanceGivenInvariantAndAllOtherBalances(b *testing.B) {
+	amp := uint256.NewInt(5000)
+	balances := []*uint256.Int{
+		uint256.MustFromDecimal("9999991000000000000000"),
+		uint256.MustFromDecimal("99999910000000000056"),
+		uint256.MustFromDecimal("8897791020011100123456"),
+		uint256.MustFromDecimal("13288977911102200123456"),
+		uint256.MustFromDecimal("199791011102200123456"),
+		uint256.MustFromDecimal("1997200112156340123456"),
+	}
+	invariant, err := StableMath.CalculateInvariantV1(amp, balances, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_, err := StableMath.GetTokenBalanceGivenInvariantAndAllOtherBalances(amp, balances, invariant, 2)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCalcOutGivenIn(b *testing.B) {
+	amp := uint256.NewInt(5000)
+	balances := []*uint256.Int{
+		uint256.MustFromDecimal("9999991000000000000000"),
+		uint256.MustFromDecimal("99999910000000000056"),
+		uint256.MustFromDecimal("8897791020011100123456"),
+		uint256.MustFromDecimal("13288977911102200123456"),
+		uint256.MustFromDecimal("199791011102200123456"),
+		uint256.MustFromDecimal("1997200112156340123456"),
+	}
+	invariant, err := StableMath.CalculateInvariantV1(amp, balances, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	amountIn := uint256.MustFromDecimal("1000000000000000000")
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		bals := make([]*uint256.Int, len(balances))
+		copy(bals, balances)
+		_, err := StableMath.CalcOutGivenIn(invariant, amp, amountIn, bals, 0, 2)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/liquidity-source/balancer/v3/math/fixed_point_math.go
+++ b/pkg/liquidity-source/balancer/v3/math/fixed_point_math.go
@@ -56,6 +56,14 @@ func (f *fixPoint) DivRawUp(a, b *uint256.Int) (*uint256.Int, error) {
 	return &result, nil
 }
 
+func (f *fixPoint) DivRawUpInto(z, a, b *uint256.Int) error {
+	if b.IsZero() {
+		return ErrZeroDivision
+	}
+	v3Utils.DivRoundingUp(a, b, z)
+	return nil
+}
+
 func (f *fixPoint) PowUp(x, y *uint256.Int) (*uint256.Int, error) {
 	if y.Eq(U1e18) {
 		return x, nil

--- a/pkg/liquidity-source/balancer/v3/math/stable_math.go
+++ b/pkg/liquidity-source/balancer/v3/math/stable_math.go
@@ -145,40 +145,33 @@ func (s *stableMath) ComputeBalance(
 		return nil, err
 	}
 
-	prevTokenBalance := new(uint256.Int)
-	for i := 0; i < 255; i++ {
-		prevTokenBalance.Set(tokenBalance)
+	var bufA, bufB uint256.Int
+	bufA.Set(tokenBalance)
+	prev, next := &bufA, &bufB
 
+	for range 255 {
 		// y = (y^2 + c)/(2y + b - D)
-		numerator.Mul(tokenBalance, tokenBalance)
+		numerator.Mul(prev, prev)
 		numerator.Add(numerator, c)
 
-		denominator.Mul(tokenBalance, U2)
+		denominator.Mul(prev, U2)
 		denominator.Add(denominator, b)
 		denominator.Sub(denominator, invariant)
 
-		tokenBalance, err = FixPoint.DivRawUp(numerator, denominator)
-		if err != nil {
+		if err := FixPoint.DivRawUpInto(next, numerator, denominator); err != nil {
 			return nil, err
 		}
 
-		if tokenBalance.Gt(prevTokenBalance) {
-			mulResult, err = FixPoint.Sub(tokenBalance, prevTokenBalance)
-			if err != nil {
-				return nil, err
-			}
-			if mulResult.Cmp(U1) <= 0 {
-				return tokenBalance, nil
-			}
+		if next.Gt(prev) {
+			mulResult.SubOverflow(next, prev)
 		} else {
-			mulResult, err = FixPoint.Sub(prevTokenBalance, tokenBalance)
-			if err != nil {
-				return nil, err
-			}
-			if mulResult.Cmp(U1) <= 0 {
-				return tokenBalance, nil
-			}
+			mulResult.SubOverflow(prev, next)
 		}
+		if mulResult.Cmp(U1) <= 0 {
+			return new(uint256.Int).Set(next), nil
+		}
+
+		prev, next = next, prev
 	}
 
 	return nil, ErrStableComputeBalanceDidNotConverge

--- a/pkg/liquidity-source/balancer/v3/math/stable_math_bench_test.go
+++ b/pkg/liquidity-source/balancer/v3/math/stable_math_bench_test.go
@@ -1,0 +1,24 @@
+package math
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+)
+
+func BenchmarkStableMath_ComputeBalance(b *testing.B) {
+	amp := uint256.NewInt(200000)
+	balances := []*uint256.Int{
+		uint256.MustFromDecimal("340867122491122140643"),
+		uint256.MustFromDecimal("384610409069784884043"),
+	}
+	invariant := uint256.MustFromDecimal("725470946757739599230")
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, err := StableMath.ComputeBalance(amp, balances, invariant, 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/liquidity-source/dodo/libv2/safe_math.go
+++ b/pkg/liquidity-source/dodo/libv2/safe_math.go
@@ -60,12 +60,16 @@ func SafeAdd(a, b *uint256.Int) *uint256.Int {
 
 // SafeSqrt https://github.com/DODOEX/contractV2/blob/c58c067c4038437610a9cc8aef8f8025e2af4f63/contracts/lib/SafeMath.sol#L56
 func SafeSqrt(x *uint256.Int) *uint256.Int {
-	z := new(uint256.Int).Add(new(uint256.Int).Div(x, number.Number_2), number.Number_1)
-	y := x
-	for z.Cmp(y) < 0 {
-		y = z
-		z = new(uint256.Int).Div(new(uint256.Int).Add(new(uint256.Int).Div(x, z), z), number.Number_2)
+	var z, y, tmp uint256.Int
+	z.Div(x, number.Number_2)
+	z.Add(&z, number.Number_1)
+	y.Set(x)
+	for z.Cmp(&y) < 0 {
+		y.Set(&z)
+		tmp.Div(x, &z)
+		tmp.Add(&tmp, &z)
+		z.Div(&tmp, number.Number_2)
 	}
 
-	return y
+	return new(uint256.Int).Set(&y)
 }

--- a/pkg/liquidity-source/dodo/libv2/safe_sqrt_bench_test.go
+++ b/pkg/liquidity-source/dodo/libv2/safe_sqrt_bench_test.go
@@ -1,0 +1,18 @@
+package libv2
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+)
+
+func BenchmarkSafeSqrt(b *testing.B) {
+	x, _ := uint256.FromBig(new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil))
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		SafeSqrt(x)
+	}
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -99,6 +99,7 @@ import (
 	pkg_liquiditysource_kipseli_pamm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/kipseli/pamm"
 	pkg_liquiditysource_kipseli_prop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/kipseli/prop"
 	pkg_liquiditysource_kuruob "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/kuru-ob"
+	pkg_liquiditysource_ladder "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
 	pkg_liquiditysource_lfj_poe "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/lfj/poe"
 	pkg_liquiditysource_lglclob "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/lgl-clob"
 	pkg_liquiditysource_liquidcore "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/liquidcore"
@@ -342,6 +343,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_kipseli_pamm.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_kipseli_prop.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_kuruob.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_ladder.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_lfj_poe.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_lglclob.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_liquidcore.PoolSimulator{})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Benchmark Results

All measured with `go test -bench ... -benchmem`, using the same benchmark before and after each change, with real fixture data from each package's existing test suite.

### `dodo/libv2.SafeSqrt`
`BenchmarkSafeSqrt`

| Metric | Before | After | Delta |
|---|---|---|---|
| ns/op | 3,400 | 2,250 | -34% |
| allocs/op | 66 | 1 | -98% |
| B/op | 2,112 | 32 | -98% |

### `balancer/v2/math.GetTokenBalanceGivenInvariantAndAllOtherBalances`
`BenchmarkGetTokenBalanceGivenInvariantAndAllOtherBalances`

| Metric | Before | After | Delta |
|---|---|---|---|
| ns/op | 3,232 | 1,557 | -52% |
| allocs/op | 70 | 35 | -50% |
| B/op | 2,240 | 1,120 | -50% |

### `balancer/v2/math.CalcOutGivenIn` (actual swap path)
`BenchmarkCalcOutGivenIn`

| Metric | Before | After | Delta |
|---|---|---|---|
| ns/op | 3,080 | 2,088 | -32% |
| allocs/op | 74 | 39 | -47% |
| B/op | 2,368 | 1,248 | -47% |

### `balancer/v3/math.ComputeBalance`
`BenchmarkStableMath_ComputeBalance`

| Metric | Before | After | Delta |
|---|---|---|---|
| ns/op | 867.7 | 453.3 | -48% |
| allocs/op | 14 | 3 | -79% |
| B/op | 448 | 96 | -79% |

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
