### PR TITLE
feat: support Ekubo Ve33 pools on Robinhood

### DIFF
--- a/pkg/liquidity-source/ekubo/v3/abis/Ve33.json
+++ b/pkg/liquidity-source/ekubo/v3/abis/Ve33.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "event",
+    "name": "VoteWeightApplied",
+    "inputs": [
+      { "name": "owner", "type": "address", "indexed": false },
+      { "name": "stakeId", "type": "bytes32", "indexed": false },
+      { "name": "poolId", "type": "bytes32", "indexed": false },
+      { "name": "weight", "type": "uint128", "indexed": false },
+      { "name": "votedSwapFee", "type": "uint64", "indexed": false },
+      { "name": "swapFee", "type": "uint64", "indexed": false }
+    ],
+    "anonymous": false
+  }
+]

--- a/pkg/liquidity-source/ekubo/v3/abis/Ve33DataFetcher.json
+++ b/pkg/liquidity-source/ekubo/v3/abis/Ve33DataFetcher.json
@@ -1,9 +1,47 @@
 [
   {
     "type": "function",
-    "name": "getPoolSwapFees",
-    "inputs": [{ "name": "poolIds", "type": "bytes32[]" }],
-    "outputs": [{ "name": "swapFees", "type": "uint64[]" }],
+    "name": "getVe33QuoteData",
+    "inputs": [
+      {
+        "name": "poolKeys",
+        "type": "tuple[]",
+        "components": [
+          { "name": "token0", "type": "address" },
+          { "name": "token1", "type": "address" },
+          { "name": "config", "type": "bytes32" }
+        ]
+      },
+      { "name": "minBitmapsSearched", "type": "uint32" }
+    ],
+    "outputs": [
+      {
+        "name": "results",
+        "type": "tuple[]",
+        "components": [
+          {
+            "name": "quoteData",
+            "type": "tuple",
+            "components": [
+              { "name": "tick", "type": "int32" },
+              { "name": "sqrtRatio", "type": "uint96" },
+              { "name": "liquidity", "type": "uint128" },
+              { "name": "minTick", "type": "int32" },
+              { "name": "maxTick", "type": "int32" },
+              {
+                "name": "ticks",
+                "type": "tuple[]",
+                "components": [
+                  { "name": "number", "type": "int32" },
+                  { "name": "liquidityDelta", "type": "int128" }
+                ]
+              }
+            ]
+          },
+          { "name": "swapFee", "type": "uint64" }
+        ]
+      }
+    ],
     "stateMutability": "view"
   }
 ]

--- a/pkg/liquidity-source/ekubo/v3/abis/Ve33DataFetcher.json
+++ b/pkg/liquidity-source/ekubo/v3/abis/Ve33DataFetcher.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "function",
+    "name": "getPoolSwapFees",
+    "inputs": [{ "name": "poolIds", "type": "bytes32[]" }],
+    "outputs": [{ "name": "swapFees", "type": "uint64[]" }],
+    "stateMutability": "view"
+  }
+]

--- a/pkg/liquidity-source/ekubo/v3/abis/abis.go
+++ b/pkg/liquidity-source/ekubo/v3/abis/abis.go
@@ -14,11 +14,14 @@ var (
 	MevCaptureRouterABI       abi.ABI
 	BoostedFeesABI            abi.ABI
 	BoostedFeesDataFetcherABI abi.ABI
+	Ve33ABI                   abi.ABI
+	Ve33DataFetcherABI        abi.ABI
 
-	OrderUpdatedEvent    abi.Event
-	PositionUpdatedEvent abi.Event
-	PoolBoostedEvent     abi.Event
-	PoolInitializedEvent abi.Event
+	OrderUpdatedEvent      abi.Event
+	PositionUpdatedEvent   abi.Event
+	PoolBoostedEvent       abi.Event
+	PoolInitializedEvent   abi.Event
+	VoteWeightAppliedEvent abi.Event
 )
 
 func init() {
@@ -33,6 +36,8 @@ func init() {
 		{&MevCaptureRouterABI, mevCaptureRouterJson},
 		{&BoostedFeesABI, boostedFeesJson},
 		{&BoostedFeesDataFetcherABI, boostedFeesDataFetcherJson},
+		{&Ve33ABI, ve33Json},
+		{&Ve33DataFetcherABI, ve33DataFetcherJson},
 	}
 
 	for _, b := range builder {
@@ -47,4 +52,5 @@ func init() {
 	OrderUpdatedEvent = TwammABI.Events["OrderUpdated"]
 	PoolBoostedEvent = BoostedFeesABI.Events["PoolBoosted"]
 	PoolInitializedEvent = CoreABI.Events["PoolInitialized"]
+	VoteWeightAppliedEvent = Ve33ABI.Events["VoteWeightApplied"]
 }

--- a/pkg/liquidity-source/ekubo/v3/abis/embed.go
+++ b/pkg/liquidity-source/ekubo/v3/abis/embed.go
@@ -23,4 +23,10 @@ var (
 
 	//go:embed BoostedFeesDataFetcher.json
 	boostedFeesDataFetcherJson []byte
+
+	//go:embed Ve33.json
+	ve33Json []byte
+
+	//go:embed Ve33DataFetcher.json
+	ve33DataFetcherJson []byte
 )

--- a/pkg/liquidity-source/ekubo/v3/config.go
+++ b/pkg/liquidity-source/ekubo/v3/config.go
@@ -78,9 +78,9 @@ func (c *Config) ExtensionType(extension common.Address) ExtensionType {
 			c.MevCapture:              ExtensionTypeMevCapture,
 			c.BoostedFeesConcentrated: ExtensionTypeBoostedFeesConcentrated,
 		}
-		if c.Ve33 != (common.Address{}) {
-			c.supportedExtensions[c.Ve33] = ExtensionTypeVe33
-		}
+	}
+	if c.Ve33 != (common.Address{}) {
+		c.supportedExtensions[c.Ve33] = ExtensionTypeVe33
 	}
 
 	if extensionType, ok := c.supportedExtensions[extension]; ok {

--- a/pkg/liquidity-source/ekubo/v3/config.go
+++ b/pkg/liquidity-source/ekubo/v3/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	BoostedFeesConcentrated common.Address       `json:"boostedFeesConcentrated"`
 	QuoteDataFetcher        string               `json:"quoteDataFetcher"`
 	BoostedFeesDataFetcher  string               `json:"boostedFeesDataFetcher"`
+	Ve33                    common.Address       `json:"ve33"`
+	Ve33DataFetcher         string               `json:"ve33DataFetcher"`
 
 	supportedExtensions map[common.Address]ExtensionType
 }
@@ -75,6 +77,9 @@ func (c *Config) ExtensionType(extension common.Address) ExtensionType {
 			c.Twamm.V2.Address:        ExtensionTypeTwamm,
 			c.MevCapture:              ExtensionTypeMevCapture,
 			c.BoostedFeesConcentrated: ExtensionTypeBoostedFeesConcentrated,
+		}
+		if c.Ve33 != (common.Address{}) {
+			c.supportedExtensions[c.Ve33] = ExtensionTypeVe33
 		}
 	}
 

--- a/pkg/liquidity-source/ekubo/v3/config_test.go
+++ b/pkg/liquidity-source/ekubo/v3/config_test.go
@@ -41,3 +41,14 @@ func TestConfigSupportsVe33(t *testing.T) {
 	require.Equal(t, ExtensionTypeVe33, cfg.ExtensionType(ve33))
 	require.Equal(t, ExtensionTypeNoSwapCallPoints, cfg.ExtensionType(common.HexToAddress("0x1")))
 }
+
+func TestConfigSupportsVe33SetAfterFirstLookup(t *testing.T) {
+	t.Parallel()
+
+	ve33 := common.HexToAddress("0xd100000000000000000000000000000000000000")
+	cfg := &Config{}
+
+	require.Equal(t, ExtensionTypeNoSwapCallPoints, cfg.ExtensionType(common.HexToAddress("0x1")))
+	cfg.Ve33 = ve33
+	require.Equal(t, ExtensionTypeVe33, cfg.ExtensionType(ve33))
+}

--- a/pkg/liquidity-source/ekubo/v3/config_test.go
+++ b/pkg/liquidity-source/ekubo/v3/config_test.go
@@ -31,3 +31,13 @@ func TestConfigSupportsTwammV1AndV2(t *testing.T) {
 	require.Equal(t, "v2-data-fetcher", cfg.TwammDataFetcher(v2Twamm))
 	require.Empty(t, cfg.TwammDataFetcher(common.HexToAddress("0x1111111111111111111111111111111111111111")))
 }
+
+func TestConfigSupportsVe33(t *testing.T) {
+	t.Parallel()
+
+	ve33 := common.HexToAddress("0xd100000000000000000000000000000000000000")
+	cfg := &Config{Ve33: ve33}
+
+	require.Equal(t, ExtensionTypeVe33, cfg.ExtensionType(ve33))
+	require.Equal(t, ExtensionTypeNoSwapCallPoints, cfg.ExtensionType(common.HexToAddress("0x1")))
+}

--- a/pkg/liquidity-source/ekubo/v3/data_fetchers.go
+++ b/pkg/liquidity-source/ekubo/v3/data_fetchers.go
@@ -23,6 +23,7 @@ const (
 	quoteDataFetcherMethod              = "getQuoteData"
 	twammDataFetcherMethod              = "getPoolState"
 	boostedFeesDataFetcherMethod        = "getPoolState"
+	ve33DataFetcherMethod               = "getPoolSwapFees"
 )
 
 type (
@@ -92,7 +93,7 @@ func (f *dataFetchers) fetchPools(
 		extType ExtensionType
 	}
 
-	twammPoolKeys, boostedFeeConcentratedPoolKeys, basicPoolKeys := make([]pools.AnyPoolKey, 0), make([]pools.AnyPoolKey, 0), make([]poolKeyWithExtType, 0)
+	twammPoolKeys, boostedFeeConcentratedPoolKeys, ve33PoolKeys, basicPoolKeys := make([]pools.AnyPoolKey, 0), make([]pools.AnyPoolKey, 0), make([]pools.AnyPoolKey, 0), make([]poolKeyWithExtType, 0)
 
 	for _, key := range poolKeys {
 		extType := f.config.ExtensionType(key.Extension())
@@ -107,6 +108,8 @@ func (f *dataFetchers) fetchPools(
 			twammPoolKeys = append(twammPoolKeys, key)
 		case ExtensionTypeBoostedFeesConcentrated:
 			boostedFeeConcentratedPoolKeys = append(boostedFeeConcentratedPoolKeys, key)
+		case ExtensionTypeVe33:
+			ve33PoolKeys = append(ve33PoolKeys, key)
 		default:
 			logger.Errorf("unknown extension %v", key.Extension())
 		}
@@ -186,6 +189,79 @@ func (f *dataFetchers) fetchPools(
 					blockNumber: blockNumber,
 				},
 				poolKey,
+			})
+		}
+	}
+
+	for _, poolKeyBatch := range lo.Chunk(ve33PoolKeys, maxBatchSize) {
+		if f.config.Ve33DataFetcher == "" {
+			return nil, fmt.Errorf("missing Ve33DataFetcher for Ve33 pools")
+		}
+
+		req := f.ethrpcClient.R().SetContext(ctx)
+		if overrides != nil {
+			req.SetOverrides(overrides)
+		}
+
+		batchQuoteData := make([]quoteData, len(poolKeyBatch))
+		batchSwapFees := make([]uint64, len(poolKeyBatch))
+		poolIDs := make([]common.Hash, len(poolKeyBatch))
+		for i, poolKey := range poolKeyBatch {
+			poolID, err := poolKey.NumId()
+			if err != nil {
+				return nil, fmt.Errorf("computing Ve33 pool id: %w", err)
+			}
+			poolIDs[i] = common.BytesToHash(poolID)
+		}
+
+		req.AddCall(&ethrpc.Call{
+			ABI:    abis.QuoteDataFetcherABI,
+			Target: f.config.QuoteDataFetcher,
+			Method: quoteDataFetcherMethod,
+			Params: []any{
+				lo.Map(poolKeyBatch, func(poolKey pools.AnyPoolKey, _ int) pools.AbiPoolKey {
+					return poolKey.ToAbi()
+				}),
+				minTickSpacingsPerPool,
+			},
+		}, []any{&batchQuoteData})
+		req.AddCall(&ethrpc.Call{
+			ABI:    abis.Ve33DataFetcherABI,
+			Target: f.config.Ve33DataFetcher,
+			Method: ve33DataFetcherMethod,
+			Params: []any{poolIDs},
+		}, []any{&batchSwapFees})
+
+		resp, err := req.Aggregate()
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve quote data for Ve33 pools: %w", err)
+		}
+
+		var blockNumber uint64
+		if resp.BlockNumber != nil {
+			blockNumber = resp.BlockNumber.Uint64()
+		}
+
+		for i, poolKey := range poolKeyBatch {
+			var underlying pools.Pool
+			switch config := poolKey.Config.TypeConfig.(type) {
+			case pools.FullRangePoolTypeConfig:
+				underlying = pools.NewFullRangePool(poolKey.ToFullRange(config), newFullRangePoolState(&batchQuoteData[i]))
+			case pools.StableswapPoolTypeConfig:
+				underlying = pools.NewStableswapPool(poolKey.ToStableswap(config), newStableswapPoolState(&batchQuoteData[i]))
+			case pools.ConcentratedPoolTypeConfig:
+				underlying = pools.NewConcentratedPool(poolKey.ToConcentrated(config), newConcentratedPoolState(&batchQuoteData[i]))
+			default:
+				logger.Errorf("unexpected pool type config %T for Ve33 pool", config)
+				continue
+			}
+
+			fetchedPools = append(fetchedPools, fetchedPool{
+				PoolWithBlockNumber: PoolWithBlockNumber{
+					Pool:        pools.NewVe33Pool(underlying, batchSwapFees[i]),
+					blockNumber: blockNumber,
+				},
+				key: poolKey,
 			})
 		}
 	}

--- a/pkg/liquidity-source/ekubo/v3/data_fetchers.go
+++ b/pkg/liquidity-source/ekubo/v3/data_fetchers.go
@@ -23,7 +23,7 @@ const (
 	quoteDataFetcherMethod              = "getQuoteData"
 	twammDataFetcherMethod              = "getPoolState"
 	boostedFeesDataFetcherMethod        = "getPoolState"
-	ve33DataFetcherMethod               = "getPoolSwapFees"
+	ve33DataFetcherMethod               = "getVe33QuoteData"
 )
 
 type (
@@ -66,6 +66,11 @@ type (
 		DonateRateToken0 *big.Int                    `json:"donateRateToken0"`
 		DonateRateToken1 *big.Int                    `json:"donateRateToken1"`
 		DonateRateDeltas []boostedTimeDonateRateInfo `json:"donateRateDeltas"`
+	}
+
+	ve33QuoteData struct {
+		QuoteData quoteData `json:"quoteData"`
+		SwapFee   uint64    `json:"swapFee"`
 	}
 
 	dataFetchers struct {
@@ -203,36 +208,18 @@ func (f *dataFetchers) fetchPools(
 			req.SetOverrides(overrides)
 		}
 
-		batchQuoteData := make([]quoteData, len(poolKeyBatch))
-		batchSwapFees := make([]uint64, len(poolKeyBatch))
-		poolIDs := make([]common.Hash, len(poolKeyBatch))
-		for i, poolKey := range poolKeyBatch {
-			poolID, err := poolKey.NumId()
-			if err != nil {
-				return nil, fmt.Errorf("computing Ve33 pool id: %w", err)
-			}
-			poolIDs[i] = common.BytesToHash(poolID)
-		}
-
-		req.AddCall(&ethrpc.Call{
-			ABI:    abis.QuoteDataFetcherABI,
-			Target: f.config.QuoteDataFetcher,
-			Method: quoteDataFetcherMethod,
+		batchQuoteData := make([]ve33QuoteData, len(poolKeyBatch))
+		resp, err := req.AddCall(&ethrpc.Call{
+			ABI:    abis.Ve33DataFetcherABI,
+			Target: f.config.Ve33DataFetcher,
+			Method: ve33DataFetcherMethod,
 			Params: []any{
 				lo.Map(poolKeyBatch, func(poolKey pools.AnyPoolKey, _ int) pools.AbiPoolKey {
 					return poolKey.ToAbi()
 				}),
 				minTickSpacingsPerPool,
 			},
-		}, []any{&batchQuoteData})
-		req.AddCall(&ethrpc.Call{
-			ABI:    abis.Ve33DataFetcherABI,
-			Target: f.config.Ve33DataFetcher,
-			Method: ve33DataFetcherMethod,
-			Params: []any{poolIDs},
-		}, []any{&batchSwapFees})
-
-		resp, err := req.Aggregate()
+		}, []any{&batchQuoteData}).Aggregate()
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve quote data for Ve33 pools: %w", err)
 		}
@@ -243,14 +230,15 @@ func (f *dataFetchers) fetchPools(
 		}
 
 		for i, poolKey := range poolKeyBatch {
+			data := &batchQuoteData[i]
 			var underlying pools.Pool
 			switch config := poolKey.Config.TypeConfig.(type) {
 			case pools.FullRangePoolTypeConfig:
-				underlying = pools.NewFullRangePool(poolKey.ToFullRange(config), newFullRangePoolState(&batchQuoteData[i]))
+				underlying = pools.NewFullRangePool(poolKey.ToFullRange(config), newFullRangePoolState(&data.QuoteData))
 			case pools.StableswapPoolTypeConfig:
-				underlying = pools.NewStableswapPool(poolKey.ToStableswap(config), newStableswapPoolState(&batchQuoteData[i]))
+				underlying = pools.NewStableswapPool(poolKey.ToStableswap(config), newStableswapPoolState(&data.QuoteData))
 			case pools.ConcentratedPoolTypeConfig:
-				underlying = pools.NewConcentratedPool(poolKey.ToConcentrated(config), newConcentratedPoolState(&batchQuoteData[i]))
+				underlying = pools.NewConcentratedPool(poolKey.ToConcentrated(config), newConcentratedPoolState(&data.QuoteData))
 			default:
 				logger.Errorf("unexpected pool type config %T for Ve33 pool", config)
 				continue
@@ -258,7 +246,7 @@ func (f *dataFetchers) fetchPools(
 
 			fetchedPools = append(fetchedPools, fetchedPool{
 				PoolWithBlockNumber: PoolWithBlockNumber{
-					Pool:        pools.NewVe33Pool(underlying, batchSwapFees[i]),
+					Pool:        pools.NewVe33Pool(underlying, data.SwapFee),
 					blockNumber: blockNumber,
 				},
 				key: poolKey,

--- a/pkg/liquidity-source/ekubo/v3/data_fetchers_test.go
+++ b/pkg/liquidity-source/ekubo/v3/data_fetchers_test.go
@@ -1,0 +1,60 @@
+package ekubov3
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/abis"
+)
+
+func TestDecodeVe33QuoteData(t *testing.T) {
+	t.Parallel()
+
+	type abiTick struct {
+		Number         int32
+		LiquidityDelta *big.Int
+	}
+	type abiQuoteData struct {
+		Tick      int32
+		SqrtRatio *big.Int
+		Liquidity *big.Int
+		MinTick   int32
+		MaxTick   int32
+		Ticks     []abiTick
+	}
+	type abiVe33QuoteData struct {
+		QuoteData abiQuoteData
+		SwapFee   uint64
+	}
+
+	expected := []abiVe33QuoteData{{
+		QuoteData: abiQuoteData{
+			Tick:      7,
+			SqrtRatio: big.NewInt(11),
+			Liquidity: big.NewInt(13),
+			MinTick:   -17,
+			MaxTick:   19,
+			Ticks: []abiTick{{
+				Number:         23,
+				LiquidityDelta: big.NewInt(-29),
+			}},
+		},
+		SwapFee: 31,
+	}}
+
+	method := abis.Ve33DataFetcherABI.Methods[ve33DataFetcherMethod]
+	encoded, err := method.Outputs.Pack(expected)
+	require.NoError(t, err)
+
+	var decoded []ve33QuoteData
+	require.NoError(t, abis.Ve33DataFetcherABI.UnpackIntoInterface(
+		&decoded, ve33DataFetcherMethod, encoded,
+	))
+	require.Len(t, decoded, 1)
+	require.Equal(t, expected[0].SwapFee, decoded[0].SwapFee)
+	require.Equal(t, expected[0].QuoteData.Tick, decoded[0].QuoteData.Tick)
+	require.Equal(t, expected[0].QuoteData.SqrtRatio, decoded[0].QuoteData.SqrtRatioFloat)
+	require.Equal(t, expected[0].QuoteData.Ticks[0].LiquidityDelta, decoded[0].QuoteData.Ticks[0].LiquidityDelta)
+}

--- a/pkg/liquidity-source/ekubo/v3/event_parser.go
+++ b/pkg/liquidity-source/ekubo/v3/event_parser.go
@@ -69,7 +69,10 @@ func (e *EventParser) handleVe33Log(log types.Log) ([]string, error) {
 	}
 	values, err := abis.VoteWeightAppliedEvent.Inputs.Unpack(log.Data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"decoding VoteWeightApplied event data of length %d: %w",
+			len(log.Data), err,
+		)
 	}
 	poolID, ok := values[2].([32]byte)
 	if !ok {

--- a/pkg/liquidity-source/ekubo/v3/event_parser.go
+++ b/pkg/liquidity-source/ekubo/v3/event_parser.go
@@ -67,11 +67,16 @@ func (e *EventParser) handleVe33Log(log types.Log) ([]string, error) {
 	if len(log.Topics) == 0 || log.Topics[0] != abis.VoteWeightAppliedEvent.ID {
 		return nil, nil
 	}
-	if len(log.Data) < 96 {
-		return nil, fmt.Errorf("invalid data length for VoteWeightApplied event")
+	values, err := abis.VoteWeightAppliedEvent.Inputs.Unpack(log.Data)
+	if err != nil {
+		return nil, err
+	}
+	poolID, ok := values[2].([32]byte)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse poolId from VoteWeightApplied event data")
 	}
 
-	return []string{"0x" + common.Bytes2Hex(log.Data[64:96])}, nil
+	return []string{"0x" + common.Bytes2Hex(poolID[:])}, nil
 }
 
 func (e *EventParser) handleCoreLog(log types.Log) ([]string, error) {

--- a/pkg/liquidity-source/ekubo/v3/event_parser.go
+++ b/pkg/liquidity-source/ekubo/v3/event_parser.go
@@ -56,9 +56,22 @@ func (e *EventParser) DecodePoolAddressesFromFactoryLog(_ context.Context, log t
 		return e.handleTwammLog(log, log.Address)
 	case e.config.BoostedFeesConcentrated:
 		return e.handleBoostedFeesLog(log)
+	case e.config.Ve33:
+		return e.handleVe33Log(log)
 	default:
 		return nil, nil
 	}
+}
+
+func (e *EventParser) handleVe33Log(log types.Log) ([]string, error) {
+	if len(log.Topics) == 0 || log.Topics[0] != abis.VoteWeightAppliedEvent.ID {
+		return nil, nil
+	}
+	if len(log.Data) < 96 {
+		return nil, fmt.Errorf("invalid data length for VoteWeightApplied event")
+	}
+
+	return []string{"0x" + common.Bytes2Hex(log.Data[64:96])}, nil
 }
 
 func (e *EventParser) handleCoreLog(log types.Log) ([]string, error) {

--- a/pkg/liquidity-source/ekubo/v3/event_parser_test.go
+++ b/pkg/liquidity-source/ekubo/v3/event_parser_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/abis"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/pools"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/test"
 )
@@ -119,4 +120,23 @@ func TestEventParserDecodeBoostedFees(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, logByAddress[expectedPoolAddress])
+}
+
+func TestEventParserDecodeVoteWeightApplied(t *testing.T) {
+	t.Parallel()
+
+	ve33 := common.HexToAddress("0xd100000000000000000000000000000000000000")
+	parser := &EventParser{config: &Config{Ve33: ve33}}
+	poolID := common.HexToHash("0x1234")
+	data := make([]byte, 192)
+	copy(data[64:96], poolID[:])
+
+	poolAddresses, err := parser.DecodePoolAddressesFromFactoryLog(context.Background(), types.Log{
+		Address: ve33,
+		Topics:  []common.Hash{abis.VoteWeightAppliedEvent.ID},
+		Data:    data,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{poolID.Hex()}, poolAddresses)
 }

--- a/pkg/liquidity-source/ekubo/v3/extension_type.go
+++ b/pkg/liquidity-source/ekubo/v3/extension_type.go
@@ -7,6 +7,7 @@ const (
 	ExtensionTypeTwamm
 	ExtensionTypeMevCapture
 	ExtensionTypeBoostedFeesConcentrated
+	ExtensionTypeVe33
 )
 
 type ExtensionType int

--- a/pkg/liquidity-source/ekubo/v3/pool_tracker.go
+++ b/pkg/liquidity-source/ekubo/v3/pool_tracker.go
@@ -168,6 +168,12 @@ func (d *PoolTracker) applyLogs(params pool.GetNewPoolStateParams, pool *PoolWit
 			} else {
 				continue
 			}
+		case d.config.Ve33:
+			if len(log.Topics) > 0 && log.Topics[0] == abis.VoteWeightAppliedEvent.ID {
+				event = pools.EventVoteWeightApplied
+			} else {
+				continue
+			}
 		default:
 			continue
 		}

--- a/pkg/liquidity-source/ekubo/v3/pools/events.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/events.go
@@ -21,6 +21,7 @@ const (
 	EventOrderUpdated
 	EventFeesDonated
 	EventPoolBoosted
+	EventVoteWeightApplied
 )
 
 type (

--- a/pkg/liquidity-source/ekubo/v3/pools/ve33.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/ve33.go
@@ -1,0 +1,126 @@
+package pools
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/holiman/uint256"
+
+	ekubomath "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/math"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/quoting"
+)
+
+type (
+	Ve33PoolState[S any] struct {
+		UnderlyingPoolState S      `json:"underlyingPoolState"`
+		SwapFee             uint64 `json:"swapFee"`
+	}
+
+	Ve33Pool struct {
+		Pool
+		swapFee uint64
+	}
+)
+
+func (p *Ve33Pool) GetKey() IPoolKey {
+	return p.Pool.GetKey()
+}
+
+func (p *Ve33Pool) GetState() any {
+	return NewVe33PoolState(p.Pool.GetState(), p.swapFee)
+}
+
+func (p *Ve33Pool) CloneSwapStateOnly() Pool {
+	cloned := *p
+	cloned.Pool = p.Pool.CloneSwapStateOnly()
+	return &cloned
+}
+
+func (p *Ve33Pool) SetSwapState(state quoting.SwapState) {
+	p.Pool.SetSwapState(state)
+}
+
+func (p *Ve33Pool) ApplyEvent(event Event, data []byte, blockTimestamp uint64) error {
+	if event != EventVoteWeightApplied {
+		return p.Pool.ApplyEvent(event, data, blockTimestamp)
+	}
+
+	swapFee, matches, err := parseVoteWeightAppliedEventIfMatching(data, p.GetKey())
+	if err != nil {
+		return err
+	}
+	if matches {
+		p.swapFee = swapFee
+	}
+	return nil
+}
+
+func (p *Ve33Pool) NewBlock() {
+	p.Pool.NewBlock()
+}
+
+func (p *Ve33Pool) Quote(amount *uint256.Int, isToken1 bool) (*quoting.Quote, error) {
+	quote, err := p.Pool.Quote(amount, isToken1)
+	if err != nil {
+		return nil, err
+	}
+
+	quote.SwapInfo.Forward = ptr(p.GetKey().Extension())
+	quote.Gas += quoting.ExtraBaseGasCostOfOneVe33Swap
+
+	if p.swapFee == 0 || quote.CalculatedAmount.IsZero() {
+		return quote, nil
+	}
+
+	if amount.Sign() >= 0 {
+		fee := ekubomath.ComputeFee(quote.CalculatedAmount, p.swapFee)
+		quote.CalculatedAmount.Sub(quote.CalculatedAmount, fee)
+		quote.FeesPaid.Add(quote.FeesPaid, fee)
+	} else {
+		includingFee, err := ekubomath.AmountBeforeFee(quote.CalculatedAmount, p.swapFee)
+		if err != nil {
+			return nil, fmt.Errorf("amount before Ve33 fee: %w", err)
+		}
+		fee := new(uint256.Int).Sub(includingFee, quote.CalculatedAmount)
+		quote.CalculatedAmount = includingFee
+		quote.FeesPaid.Add(quote.FeesPaid, fee)
+	}
+
+	return quote, nil
+}
+
+func (p *Ve33Pool) CalcBalances() ([]uint256.Int, error) {
+	return p.Pool.CalcBalances()
+}
+
+func NewVe33PoolState[S any](underlyingPoolState S, swapFee uint64) *Ve33PoolState[S] {
+	return &Ve33PoolState[S]{
+		UnderlyingPoolState: underlyingPoolState,
+		SwapFee:             swapFee,
+	}
+}
+
+func NewVe33Pool(underlyingPool Pool, swapFee uint64) *Ve33Pool {
+	return &Ve33Pool{Pool: underlyingPool, swapFee: swapFee}
+}
+
+func parseVoteWeightAppliedEventIfMatching(data []byte, poolKey IPoolKey) (uint64, bool, error) {
+	if len(data) < 192 {
+		return 0, false, fmt.Errorf("invalid VoteWeightApplied event data length: %d", len(data))
+	}
+
+	expectedPoolID, err := poolKey.NumId()
+	if err != nil {
+		return 0, false, fmt.Errorf("computing expected pool id: %w", err)
+	}
+	if !bytes.Equal(data[64:96], expectedPoolID) {
+		return 0, false, nil
+	}
+
+	return binary.BigEndian.Uint64(data[184:192]), true, nil
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/liquidity-source/ekubo/v3/pools/ve33.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/ve33.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 
 	ekubomath "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/math"
@@ -19,7 +20,8 @@ type (
 
 	Ve33Pool struct {
 		Pool
-		swapFee uint64
+		extension common.Address
+		swapFee   uint64
 	}
 )
 
@@ -66,7 +68,7 @@ func (p *Ve33Pool) Quote(amount *uint256.Int, isToken1 bool) (*quoting.Quote, er
 		return nil, err
 	}
 
-	quote.SwapInfo.Forward = ptr(p.GetKey().Extension())
+	quote.SwapInfo.Forward = &p.extension
 	quote.Gas += quoting.ExtraBaseGasCostOfOneVe33Swap
 
 	if p.swapFee == 0 || quote.CalculatedAmount.IsZero() {
@@ -102,7 +104,11 @@ func NewVe33PoolState[S any](underlyingPoolState S, swapFee uint64) *Ve33PoolSta
 }
 
 func NewVe33Pool(underlyingPool Pool, swapFee uint64) *Ve33Pool {
-	return &Ve33Pool{Pool: underlyingPool, swapFee: swapFee}
+	return &Ve33Pool{
+		Pool:      underlyingPool,
+		extension: underlyingPool.GetKey().Extension(),
+		swapFee:   swapFee,
+	}
 }
 
 func parseVoteWeightAppliedEventIfMatching(data []byte, poolKey IPoolKey) (uint64, bool, error) {
@@ -119,8 +125,4 @@ func parseVoteWeightAppliedEventIfMatching(data []byte, poolKey IPoolKey) (uint6
 	}
 
 	return binary.BigEndian.Uint64(data[184:192]), true, nil
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/pkg/liquidity-source/ekubo/v3/pools/ve33.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/ve33.go
@@ -25,6 +25,14 @@ type (
 	}
 )
 
+const (
+	abiWordSize                        = 32
+	voteWeightAppliedPoolIDOffset      = 2 * abiWordSize
+	voteWeightAppliedSwapFeeWord       = 5
+	voteWeightAppliedSwapFeeOffset     = (voteWeightAppliedSwapFeeWord+1)*abiWordSize - 8
+	voteWeightAppliedEncodedDataLength = 6 * abiWordSize
+)
+
 func (p *Ve33Pool) GetKey() IPoolKey {
 	return p.Pool.GetKey()
 }
@@ -84,9 +92,10 @@ func (p *Ve33Pool) Quote(amount *uint256.Int, isToken1 bool) (*quoting.Quote, er
 		if err != nil {
 			return nil, fmt.Errorf("amount before Ve33 fee: %w", err)
 		}
-		fee := new(uint256.Int).Sub(includingFee, quote.CalculatedAmount)
+		var fee uint256.Int
+		fee.Sub(includingFee, quote.CalculatedAmount)
 		quote.CalculatedAmount = includingFee
-		quote.FeesPaid.Add(quote.FeesPaid, fee)
+		quote.FeesPaid.Add(quote.FeesPaid, &fee)
 	}
 
 	return quote, nil
@@ -112,7 +121,7 @@ func NewVe33Pool(underlyingPool Pool, swapFee uint64) *Ve33Pool {
 }
 
 func parseVoteWeightAppliedEventIfMatching(data []byte, poolKey IPoolKey) (uint64, bool, error) {
-	if len(data) < 192 {
+	if len(data) < voteWeightAppliedEncodedDataLength {
 		return 0, false, fmt.Errorf("invalid VoteWeightApplied event data length: %d", len(data))
 	}
 
@@ -120,9 +129,11 @@ func parseVoteWeightAppliedEventIfMatching(data []byte, poolKey IPoolKey) (uint6
 	if err != nil {
 		return 0, false, fmt.Errorf("computing expected pool id: %w", err)
 	}
-	if !bytes.Equal(data[64:96], expectedPoolID) {
+	poolID := data[voteWeightAppliedPoolIDOffset : voteWeightAppliedPoolIDOffset+abiWordSize]
+	if !bytes.Equal(poolID, expectedPoolID) {
 		return 0, false, nil
 	}
 
-	return binary.BigEndian.Uint64(data[184:192]), true, nil
+	swapFee := data[voteWeightAppliedSwapFeeOffset : voteWeightAppliedSwapFeeOffset+8]
+	return binary.BigEndian.Uint64(swapFee), true, nil
 }

--- a/pkg/liquidity-source/ekubo/v3/pools/ve33_test.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/ve33_test.go
@@ -39,11 +39,16 @@ func TestVe33PoolExactInputTakesFeeFromOutput(t *testing.T) {
 	t.Parallel()
 
 	pool := newVe33FullRangePool(t, onePercentVe33Fee)
-	quote, err := pool.Quote(uint256.NewInt(1_000), false)
+	amount := uint256.NewInt(1_000)
+	quote, err := pool.Quote(amount, false)
 	require.NoError(t, err)
 
 	require.Equal(t, "989", quote.CalculatedAmount.String())
 	require.Equal(t, pool.GetKey().Extension(), *quote.SwapInfo.Forward)
+	firstForward := quote.SwapInfo.Forward
+	quote, err = pool.Quote(amount, false)
+	require.NoError(t, err)
+	require.Same(t, firstForward, quote.SwapInfo.Forward)
 }
 
 func TestVe33PoolExactOutputGrossesUpInput(t *testing.T) {

--- a/pkg/liquidity-source/ekubo/v3/pools/ve33_test.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/ve33_test.go
@@ -74,9 +74,12 @@ func TestVe33PoolAppliesVoteWeightEvent(t *testing.T) {
 	poolID, err := pool.GetKey().NumId()
 	require.NoError(t, err)
 
-	data := make([]byte, 192)
-	copy(data[64:96], poolID)
-	binary.BigEndian.PutUint64(data[184:192], onePercentVe33Fee)
+	data := make([]byte, voteWeightAppliedEncodedDataLength)
+	copy(data[voteWeightAppliedPoolIDOffset:voteWeightAppliedPoolIDOffset+abiWordSize], poolID)
+	binary.BigEndian.PutUint64(
+		data[voteWeightAppliedSwapFeeOffset:voteWeightAppliedSwapFeeOffset+8],
+		onePercentVe33Fee,
+	)
 	require.NoError(t, pool.ApplyEvent(EventVoteWeightApplied, data, 0))
 
 	state := pool.GetState().(*Ve33PoolState[any])

--- a/pkg/liquidity-source/ekubo/v3/pools/ve33_test.go
+++ b/pkg/liquidity-source/ekubo/v3/pools/ve33_test.go
@@ -1,0 +1,79 @@
+package pools
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	ekubomath "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/math"
+)
+
+const onePercentVe33Fee = uint64((uint64(1) << 63) / 50)
+
+func newVe33FullRangePool(t *testing.T, swapFee uint64) *Ve33Pool {
+	t.Helper()
+
+	key := NewPoolKey(
+		common.HexToAddress("0x1"),
+		common.HexToAddress("0x2"),
+		NewPoolConfig(
+			common.HexToAddress("0xd100000000000000000000000000000000000000"),
+			0,
+			NewFullRangePoolTypeConfig(),
+		),
+	)
+	underlying := NewFullRangePool(
+		key,
+		NewFullRangePoolState(
+			NewFullRangePoolSwapState(new(uint256.Int).Lsh(uint256.NewInt(1), 128)),
+			uint256.NewInt(1_000_000),
+		),
+	)
+	return NewVe33Pool(underlying, swapFee)
+}
+
+func TestVe33PoolExactInputTakesFeeFromOutput(t *testing.T) {
+	t.Parallel()
+
+	pool := newVe33FullRangePool(t, onePercentVe33Fee)
+	quote, err := pool.Quote(uint256.NewInt(1_000), false)
+	require.NoError(t, err)
+
+	require.Equal(t, "989", quote.CalculatedAmount.String())
+	require.Equal(t, pool.GetKey().Extension(), *quote.SwapInfo.Forward)
+}
+
+func TestVe33PoolExactOutputGrossesUpInput(t *testing.T) {
+	t.Parallel()
+
+	withoutFee := newVe33FullRangePool(t, 0)
+	underlyingQuote, err := withoutFee.Quote(new(uint256.Int).Neg(uint256.NewInt(500)), false)
+	require.NoError(t, err)
+
+	withFee := newVe33FullRangePool(t, onePercentVe33Fee)
+	quote, err := withFee.Quote(new(uint256.Int).Neg(uint256.NewInt(500)), false)
+	require.NoError(t, err)
+
+	expected, err := ekubomath.AmountBeforeFee(underlyingQuote.CalculatedAmount, onePercentVe33Fee)
+	require.NoError(t, err)
+	require.Equal(t, expected, quote.CalculatedAmount)
+}
+
+func TestVe33PoolAppliesVoteWeightEvent(t *testing.T) {
+	t.Parallel()
+
+	pool := newVe33FullRangePool(t, 0)
+	poolID, err := pool.GetKey().NumId()
+	require.NoError(t, err)
+
+	data := make([]byte, 192)
+	copy(data[64:96], poolID)
+	binary.BigEndian.PutUint64(data[184:192], onePercentVe33Fee)
+	require.NoError(t, pool.ApplyEvent(EventVoteWeightApplied, data, 0))
+
+	state := pool.GetState().(*Ve33PoolState[any])
+	require.Equal(t, onePercentVe33Fee, state.SwapFee)
+}

--- a/pkg/liquidity-source/ekubo/v3/pools_list_updater.go
+++ b/pkg/liquidity-source/ekubo/v3/pools_list_updater.go
@@ -116,13 +116,17 @@ func (u *PoolListUpdater) getNewPoolKeys(ctx context.Context) ([]pools.AnyPoolKe
 	for {
 		req := graphql.NewRequest(subgraphQuery)
 		req.Var("startId", cursor.id)
-		req.Var("extensions", []common.Address{
+		extensions := []common.Address{
 			u.config.Oracle,
 			u.config.Twamm.V1.Address,
 			u.config.Twamm.V2.Address,
 			u.config.MevCapture,
 			u.config.BoostedFeesConcentrated,
-		})
+		}
+		if u.config.Ve33 != (common.Address{}) {
+			extensions = append(extensions, u.config.Ve33)
+		}
+		req.Var("extensions", extensions)
 
 		var res struct {
 			PoolInitializations []poolInitialization `json:"poolInitializations"`

--- a/pkg/liquidity-source/ekubo/v3/quoting/gas.go
+++ b/pkg/liquidity-source/ekubo/v3/quoting/gas.go
@@ -34,4 +34,7 @@ const (
 	GasCostOfExecutingVirtualDonations     = 6_814
 	GasCostOfCrossingOneVirtualDonateDelta = 4_271
 	GasCostOfBoostedFeesFeeAccumulation    = 19_279
+
+	// Ve33
+	ExtraBaseGasCostOfOneVe33Swap = 30_000
 )

--- a/pkg/liquidity-source/ekubo/v3/unmarshal.go
+++ b/pkg/liquidity-source/ekubo/v3/unmarshal.go
@@ -53,23 +53,37 @@ func unmarshalPool(extraBytes []byte, staticExtra *StaticExtra) (pools.Pool, err
 				poolKey,
 				twammState,
 			)
+		case ExtensionTypeVe33:
+			state, err := unmarshalExtra[pools.Ve33PoolState[*pools.FullRangePoolState]](extraBytes)
+			if err != nil {
+				return nil, fmt.Errorf("parsing Ve33 full range pool state: %w", err)
+			}
+
+			pool = pools.NewVe33Pool(
+				pools.NewFullRangePool(poolKey, state.UnderlyingPoolState),
+				state.SwapFee,
+			)
 		default:
 			return nil, fmt.Errorf("unknown extension type %v for full range pool", staticExtra.ExtensionType)
 		}
 	case pools.StableswapPoolTypeConfig:
-		if staticExtra.ExtensionType != ExtensionTypeNoSwapCallPoints {
+		poolKey := staticExtra.PoolKey.ToStableswap(config)
+		switch staticExtra.ExtensionType {
+		case ExtensionTypeNoSwapCallPoints:
+			stableswapState, err := unmarshalExtra[pools.StableswapPoolState](extraBytes)
+			if err != nil {
+				return nil, fmt.Errorf("parsing stableswap pool state: %w", err)
+			}
+			pool = pools.NewStableswapPool(poolKey, stableswapState)
+		case ExtensionTypeVe33:
+			state, err := unmarshalExtra[pools.Ve33PoolState[*pools.StableswapPoolState]](extraBytes)
+			if err != nil {
+				return nil, fmt.Errorf("parsing Ve33 stableswap pool state: %w", err)
+			}
+			pool = pools.NewVe33Pool(pools.NewStableswapPool(poolKey, state.UnderlyingPoolState), state.SwapFee)
+		default:
 			return nil, fmt.Errorf("unknown extension type %v for stableswap pool", staticExtra.ExtensionType)
 		}
-
-		stableswapState, err := unmarshalExtra[pools.StableswapPoolState](extraBytes)
-		if err != nil {
-			return nil, fmt.Errorf("parsing stableswap pool state: %w", err)
-		}
-
-		pool = pools.NewStableswapPool(
-			staticExtra.PoolKey.ToStableswap(config),
-			stableswapState,
-		)
 	case pools.ConcentratedPoolTypeConfig:
 		poolKey := staticExtra.PoolKey.ToConcentrated(config)
 
@@ -101,6 +115,16 @@ func unmarshalPool(extraBytes []byte, staticExtra *StaticExtra) (pools.Pool, err
 			}
 
 			pool = pools.NewBoostedFeesPool(poolKey, state)
+		case ExtensionTypeVe33:
+			state, err := unmarshalExtra[pools.Ve33PoolState[*pools.ConcentratedPoolState]](extraBytes)
+			if err != nil {
+				return nil, fmt.Errorf("parsing Ve33 concentrated pool state: %w", err)
+			}
+
+			pool = pools.NewVe33Pool(
+				pools.NewConcentratedPool(poolKey, state.UnderlyingPoolState),
+				state.SwapFee,
+			)
 		default:
 			return nil, fmt.Errorf("unknown extension type %v for concentrated pool", staticExtra.ExtensionType)
 		}

--- a/pkg/liquidity-source/ekubo/v3/unmarshal_test.go
+++ b/pkg/liquidity-source/ekubo/v3/unmarshal_test.go
@@ -11,33 +11,70 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/pools"
 )
 
-func TestUnmarshalVe33FullRangePool(t *testing.T) {
+func TestUnmarshalVe33Pools(t *testing.T) {
 	t.Parallel()
 
 	const swapFee = uint64(123)
 	ve33 := common.HexToAddress("0xd100000000000000000000000000000000000000")
-	key := pools.AnyPoolKey{PoolKey: pools.NewPoolKey(
-		common.HexToAddress("0x1"),
-		common.HexToAddress("0x2"),
-		pools.NewPoolConfig(ve33, 0, pools.PoolTypeConfig(pools.NewFullRangePoolTypeConfig())),
-	)}
-	state := pools.NewVe33PoolState(
-		pools.NewFullRangePoolState(
-			pools.NewFullRangePoolSwapState(new(uint256.Int).Lsh(uint256.NewInt(1), 128)),
-			uint256.NewInt(1_000_000),
-		),
-		swapFee,
-	)
-	extra, err := json.Marshal(state)
-	require.NoError(t, err)
 
-	pool, err := unmarshalPool(extra, &StaticExtra{
-		ExtensionType: ExtensionTypeVe33,
-		PoolKey:       key,
-	})
-	require.NoError(t, err)
+	tests := []struct {
+		name       string
+		typeConfig pools.PoolTypeConfig
+		state      any
+	}{
+		{
+			name:       "full range",
+			typeConfig: pools.NewFullRangePoolTypeConfig(),
+			state: pools.NewFullRangePoolState(
+				pools.NewFullRangePoolSwapState(new(uint256.Int).Lsh(uint256.NewInt(1), 128)),
+				uint256.NewInt(1_000_000),
+			),
+		},
+		{
+			name:       "stableswap",
+			typeConfig: pools.NewStableswapPoolTypeConfig(0, 1),
+			state: pools.NewStableswapPoolState(
+				pools.NewStableswapPoolSwapState(new(uint256.Int).Lsh(uint256.NewInt(1), 128)),
+				uint256.NewInt(1_000_000),
+			),
+		},
+		{
+			name:       "concentrated",
+			typeConfig: pools.NewConcentratedPoolTypeConfig(1),
+			state: pools.NewConcentratedPoolState(
+				pools.NewConcentratedPoolSwapState(
+					new(uint256.Int).Lsh(uint256.NewInt(1), 128),
+					uint256.NewInt(1_000_000),
+					0,
+				),
+				[]pools.Tick{},
+				[2]int32{-10, 10},
+				0,
+			),
+		},
+	}
 
-	roundTrip, err := json.Marshal(pool.GetState())
-	require.NoError(t, err)
-	require.JSONEq(t, string(extra), string(roundTrip))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			key := pools.AnyPoolKey{PoolKey: pools.NewPoolKey(
+				common.HexToAddress("0x1"),
+				common.HexToAddress("0x2"),
+				pools.NewPoolConfig(ve33, 0, tt.typeConfig),
+			)}
+			extra, err := json.Marshal(pools.NewVe33PoolState(tt.state, swapFee))
+			require.NoError(t, err)
+
+			pool, err := unmarshalPool(extra, &StaticExtra{
+				ExtensionType: ExtensionTypeVe33,
+				PoolKey:       key,
+			})
+			require.NoError(t, err)
+
+			roundTrip, err := json.Marshal(pool.GetState())
+			require.NoError(t, err)
+			require.JSONEq(t, string(extra), string(roundTrip))
+		})
+	}
 }

--- a/pkg/liquidity-source/ekubo/v3/unmarshal_test.go
+++ b/pkg/liquidity-source/ekubo/v3/unmarshal_test.go
@@ -1,0 +1,43 @@
+package ekubov3
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ekubo/v3/pools"
+)
+
+func TestUnmarshalVe33FullRangePool(t *testing.T) {
+	t.Parallel()
+
+	const swapFee = uint64(123)
+	ve33 := common.HexToAddress("0xd100000000000000000000000000000000000000")
+	key := pools.AnyPoolKey{PoolKey: pools.NewPoolKey(
+		common.HexToAddress("0x1"),
+		common.HexToAddress("0x2"),
+		pools.NewPoolConfig(ve33, 0, pools.PoolTypeConfig(pools.NewFullRangePoolTypeConfig())),
+	)}
+	state := pools.NewVe33PoolState(
+		pools.NewFullRangePoolState(
+			pools.NewFullRangePoolSwapState(new(uint256.Int).Lsh(uint256.NewInt(1), 128)),
+			uint256.NewInt(1_000_000),
+		),
+		swapFee,
+	)
+	extra, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	pool, err := unmarshalPool(extra, &StaticExtra{
+		ExtensionType: ExtensionTypeVe33,
+		PoolKey:       key,
+	})
+	require.NoError(t, err)
+
+	roundTrip, err := json.Marshal(pool.GetState())
+	require.NoError(t, err)
+	require.JSONEq(t, string(extra), string(roundTrip))
+}


### PR DESCRIPTION
## Why did we need it?

Ekubo Ve33 pools use the normal Ekubo V3 pool curves but move swap fees into the Ve33 extension. The fee is a dynamic Q64 value selected through voting, so treating these pools as ordinary zero-fee Ekubo pools overquotes output.

This change:

- recognizes a configured Ve33 extension when listing Ekubo pools
- supports full-range, stableswap, and concentrated Ve33 pools
- atomically batch-loads Core quote state and current Ve33 fees through `getVe33QuoteData`
- applies `VoteWeightApplied` logs to keep the fee current
- preserves Ve33 state through pool serialization and reconstruction

### Pricing logic

The wrapper first quotes the underlying zero-core-fee pool. For exact input it computes the fee from the calculated output and subtracts it. For exact output it computes `amountBeforeFee` from the calculated input. This matches [Ve33.sol](https://github.com/EkuboProtocol/evm-contracts/blob/main/src/extensions/Ve33.sol) and the [Ekubo Rust SDK quoter](https://github.com/EkuboProtocol/rust-sdk/blob/main/src/quoting/pools/ve33.rs).

### Contracts and configuration

- target network: Robinhood, chain ID 4663
- Ve33 contract: `0xD18685a514E59b06d59824e16Db07e73345d9953`, supplied through the Ekubo DEX configuration as `ve33`
- Ve33DataFetcher: `0x61F03754b1c7A7F0E584FD8869c00Ba898ab888d`, supplied as `ve33DataFetcher`
- merged lens ABI: [EkuboProtocol/evm-contracts#360](https://github.com/EkuboProtocol/evm-contracts/pull/360)

No Ve33 behavior is enabled when the configured address is zero. The deterministic addresses above are deployed on Robinhood mainnet and testnet and must be supplied by the consuming application.

## Related Issue

No linked issue.

## Release Note

Consumers enabling Ve33 must configure both `ve33` and `ve33DataFetcher`. Existing Ekubo configurations remain unchanged.

## How Has This Been Tested?

- `go test ./pkg/liquidity-source/ekubo/v3/...`
- added exact-input, exact-output, fee-event, configuration, event-parser, nested ABI tuple decode, and JSON round-trip tests

A full `go test ./...` sweep was also attempted; unrelated live-RPC integration tests were rate-limited with HTTP 429 responses.
