### PR TITLE
feat: register parityswap-v2 and parityswap-v3 (faithful Uniswap V2/V3 forks on Robinhood Chain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Register `parityswap-v2` and `parityswap-v3` (faithful Uniswap V2/V3 forks, reusing the `uniswapv2`/`uniswapv3` liquidity sources) on Robinhood Chain.
 - Integrate `nadswap` (nadfun-contract-v2 DEX) on Monad. Supports meme-token pairs with asymmetric quote-token fee model and general pairs with LP-only constant-product math.
 - Integrate `ghost` (cross-collateral router) on Ethereum, Arbitrum, and Base. Supports directional stablecoin pairs with a linear-then-capped input fee and a target-side reserve limit.
 

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -210,6 +210,8 @@ const (
 	ExchangePandaFun                   = "panda-fun"
 	ExchangePantherSwap                = "pantherswap"
 	ExchangeParallelParallelizer       = "parallel-parallelizer"
+	ExchangeParitySwapV2               = "parityswap-v2"
+	ExchangeParitySwapV3               = "parityswap-v3"
 	ExchangePharaoh2                   = "pharaoh-2"
 	ExchangePlatypus                   = "platypus"
 	ExchangePmm1                       = "pmm-1"


### PR DESCRIPTION
## What

Registers two new exchange constants — `parityswap-v2` and `parityswap-v3` — for **ParitySwap**, a faithful Uniswap V2 + Uniswap V3 fork live on **Robinhood Chain (4663)**, which is already supported by the aggregator (`ChainIDRobinhood` in `pkg/valueobject/chain.go`, and `uniswapv3` already routes on it).

## Why constants-only

ParitySwap's swap math, events, and every external interface are **identical to canonical Uniswap V2/V3** — both exchanges can reuse the existing `uniswapv2` / `uniswapv3` liquidity sources as-is. No new pool type is introduced, so there are no `pkg/pooltypes` or msgpack changes, and no `ks-dex-adapter-lib` work (standard pool swap interfaces).

The only behavioral difference vs canonical Uniswap is a protocol-fee carve-out **inside the LP share** of the swap fee (V3: `feeProtocol = 68`, i.e. 25% of the LP fee to the factory owner, set at pool init; V2: `feeTo` enabled, 1/6 of the fee via mint). Output amounts and quoting are unaffected — pool-level pricing is exactly stock Uniswap.

## Source config (for wiring)

**`parityswap-v2`** (`uniswapv2` source):

| Field | Value |
|---|---|
| chain | `robinhood` (4663) |
| factoryAddress | `0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9` (deploy block 14320587) |
| fee / feePrecision | `3` / `1000` (standard 0.30%) |
| pair init code hash | `0xba351f4ba1c8cfdc46c3bafe1d0551666a333d5789a6909480a32bb486ba0c8c` (non-canonical) |

**`parityswap-v3`** (`uniswapv3` source):

| Field | Value |
|---|---|
| chain | `robinhood` (4663) |
| factory | `0xd479E71C45aEB1E846A7B549c346D62fE77B39bA` (deploy block 14320075) |
| subgraphAPI | `https://subgraph.parityswap.io/subgraphs/name/v3-robinhood-mainnet` (standard Uniswap V3 schema, synced to head, no indexing errors) |
| tickLensAddress | `0x1Ebc7388232b338Be9e94A813eBc303D1A7e43e0` |
| fee tiers | 500 / 3000 / 10000 (standard tick spacings 10 / 60 / 200) |
| pool init code hash | `0x18332d3ae5703e695a0f01aa77d9c7aa38e67787ed1b2983a1954b9ddbba47f7` (non-canonical) |

A standard-schema V2 subgraph is also available: `https://subgraph.parityswap.io/subgraphs/name/v2-robinhood-mainnet`.

## Contracts & evidence

All contracts are source-verified on Blockscout (`https://robinhoodchain.blockscout.com`):

- V3 factory: https://robinhoodchain.blockscout.com/address/0xd479E71C45aEB1E846A7B549c346D62fE77B39bA
- V3 SwapRouter: `0x44e613593d7CC00164D790f2636aC2e2ED7dd292` · QuoterV2: `0xbF30bD8567628Dc4E120b7536d051EaFaA3fD0fa` · NonfungiblePositionManager: `0x882c2b0e16ddcB3A09Cc6C6EFCbEf5a31914932C`
- V2 factory: https://robinhoodchain.blockscout.com/address/0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9
- V2 Router02: `0x8bc3ce37f87d5F3Ca1DcD4D86c0EcbC6039e3B17`

Reference pools (WETH `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` / USDG `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168`):

- V3 WETH/USDG 0.30%: `0x12eEe2FAF5d447203fe371e564Bd884D8Aa3A679` — CREATE2-derivable from the factory + init hash above; sample swap from 2026-07-22: https://robinhoodchain.blockscout.com/tx/0x1969739c2c7621c1001a208bb30a8ab7f70e4178aec2a7fd4b26db7ec006b20c
- V2 WETH/USDG: `0xC5C960Aaaf36119C9dE74E693fCc500c88B491ad`

ParitySwap focuses on long-tail pairs on Robinhood Chain (including official Robinhood stock tokens) that currently have no other routing venue, so integration expands quotable coverage rather than competing on already-served pairs.

- App: https://app.parityswap.io
- DexScreener: pools auto-tracked (dexId = the V3 factory address)
- DefiLlama: `parityswap` TVL adapter (merged)

## Notes for reviewers

- The init code hashes differ from canonical Uniswap (deliberate fork provenance) — relevant only if pool addresses are CREATE2-derived rather than read from factory events/subgraph.
- No fee-on-transfer tokens in our listed pairs; no hooks; no custom router requirements.
- Happy to provide anything else that speeds up review: additional sample transactions, fixtures, or quote comparisons vs QuoterV2.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
