### PR TITLE
feat(angle-transmuter): thread overrides into GetNewPoolStateWithOverrides (was a no-op stub)

### DIFF
--- a/pkg/liquidity-source/angle-transmuter/pool_tracker.go
+++ b/pkg/liquidity-source/angle-transmuter/pool_tracker.go
@@ -29,6 +29,8 @@ type PoolTracker struct {
 	ethrpcClient *ethrpc.Client
 }
 
+var _ pool.IPoolTrackerWithOverrides = (*PoolTracker)(nil)
+
 type DecodedOracleConfig struct {
 	OracleType      uint8
 	TargetType      uint8
@@ -129,6 +131,13 @@ func (t *PoolTracker) GetNewPoolState(
 	return t.getNewPoolState(ctx, p, params, nil)
 }
 
+// GetNewPoolStateWithOverrides behaves like GetNewPoolState but reads the
+// transmuter's collateral/fee state and oracle feeds (Chainlink/Pyth/Morpho)
+// under the given state overrides. Angle Transmuter is oracle-priced: fees and
+// mint/burn prices depend on oracle reads made fresh at call time, not on
+// values carried in swap logs, so a log-only fold cannot recover them. Reading
+// them under the pending tx's post-victim prestate override yields the correct
+// post-victim price state for backrun sims.
 func (t *PoolTracker) GetNewPoolStateWithOverrides(
 	ctx context.Context,
 	p entity.Pool,
@@ -141,10 +150,10 @@ func (t *PoolTracker) getNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
 	_ pool.GetNewPoolStateParams,
-	_ map[common.Address]gethclient.OverrideAccount,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) (entity.Pool, error) {
 	var collateralList []common.Address
-	if _, err := t.ethrpcClient.NewRequest().SetContext(ctx).
+	if _, err := t.ethrpcClient.NewRequest().SetContext(ctx).SetOverrides(overrides).
 		AddCall(&ethrpc.Call{
 			ABI:    transmuterABI,
 			Target: t.config.Transmuter,
@@ -160,7 +169,7 @@ func (t *PoolTracker) getNewPoolState(
 	collateralBalances := make([]*big.Int, len(collateralList))
 	var totalStablecoinIssued *big.Int
 
-	calls := t.ethrpcClient.NewRequest().SetContext(ctx)
+	calls := t.ethrpcClient.NewRequest().SetContext(ctx).SetOverrides(overrides)
 	for i, collateral := range collateralList {
 		collateralInfo[i] = &CollateralInfo{}
 		calls.AddCall(&ethrpc.Call{
@@ -237,7 +246,7 @@ func (t *PoolTracker) getNewPoolState(
 		make([]*uint256.Int, len(collateralList)), // target
 	}
 
-	calls = t.ethrpcClient.NewRequest().SetContext(ctx)
+	calls = t.ethrpcClient.NewRequest().SetContext(ctx).SetOverrides(overrides)
 	for i, collat := range oracleConfigs {
 		configs := []struct {
 			typ  OracleReadType


### PR DESCRIPTION
## Summary

`GetNewPoolStateWithOverrides` on `angle-transmuter`'s `PoolTracker` was a broken stub: it forwarded `params.Overrides` into `getNewPoolState`, but `getNewPoolState`'s signature discarded that parameter (`_ map[common.Address]gethclient.OverrideAccount`) and never threaded it into any of its 3 `ethrpc.NewRequest()` call chains via `.SetOverrides(...)`. The net effect: the method silently returned the **current confirmed (pre-victim) on-chain state** instead of the **post-victim prestate state** — wiring a backrun path against this dex would look like it worked while actually reading stale state.

This fixes it by:
- Renaming the discarded param to `overrides` and threading `.SetOverrides(overrides)` into all three request chains in `getNewPoolState`:
  - the `getCollateralList` call
  - the per-collateral batch (`getCollateralInfo` / `getOracle` / `getIssuedByCollateral` / `getStablecoinCap` / ERC20 `balanceOf`)
  - the oracle feed reads (Chainlink `latestRoundData`, Pyth `getPriceUnsafe`, Morpho `price`)
- Adding the `var _ pool.IPoolTrackerWithOverrides = (*PoolTracker)(nil)` interface assertion (was missing).
- `GetNewPoolState` (the plain entry point) keeps passing `nil`, so normal flow is unchanged — `SetOverrides(nil)` is a no-op.

Angle Transmuter is oracle-priced (Chainlink/Pyth/Morpho reads at call time, not derived from swap logs), so reading those oracle values **fresh under the victim's prestate override** is exactly what makes the "cách 1" (RPC + stateOverride) backrun approach correct for this dex — a log-only fold cannot recover fee/price state that depends on live oracle reads.

Same mechanical pattern as the merged mooniswap (#1562-equivalent commit `9f445fe0`), algebra-integral, and uniswap-v4 override PRs.

Unblocks cách-1 backrun handling for `parallel-parallelizer` and `angle-transmuter-eur`/`angle-transmuter-usd` in dexdex-arb/reserve-taker, which already list these exchanges in `stateDiffDexes` but currently have no working override handler in dex-lib to back that config.

## Test plan

- [x] `gofmt -l` on the changed file: empty
- [x] `go build ./pkg/liquidity-source/angle-transmuter/...`: success
- [x] `go vet ./pkg/liquidity-source/angle-transmuter/...`: no issues
- [x] `golangci-lint run ./pkg/liquidity-source/angle-transmuter/...`: no issues
- [x] `go test ./pkg/liquidity-source/angle-transmuter/...`: 24 passed (existing pool-simulator tests; no tracker-level test existed before, none broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)