### PR TITLE
fix/liquidcore pool discovery abort

### DIFF
--- a/pkg/liquidity-source/liquidcore/pool_list_updater.go
+++ b/pkg/liquidity-source/liquidcore/pool_list_updater.go
@@ -63,33 +63,45 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 	metadata.LastCount, metadata.LastPoolsChecksum = len(poolAddrs), poolsChecksum
 
 	pools := make([]entity.Pool, 0, len(poolAddrs))
-	for _, poolAddr := range poolAddrs {
-		addr := hexutil.Encode(poolAddr[:])
-
-		var tokenResp struct {
-			Token0, Token1 common.Address
-		}
-		if _, err := u.ethrpcClient.NewRequest().SetContext(ctx).
-			AddCall(&ethrpc.Call{
+	if len(poolAddrs) > 0 {
+		tokenResps := make([]struct{ Token0, Token1 common.Address }, len(poolAddrs))
+		req := u.ethrpcClient.NewRequest().SetContext(ctx)
+		for i, poolAddr := range poolAddrs {
+			req.AddCall(&ethrpc.Call{
 				ABI:    poolABI,
-				Target: addr,
-				Method: "getTokens"}, []any{&tokenResp}).
-			Call(); err != nil {
+				Target: hexutil.Encode(poolAddr[:]),
+				Method: "getTokens",
+			}, []any{&tokenResps[i]})
+		}
+		// TryAggregate (not Call/Aggregate) so one dead/reverting pool
+		// address from the router's getPools() list doesn't abort discovery
+		// of every other pool -- and, since GetNewPools only persists
+		// metadataBytes on a fully successful return, doesn't get every
+		// subsequent run stuck retrying the same broken address forever.
+		resp, err := req.TryAggregate()
+		if err != nil {
 			return nil, nil, err
 		}
 
-		pools = append(pools, entity.Pool{
-			Address:   addr,
-			Exchange:  u.config.DexId,
-			Type:      DexType,
-			Timestamp: time.Now().Unix(),
-			Reserves:  []string{"0", "0"},
-			Tokens: []*entity.PoolToken{
-				{Address: hexutil.Encode(tokenResp.Token0[:]), Swappable: true},
-				{Address: hexutil.Encode(tokenResp.Token1[:]), Swappable: true},
-			},
-			Extra: "{}",
-		})
+		for i, poolAddr := range poolAddrs {
+			if !resp.Result[i] {
+				l.Warn().Str("pool", hexutil.Encode(poolAddr[:])).Msg("skipping pool: getTokens call failed")
+				continue
+			}
+
+			pools = append(pools, entity.Pool{
+				Address:   hexutil.Encode(poolAddr[:]),
+				Exchange:  u.config.DexId,
+				Type:      DexType,
+				Timestamp: time.Now().Unix(),
+				Reserves:  []string{"0", "0"},
+				Tokens: []*entity.PoolToken{
+					{Address: hexutil.Encode(tokenResps[i].Token0[:]), Swappable: true},
+					{Address: hexutil.Encode(tokenResps[i].Token1[:]), Swappable: true},
+				},
+				Extra: "{}",
+			})
+		}
 	}
 
 	l.Info().Int("count", len(pools)).Msg("finished getting new pools")

--- a/pkg/liquidity-source/liquidcore/pool_list_updater.go
+++ b/pkg/liquidity-source/liquidcore/pool_list_updater.go
@@ -44,11 +44,23 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		}
 	}
 
-	var poolAddrs []common.Address
+	var rawPoolAddrs []common.Address
 	if _, err := u.ethrpcClient.NewRequest().SetContext(ctx).
-		AddCall(&ethrpc.Call{ABI: routerABI, Target: u.config.Router, Method: "getPools"}, []any{&poolAddrs}).
+		AddCall(&ethrpc.Call{ABI: routerABI, Target: u.config.Router, Method: "getPools"}, []any{&rawPoolAddrs}).
 		Call(); err != nil {
 		return nil, nil, err
+	}
+	// getPools can contain zero-address entries (e.g. unset/cleared array
+	// slots). A call to the zero address has no code, so the multicall
+	// still reports success (a call to a no-code address never reverts) --
+	// only the ABI-unpack of its empty returndata fails, which the
+	// TryAggregate result flag below can't see -- so filter these out here
+	// rather than relying on that check alone.
+	poolAddrs := make([]common.Address, 0, len(rawPoolAddrs))
+	for _, addr := range rawPoolAddrs {
+		if addr != (common.Address{}) {
+			poolAddrs = append(poolAddrs, addr)
+		}
 	}
 
 	var poolsChecksum common.Address
@@ -84,7 +96,8 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 		}
 
 		for i, poolAddr := range poolAddrs {
-			if !resp.Result[i] {
+			tokenResp := tokenResps[i]
+			if !resp.Result[i] || tokenResp.Token0 == (common.Address{}) || tokenResp.Token1 == (common.Address{}) {
 				l.Warn().Str("pool", hexutil.Encode(poolAddr[:])).Msg("skipping pool: getTokens call failed")
 				continue
 			}
@@ -96,8 +109,8 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 				Timestamp: time.Now().Unix(),
 				Reserves:  []string{"0", "0"},
 				Tokens: []*entity.PoolToken{
-					{Address: hexutil.Encode(tokenResps[i].Token0[:]), Swappable: true},
-					{Address: hexutil.Encode(tokenResps[i].Token1[:]), Swappable: true},
+					{Address: hexutil.Encode(tokenResp.Token0[:]), Swappable: true},
+					{Address: hexutil.Encode(tokenResp.Token1[:]), Swappable: true},
 				},
 				Extra: "{}",
 			})


### PR DESCRIPTION
- **fix: don't abort liquidcore pool discovery when one pool's getTokens fails**
- **fix: filter zero-address pools out of liquidcore pool discovery**
