### PR TITLE
feat: add x layer chain (eip155:196)

### DIFF
--- a/pkg/valueobject/chain.go
+++ b/pkg/valueobject/chain.go
@@ -47,6 +47,7 @@ const (
 	ChainIDMegaETH         ChainID = 4326
 	ChainIDRise            ChainID = 4153
 	ChainIDRobinhood       ChainID = 4663
+	ChainIDXLayer          ChainID = 196
 
 	// ChainIDSolana is currently used in case of store price to db, that we should transform token addr into lowercase or not.
 	ChainIDSolana ChainID = 0
@@ -93,6 +94,7 @@ var ChainNameMap = map[ChainID]string{
 	ChainIDMegaETH:         "megaeth",
 	ChainIDRise:            "rise",
 	ChainIDRobinhood:       "robinhood",
+	ChainIDXLayer:          "xlayer",
 
 	ChainIDSolana: "solana",
 }

--- a/pkg/valueobject/wrapped_native.go
+++ b/pkg/valueobject/wrapped_native.go
@@ -50,6 +50,7 @@ var WrappedNativeMap = map[ChainID]string{
 	ChainIDMegaETH:         "0x4200000000000000000000000000000000000006",
 	ChainIDRise:            "0x4200000000000000000000000000000000000006",
 	ChainIDRobinhood:       "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+	ChainIDXLayer:          "0xe538905cf8410324e03A5A23C1c177a474D59b2b",
 }
 
 // LowerWrapped returns lowercase wrapped token string


### PR DESCRIPTION
## Summary

Adds X Layer (`eip155:196`) to `pkg/valueobject` so the chain is routable — enables the PRINTR bonding-curve liquidity source (already merged in `9a2e00ba`) to be configured on X Layer.

## Changes

- `chain.go`: `ChainIDXLayer = 196` const + `ChainNameMap` entry `"xlayer"`
- `wrapped_native.go`: `WrappedNativeMap` entry — WOKB `0xe538905cf8410324e03A5A23C1c177a474D59b2b`

## Notes

- Native token is OKB (18 decimals); wrapped native is WOKB.
- No per-DEX constants added (no Uniswap V4 / Curve deployment wired here) — this is the base chain registration.

## Test plan

- [x] `go build ./pkg/valueobject/...`
- [x] `go vet ./pkg/valueobject/...`