### PR TITLE
feat(uniswap-v4): add GetNewPoolStateWithOverrides for backrun sims

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/goccy/go-json"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
@@ -123,6 +124,11 @@ type HookParam struct {
 	HookExtra   HookExtra
 	HookAddress common.Address
 	BlockNumber *big.Int
+	// Overrides carries eth_call state overrides (e.g. post-victim-tx prestate) so a hook's
+	// Track/GetReserves RPC reads can be re-priced against pending-block state rather than the
+	// latest on-chain state. Threaded through by PoolTracker.GetNewPoolStateWithOverrides; nil
+	// in the normal-flow (GetNewPoolState) path.
+	Overrides map[common.Address]gethclient.OverrideAccount
 }
 
 type HookExtra json.RawMessage

--- a/pkg/liquidity-source/uniswap/v4/hooks/angstrom/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/angstrom/hook.go
@@ -67,7 +67,7 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 	var extra HookExtra
 	_ = param.HookExtra.Unmarshal(&extra)
 
-	req := param.RpcClient.NewRequest().SetContext(ctx)
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetOverrides(param.Overrides)
 	if param.BlockNumber != nil {
 		req.SetBlockNumber(param.BlockNumber)
 	}

--- a/pkg/liquidity-source/uniswap/v4/hooks/angstrom/hook_l2.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/angstrom/hook_l2.go
@@ -49,7 +49,8 @@ func (h *L2Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.Ra
 			ProtocolSwapFeeE6 uint32
 		}
 	}
-	if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).AddCall(&ethrpc.Call{
+	if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 		ABI:    hookABI,
 		Target: hexutil.Encode(param.HookAddress[:]),
 		Method: "getPoolFeeConfiguration",

--- a/pkg/liquidity-source/uniswap/v4/hooks/arrakis/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/arrakis/hook.go
@@ -40,7 +40,7 @@ var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv
 
 func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
 	var feesData FeesDataRPC
-	if _, err := param.RpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+	if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 		ABI:    hookABI,
 		Target: hexutil.Encode(param.HookAddress[:]),
 		Method: "getFeesData",

--- a/pkg/liquidity-source/uniswap/v4/hooks/clanker/dynamic_fee_hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/clanker/dynamic_fee_hook.go
@@ -123,7 +123,8 @@ func (h *DynamicFeeHook) Track(ctx context.Context, param *uniswapv4.HookParam) 
 		info      TokenDeploymentInfo
 	)
 
-	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).AddCall(&ethrpc.Call{
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 		ABI:    dynamicFeeHookABI,
 		Target: hook,
 		Method: "protocolFee",

--- a/pkg/liquidity-source/uniswap/v4/hooks/clanker/static_fee_hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/clanker/static_fee_hook.go
@@ -44,7 +44,8 @@ func (h *StaticFeeHook) Track(ctx context.Context, param *uniswapv4.HookParam) (
 	token0 := common.HexToAddress(param.Pool.Tokens[0].Address)
 
 	var info TokenDeploymentInfo
-	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).AddCall(&ethrpc.Call{
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 		ABI:    dynamicFeeHookABI,
 		Target: hook,
 		Method: "protocolFee",

--- a/pkg/liquidity-source/uniswap/v4/hooks/livo/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/livo/hook.go
@@ -58,7 +58,8 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 		}
 	)
 
-	if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).AddCall(&ethrpc.Call{
+	if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 		ABI:    ILivoTokenABI,
 		Target: tokenAddress,
 		Method: "graduated",

--- a/pkg/liquidity-source/uniswap/v4/hooks/nft_strategy/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/nft_strategy/hook.go
@@ -39,7 +39,7 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 
 	var deploymentBlock int64
 	hookAddr := hexutil.Encode(param.HookAddress[:])
-	resp, err := param.RpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+	resp, err := param.RpcClient.NewRequest().SetContext(ctx).SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 		ABI:    hookABI,
 		Target: hookAddr,
 		Method: "deploymentBlock",

--- a/pkg/liquidity-source/uniswap/v4/pool_tracker.go
+++ b/pkg/liquidity-source/uniswap/v4/pool_tracker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/goccy/go-json"
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"
@@ -59,8 +60,13 @@ func NewPoolTracker(
 // Track (e.g. the auto-detect hook's calibration, which sizes its probe
 // amounts off Pool.Reserves) would otherwise observe the pool's stale
 // pre-refresh reserves.
+// overrides carries eth_call state overrides (e.g. post-victim-tx prestate) and is threaded
+// into the slot0/liquidity request as well as hookParam.Overrides, so the hook's own Track
+// (dynamic-fee config, oracle state, ...) run later by resolveHookState observes the same
+// overridden state. It is nil on the normal-flow (GetNewPoolState) path.
 func (t *PoolTracker) fetchOnchainState(
 	ctx context.Context, p *entity.Pool, blockNumber uint64,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) (*FetchRPCResult, Hook, *HookParam, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
@@ -77,13 +83,13 @@ func (t *PoolTracker) fetchOnchainState(
 		hookAddress = staticExtra.HooksAddress
 	}
 
-	hookParam := &HookParam{Cfg: t.config, RpcClient: t.ethrpcClient, Pool: p}
+	hookParam := &HookParam{Cfg: t.config, RpcClient: t.ethrpcClient, Pool: p, Overrides: overrides}
 	hook, _ := GetHook(hookAddress, hookParam)
 
 	result := &FetchRPCResult{
 		TickSpacing: staticExtra.TickSpacing,
 	}
-	rpcRequests := t.ethrpcClient.NewRequest().SetContext(ctx)
+	rpcRequests := t.ethrpcClient.NewRequest().SetContext(ctx).SetOverrides(overrides)
 	if blockNumber > 0 {
 		rpcRequests.SetBlockNumber(big.NewInt(int64(blockNumber)))
 	}
@@ -174,7 +180,7 @@ func (t *PoolTracker) BootstrapPoolState(
 	g := pool.New().WithContext(ctx)
 	g.Go(func(context.Context) error {
 		var err error
-		rpcData, hook, hookParam, err = t.fetchOnchainState(ctx, &p, 0)
+		rpcData, hook, hookParam, err = t.fetchOnchainState(ctx, &p, 0, nil)
 		if err != nil {
 			l.WithFields(logger.Fields{
 				"error": err,
@@ -260,7 +266,24 @@ func (t *PoolTracker) BootstrapPoolState(
 }
 
 func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param poolpkg.GetNewPoolStateParams) (entity.Pool, error) {
-	ticksBasedPool, err := t.newTicksBasedPool(ctx, p, param.Logs)
+	return t.getNewPoolState(ctx, p, param.Logs, param.BlockHeaders, nil)
+}
+
+// GetNewPoolStateWithOverrides behaves like GetNewPoolState but reads all base pool state
+// (slot0, liquidity, ticks) AND each hook's own state (dynamic-fee config, oracle/volatility
+// data, ...) under the given eth_call state overrides (e.g. a pending tx's post-victim
+// prestate), so the fee/config recomputed from the resulting Extra reflects that overridden
+// state rather than the latest on-chain state. BlockHeaders is not threaded through since the
+// override path isn't driven by a historical log window.
+func (t *PoolTracker) GetNewPoolStateWithOverrides(ctx context.Context, p entity.Pool,
+	params poolpkg.GetNewPoolStateWithOverridesParams) (entity.Pool, error) {
+	return t.getNewPoolState(ctx, p, params.Logs, nil, params.Overrides)
+}
+
+func (t *PoolTracker) getNewPoolState(ctx context.Context, p entity.Pool, logs []ethtypes.Log,
+	blockHeaders map[uint64]entity.BlockHeader, overrides map[common.Address]gethclient.OverrideAccount,
+) (entity.Pool, error) {
+	ticksBasedPool, err := t.newTicksBasedPool(ctx, p, logs, overrides)
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"address":  p.Address,
@@ -269,7 +292,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
+	return t.updateState(ctx, p, ticksBasedPool, logs, blockHeaders, overrides)
 }
 
 // getPoolTicks
@@ -465,7 +488,7 @@ func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity
 		return p, nil
 	}
 
-	refetchedTicks, err := t.queryRPCTicksByIndexes(ctx, p.Address, ticksToRefetch, p.BlockNumber)
+	refetchedTicks, err := t.queryRPCTicksByIndexes(ctx, p.Address, ticksToRefetch, p.BlockNumber, nil)
 	if err != nil {
 		return entity.Pool{}, err
 	}
@@ -510,6 +533,7 @@ func (t *PoolTracker) newTicksBasedPool(
 	ctx context.Context,
 	p entity.Pool,
 	logs []ethtypes.Log,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) (tickspkg.TicksBasedPool, error) {
 	l := logger.WithFields(logger.Fields{
 		"address":  p.Address,
@@ -524,7 +548,7 @@ func (t *PoolTracker) newTicksBasedPool(
 		return ticksBasedPool, err
 	}
 
-	ticks, err := t.fetchTicksFromLogs(ctx, p.Address, logs)
+	ticks, err := t.fetchTicksFromLogs(ctx, p.Address, logs, overrides)
 	if err != nil {
 		l.WithFields(logger.Fields{
 			"error": err,
@@ -549,7 +573,7 @@ func (t *PoolTracker) newTicksBasedPool(
 			"numTicks": len(ticksBasedPool.Ticks),
 		}).Info("fetch all ticks for pool")
 
-		ticks, err = t.fetchAllTicksForPool(ctx, ticksBasedPool, ticks)
+		ticks, err = t.fetchAllTicksForPool(ctx, ticksBasedPool, ticks, overrides)
 		if err != nil {
 			l.WithFields(logger.Fields{
 				"error": err,
@@ -577,6 +601,7 @@ func (t *PoolTracker) fetchTicksFromLogs(
 	ctx context.Context,
 	address string,
 	logs []ethtypes.Log,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) ([]tickspkg.Tick, error) {
 	l := logger.WithFields(logger.Fields{
 		"address": address,
@@ -600,7 +625,7 @@ func (t *PoolTracker) fetchTicksFromLogs(
 
 	blockNumber := eth.GetBlockNumberFromLogs(logs)
 
-	return t.queryRPCTicksByIndexes(ctx, address, tickIndexes, blockNumber)
+	return t.queryRPCTicksByIndexes(ctx, address, tickIndexes, blockNumber, overrides)
 }
 
 // getTickIndexesFromLogs returns all tick indexes from logs.
@@ -642,9 +667,10 @@ func (t *PoolTracker) getTickIndexesFromLogs(logs []ethtypes.Log) ([]int, error)
 // If `blockNumber` == 0, it returns the latest ticks data.
 func (t *PoolTracker) queryRPCTicksByIndexes(
 	ctx context.Context, address string, tickIndexes []int, blockNumber uint64,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) ([]tickspkg.Tick, error) {
 	if len(tickIndexes) <= tickChunkSize {
-		return t.queryRPCTicksByChunk(ctx, address, tickIndexes, blockNumber)
+		return t.queryRPCTicksByChunk(ctx, address, tickIndexes, blockNumber, overrides)
 	}
 
 	totalTicks := len(tickIndexes)
@@ -652,7 +678,7 @@ func (t *PoolTracker) queryRPCTicksByIndexes(
 	for i := 0; i < totalTicks; i += tickChunkSize {
 		toIdx := min(i+tickChunkSize, totalTicks)
 
-		newTicks, err := t.queryRPCTicksByChunk(ctx, address, tickIndexes[i:toIdx], blockNumber)
+		newTicks, err := t.queryRPCTicksByChunk(ctx, address, tickIndexes[i:toIdx], blockNumber, overrides)
 		if err != nil {
 			return nil, err
 		}
@@ -666,10 +692,12 @@ func (t *PoolTracker) queryRPCTicksByIndexes(
 // queryRPCTicksByChunk returns univ4 Ticks data.
 func (t *PoolTracker) queryRPCTicksByChunk(
 	ctx context.Context, addr string, ticks []int, blockNumber uint64,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) ([]tickspkg.Tick, error) {
 	tickResponses := make([]TicksResp, len(ticks))
 	ticksRequest := t.ethrpcClient.NewRequest()
 	ticksRequest.SetContext(ctx)
+	ticksRequest.SetOverrides(overrides)
 	if blockNumber > 0 {
 		var blockNumberBI big.Int
 		blockNumberBI.SetUint64(blockNumber)
@@ -697,7 +725,7 @@ func (t *PoolTracker) queryRPCTicksByChunk(
 	if _, err := ticksRequest.Aggregate(); err != nil {
 		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
 			// Re-query ticks data with latest block number
-			return t.queryRPCTicksByChunk(ctx, addr, ticks, 0)
+			return t.queryRPCTicksByChunk(ctx, addr, ticks, 0, overrides)
 		}
 
 		logger.WithFields(logger.Fields{
@@ -722,6 +750,7 @@ func (t *PoolTracker) fetchAllTicksForPool(
 	ctx context.Context,
 	pool tickspkg.TicksBasedPool,
 	ticksFromLogs []tickspkg.Tick,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) ([]tickspkg.Tick, error) {
 	isTickFromLogs := map[int]struct{}{}
 	lo.ForEach(ticksFromLogs, func(item tickspkg.Tick, index int) {
@@ -735,7 +764,7 @@ func (t *PoolTracker) fetchAllTicksForPool(
 		}
 	}
 
-	ticksFromPool, err := t.queryRPCTicksByIndexes(ctx, pool.Address, tickIdsFromPool, pool.BlockNumber)
+	ticksFromPool, err := t.queryRPCTicksByIndexes(ctx, pool.Address, tickIdsFromPool, pool.BlockNumber, overrides)
 	if err != nil {
 		return nil, err
 	}
@@ -757,6 +786,7 @@ func (t *PoolTracker) updateState(
 	ticksBasedPool tickspkg.TicksBasedPool,
 	logs []ethtypes.Log,
 	blockHeaders map[uint64]entity.BlockHeader,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
@@ -783,10 +813,10 @@ func (t *PoolTracker) updateState(
 		return entityPoolTicks[i].Index < entityPoolTicks[j].Index
 	})
 
-	rpcState, hook, hookParam, err := t.fetchOnchainState(ctx, &p, blockNumber)
+	rpcState, hook, hookParam, err := t.fetchOnchainState(ctx, &p, blockNumber, overrides)
 	if err != nil {
 		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, hook, hookParam, err = t.fetchOnchainState(ctx, &p, 0)
+			rpcState, hook, hookParam, err = t.fetchOnchainState(ctx, &p, 0, overrides)
 			if err != nil {
 				l.WithFields(logger.Fields{
 					"error": err,


### PR DESCRIPTION
## Summary

Dex-lib half of enabling correctly backrun-priced Uniswap v4 dynamic-fee hook pools (clanker/arrakis/nft-strategy/livo) in dexdex-arb. These hooks' fee/config state is **not** in the `PoolManager` `Swap` logs, so a normal log-driven `GetNewPoolState` refresh can't recover it — dexdex-arb needs to re-derive it via `eth_call` under state overrides built from the pending tx's post-victim prestate.

Mirrors the just-merged `algebra-integral` `GetNewPoolStateWithOverrides` pattern:
- `PoolTracker.GetNewPoolState` now delegates to a shared `getNewPoolState(ctx, p, logs, blockHeaders, overrides)`, called with `overrides == nil` — **normal-flow behavior is unchanged**.
- New `PoolTracker.GetNewPoolStateWithOverrides(ctx, p, pool.GetNewPoolStateWithOverridesParams{Logs, Overrides})` satisfies `pool.IPoolTrackerWithOverrides` (duck-typed, no registration needed — same as every other tracker in the repo).
- Overrides are threaded into every price-relevant RPC read: `fetchOnchainState`'s slot0/liquidity request, and the tick reads (`fetchTicksFromLogs` → `queryRPCTicksByIndexes` → `queryRPCTicksByChunk`, plus the `fetchAllTicksForPool` fallback), all via `ethrpc.Request.SetOverrides(overrides)`.
- `HookParam` gains an `Overrides map[common.Address]gethclient.OverrideAccount` field, set by `fetchOnchainState` and consumed by `resolveHookState` when it calls `hook.Track`/`hook.GetReserves` — no change to the `Hook` interface itself (`Track`/`GetReserves` signatures are unchanged), so all ~20 existing hooks keep compiling untouched.

## Hook wiring status

Hooks that fetch **price-affecting** state via their own `Track` RPC call now honor `param.Overrides`:

| Hook | File | State threaded |
|---|---|---|
| clanker (dynamic fee) | `hooks/clanker/dynamic_fee_hook.go` | `protocolFee`, `poolConfigVars`, `poolFeeVars` |
| clanker (static fee) | `hooks/clanker/static_fee_hook.go` | `protocolFee`, `<name>Fee`, `pairedFee` |
| arrakis | `hooks/arrakis/hook.go` | `getFeesData` |
| nft_strategy | `hooks/nft_strategy/hook.go` | `deploymentBlock`, `fee`, `calculateFee` |
| livo | `hooks/livo/hook.go` | `graduated`, `getTaxConfig` |
| angstrom (mainnet + L2) | `hooks/angstrom/hook.go`, `hook_l2.go` | `extsload` unlocked-fee slot / `getPoolFeeConfiguration` |

All six use the same `param.RpcClient.NewRequest()...SetOverrides(param.Overrides)` shape — the pattern is uniform, so angstrom was included even though (per the task's caveat) its `BeforeSwap` still fails closed on stale attestation age regardless of state overrides (attestations come from an in-process `AttestationController` subscription, not from `Track`'s RPC call), so this only helps its LP-fee slot, not the attestation gate.

Hooks that don't fetch price-affecting state via RPC in `Track` (or have no `Track` RPC call at all) were left untouched — no scope for overrides there.

## Test plan

- [x] `go build ./...` — green
- [x] `gofmt -l` — clean
- [x] `golangci-lint run ./pkg/liquidity-source/uniswap/v4/...` — no issues
- [x] `CI=1 go test ./pkg/liquidity-source/uniswap/v4/...` — 203/203 passed
- [x] `go test ./pkg/liquidity-source/uniswap/v4/...` (live RPC/subgraph tests) — same 6 pre-existing failures reproduced on a clean `origin/main` worktree (network/API-key/live-RPC dependent: `TestPoolTracker_GetNewPoolState` needs a subgraph API key, `TestPoolTracker_GetTickFromStateView`/clanker/bunni-v2 tests hit live RPC endpoints unreachable from this sandbox) — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)