### PR TITLE
feat(curve/llamma): add GetNewPoolStateWithOverrides for backrun sims (covers curve-lending too)

### DIFF
--- a/pkg/liquidity-source/curve/lending/pool_tracker.go
+++ b/pkg/liquidity-source/curve/lending/pool_tracker.go
@@ -2,7 +2,14 @@ package lending
 
 import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/curve/llamma"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
 )
 
 var _ = pooltrack.RegisterFactoryCE0(DexType, llamma.NewPoolTracker)
+
+// curve-lending registers llamma.NewPoolTracker directly (it has no PoolTracker type of
+// its own), so it inherits llamma.PoolTracker.GetNewPoolStateWithOverrides for free. This
+// assertion documents that curve-lending trackers satisfy pool.IPoolTrackerWithOverrides
+// too.
+var _ pool.IPoolTrackerWithOverrides = (*llamma.PoolTracker)(nil)

--- a/pkg/liquidity-source/curve/llamma/pool_tracker.go
+++ b/pkg/liquidity-source/curve/llamma/pool_tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/KyberNetwork/logger"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
 
@@ -25,6 +26,8 @@ type PoolTracker struct {
 }
 
 var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+var _ poolpkg.IPoolTrackerWithOverrides = (*PoolTracker)(nil)
 
 func NewPoolTracker(
 	config *Config,
@@ -44,6 +47,30 @@ func (t *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
 	_ poolpkg.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	return t.getNewPoolState(ctx, p, nil)
+}
+
+// GetNewPoolStateWithOverrides behaves like GetNewPoolState but reads the llamma pool's
+// state - including price_oracle(), which the pool derives from an external oracle
+// contract read live at call time - under the given state overrides. The llamma ABI has
+// no swap/band events to fold from logs, so a log-only path cannot recover this state;
+// reading it fresh under the pending tx's post-victim prestate override is the only way
+// to get the correct post-victim price/band state for backrun sims. curve/lending
+// registers this same PoolTracker directly (llamma.NewPoolTracker), so it inherits this
+// method for free.
+func (t *PoolTracker) GetNewPoolStateWithOverrides(
+	ctx context.Context,
+	p entity.Pool,
+	params poolpkg.GetNewPoolStateWithOverridesParams,
+) (entity.Pool, error) {
+	return t.getNewPoolState(ctx, p, params.Overrides)
+}
+
+func (t *PoolTracker) getNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) (entity.Pool, error) {
 	lg := t.logger.WithFields(logger.Fields{"poolAddress": p.Address})
 	lg.Info("Start updating state...")
@@ -67,7 +94,7 @@ func (t *PoolTracker) GetNewPoolState(
 		balances = make([]*big.Int, 2)
 	)
 
-	calls := t.ethrpcClient.NewRequest().SetContext(ctx).SetFrom(shared.AddrDummy).AddCall(&ethrpc.Call{
+	calls := t.ethrpcClient.NewRequest().SetContext(ctx).SetFrom(shared.AddrDummy).SetOverrides(overrides).AddCall(&ethrpc.Call{
 		ABI:    CurveLlammaABI,
 		Target: p.Address,
 		Method: llammaMethodGetBasePrice,
@@ -119,7 +146,8 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, err
 	}
 
-	bands, err := t.getBands(ctx, p.Address, activeBand.Int64(), minBand.Int64(), maxBand.Int64(), t.config.MaxBandLimit)
+	bands, err := t.getBands(ctx, p.Address, activeBand.Int64(), minBand.Int64(), maxBand.Int64(), t.config.MaxBandLimit,
+		overrides)
 	if err != nil {
 		return p, err
 	}
@@ -166,6 +194,7 @@ func (t *PoolTracker) GetNewPoolState(
 func (t *PoolTracker) getBands(
 	ctx context.Context,
 	poolAddress string, activeBand, minBand, maxBand, bandLimit int64,
+	overrides map[common.Address]gethclient.OverrideAccount,
 ) ([]Band, error) {
 	if minBand > maxBand {
 		return nil, nil
@@ -181,7 +210,7 @@ func (t *PoolTracker) getBands(
 		bandsY = make([]*big.Int, bandCount)
 	)
 
-	calls := t.ethrpcClient.NewRequest().SetContext(ctx).SetFrom(shared.AddrDummy)
+	calls := t.ethrpcClient.NewRequest().SetContext(ctx).SetFrom(shared.AddrDummy).SetOverrides(overrides)
 	for i := range bandCount {
 		bandIndex := big.NewInt(i + startBand)
 		calls.AddCall(&ethrpc.Call{


### PR DESCRIPTION
## Summary
- Add `GetNewPoolStateWithOverrides` to `curve/llamma.PoolTracker`, satisfying `pool.IPoolTrackerWithOverrides`. `GetNewPoolState` is refactored to delegate to a shared `getNewPoolState(ctx, p, overrides)`, with `.SetOverrides(overrides)` threaded into every `ethrpc` request the tracker issues: `get_base_price`, `price_oracle`, `fee`, `admin_fee`, `admin_fees_x`, `admin_fees_y`, `active_band`/`min_band`/`max_band`, the two token `balanceOf` calls, and the per-band `bands_x`/`bands_y` batch in `getBands`. `GetNewPoolState` keeps calling with `nil` overrides, so the normal (non-backrun) flow is unchanged.
- The llamma ABI emits **zero events** (no Swap/Band logs), so there is no log-fold path to reconstruct post-victim pool state after a pending tx — cách 1 (RPC with `stateOverride`) is the only option for backrun sims of this dex, and today there was no `GetNewPoolStateWithOverrides` at all.
- `curve/lending` registers `llamma.NewPoolTracker` directly as its own tracker factory (it has no `PoolTracker` type of its own), so it inherits the new method automatically. Added a compile-time interface assertion in `curve/lending/pool_tracker.go` to document/lock that in.
- This one PR unblocks cách-1 backrun simulation for both **curve-llamma** (9 pools) and **curve-lending** (51 pools) in dexdex-arb/reserve-taker.

## Test plan
- [x] `gofmt -l` clean on both changed packages
- [x] `go build ./pkg/liquidity-source/curve/...` — success
- [x] `go vet ./pkg/liquidity-source/curve/...` — no issues
- [x] `golangci-lint run ./pkg/liquidity-source/curve/llamma/... ./pkg/liquidity-source/curve/lending/...` — 0 issues
- [x] `go test ./pkg/liquidity-source/curve/...` — 1834 passed in 13 packages
- [ ] No on-chain fixture added — the change is purely threading overrides into existing RPC calls; existing pool_simulator tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)