### PR TITLE
feat: integrate Aegis PropAMM as a new uniswap-v4 hook venue

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/abi.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/abi.go
@@ -1,0 +1,10 @@
+package aegisprop
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/samber/lo"
+)
+
+var aegisPropHookABI = lo.Must(abi.JSON(bytes.NewReader(aegisPropHookABIJson)))

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/abis/AegisPropHook.json
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/abis/AegisPropHook.json
@@ -1,0 +1,41 @@
+[
+  {
+    "inputs": [
+      { "internalType": "PoolId", "name": "poolId", "type": "bytes32" }
+    ],
+    "name": "ladder",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              { "internalType": "uint128", "name": "price", "type": "uint128" },
+              { "internalType": "uint128", "name": "amplitude", "type": "uint128" }
+            ],
+            "internalType": "struct Level[10]",
+            "name": "bids",
+            "type": "tuple[10]"
+          },
+          {
+            "components": [
+              { "internalType": "uint128", "name": "price", "type": "uint128" },
+              { "internalType": "uint128", "name": "amplitude", "type": "uint128" }
+            ],
+            "internalType": "struct Level[10]",
+            "name": "asks",
+            "type": "tuple[10]"
+          },
+          { "internalType": "uint64", "name": "sequence", "type": "uint64" },
+          { "internalType": "uint32", "name": "expiration", "type": "uint32" },
+          { "internalType": "uint8", "name": "bidLen", "type": "uint8" },
+          { "internalType": "uint8", "name": "askLen", "type": "uint8" }
+        ],
+        "internalType": "struct Ladder",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/constant.go
@@ -1,0 +1,20 @@
+package aegisprop
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const gasBeforeSwap int64 = 39838 // same order as other PropAMM-family hooks (st0x); refine once measured on-chain
+
+var (
+	ErrInvalidAmount           = errors.New("aegisprop: invalid swap amount")
+	ErrNoLiquidity             = errors.New("aegisprop: ladder has no active levels for this side")
+	ErrStaleLadder             = errors.New("aegisprop: ladder quote has expired")
+	ErrInsufficientLadderDepth = errors.New("aegisprop: ladder depth insufficient for requested amount")
+)
+
+var HookAddresses = []common.Address{
+	common.HexToAddress("0x7e00422559c4c6a9b1592a25074a420a96412088"), // base
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/embed.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/embed.go
@@ -1,0 +1,6 @@
+package aegisprop
+
+import _ "embed"
+
+//go:embed abis/AegisPropHook.json
+var aegisPropHookABIJson []byte

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/hook.go
@@ -1,0 +1,221 @@
+package aegisprop
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+const maxLevels = 10
+
+// Level mirrors the on-chain Level struct (integration guide §4 B1). Amplitude is always
+// denominated in raw token0 units, on both the Bids and Asks side.
+type Level struct {
+	Price     *uint256.Int `json:"p"`
+	Amplitude *uint256.Int `json:"a"`
+}
+
+type LevelRPC struct {
+	Price     *big.Int
+	Amplitude *big.Int
+}
+
+type LadderRPC struct {
+	Bids       [maxLevels]LevelRPC
+	Asks       [maxLevels]LevelRPC
+	Sequence   uint64
+	Expiration uint32
+	BidLen     uint8
+	AskLen     uint8
+}
+
+// Hook holds the last-tracked ladder (integration guide §4 Path B), used to compute indicative
+// swap amounts off-chain during route simulation.
+type Hook struct {
+	uniswapv4.Hook `json:"-"`
+
+	Bids []Level `json:"b"`
+	Asks []Level `json:"k"`
+
+	Expiration uint64 `json:"e"` // unix ts; ladder valid while now < Expiration
+}
+
+type SwapInfo struct {
+	ZeroForOne bool
+	NewLevels  []Level
+}
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	hook := &Hook{
+		Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4AegisProp},
+	}
+	_ = param.HookExtra.Unmarshal(hook)
+	return hook
+}, HookAddresses...)
+
+func (h *Hook) AllowEmptyTicks() bool { return true }
+
+// GetReserves reuses the ladder Track just fetched (Track always runs before GetReserves, see
+// pool_tracker.go's resolveHookState) instead of an extra RPC round-trip: reserve0 is the token0
+// the venue can sell (sum of Ask amplitudes), reserve1 is the token1 it can spend buying token0
+// (sum of Bid amplitudes converted through each level's price).
+func (h *Hook) GetReserves(_ context.Context, _ *uniswapv4.HookParam) (entity.PoolReserves, error) {
+	reserve0 := new(uint256.Int)
+	for _, lvl := range h.Asks {
+		if lvl.Amplitude != nil {
+			reserve0.Add(reserve0, lvl.Amplitude)
+		}
+	}
+
+	reserve1 := new(uint256.Int)
+	tmp := new(uint256.Int)
+	for _, lvl := range h.Bids {
+		if lvl.Amplitude == nil || lvl.Price == nil {
+			continue
+		}
+		reserve1.Add(reserve1, u256.MulDivDown(tmp, lvl.Amplitude, lvl.Price, uPriceScale))
+	}
+
+	return entity.PoolReserves{reserve0.Dec(), reserve1.Dec()}, nil
+}
+
+func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	poolId := common.HexToHash(param.Pool.Address)
+	hookAddr := param.HookAddress.Hex()
+
+	var ladder LadderRPC
+	req := param.RpcClient.NewRequest().SetContext(ctx)
+	if param.BlockNumber != nil {
+		req.SetBlockNumber(param.BlockNumber)
+	}
+	req.AddCall(&ethrpc.Call{
+		ABI:    aegisPropHookABI,
+		Target: hookAddr,
+		Method: "ladder",
+		Params: []any{poolId},
+	}, []any{&struct{*LadderRPC}{&ladder}})
+
+	if _, err := req.Aggregate(); err != nil {
+		return nil, fmt.Errorf("failed to track aegis propamm ladder: %w", err)
+	}
+
+	h.Bids = toLevels(ladder.Bids[:], ladder.BidLen)
+	h.Asks = toLevels(ladder.Asks[:], ladder.AskLen)
+	h.Expiration = uint64(ladder.Expiration)
+
+	return json.Marshal(h)
+}
+
+func toLevels(rpcLevels []LevelRPC, length uint8) []Level {
+	if int(length) > len(rpcLevels) {
+		length = uint8(len(rpcLevels))
+	}
+	levels := make([]Level, 0, length)
+	for i := range int(length) {
+		price, _ := uint256.FromBig(rpcLevels[i].Price)
+		amplitude, _ := uint256.FromBig(rpcLevels[i].Amplitude)
+		levels = append(levels, Level{Price: price, Amplitude: amplitude})
+	}
+	return levels
+}
+
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	amt := params.AmountSpecified
+	if amt == nil || amt.Sign() <= 0 {
+		return &uniswapv4.BeforeSwapResult{
+			DeltaSpecified:   bignumber.ZeroBI,
+			DeltaUnspecified: bignumber.ZeroBI,
+			Gas:              gasBeforeSwap,
+		}, nil
+	}
+
+	if h.Expiration != 0 && time.Now().Unix() >= int64(h.Expiration) {
+		return nil, ErrStaleLadder
+	}
+
+	amtU, overflow := uint256.FromBig(amt)
+	if overflow {
+		return nil, ErrInvalidAmount
+	}
+
+	levels := h.Bids
+	if !params.ZeroForOne {
+		levels = h.Asks
+	}
+	if len(levels) == 0 {
+		return nil, ErrNoLiquidity
+	}
+
+	var (
+		deltaSpecified, deltaUnspecified *big.Int
+		updated                          []Level
+	)
+	if params.CalcOut {
+		out, upd, filled := walkExactIn(levels, amtU, params.ZeroForOne)
+		if !filled {
+			return nil, ErrInsufficientLadderDepth
+		}
+		updated = upd
+		deltaSpecified = new(big.Int).Set(amt)
+		deltaUnspecified = new(big.Int).Neg(out.ToBig())
+	} else {
+		in, upd, filled := walkExactOut(levels, amtU, params.ZeroForOne)
+		if !filled {
+			return nil, ErrInsufficientLadderDepth
+		}
+		updated = upd
+		deltaSpecified = new(big.Int).Neg(amt)
+		deltaUnspecified = new(big.Int).Set(in.ToBig())
+	}
+
+	return &uniswapv4.BeforeSwapResult{
+		DeltaSpecified:   deltaSpecified,
+		DeltaUnspecified: deltaUnspecified,
+		Gas:              gasBeforeSwap,
+		SwapInfo:         &SwapInfo{ZeroForOne: params.ZeroForOne, NewLevels: updated},
+	}, nil
+}
+
+func (h *Hook) CloneState() uniswapv4.Hook {
+	cloned := *h
+	cloned.Bids = cloneLevels(h.Bids)
+	cloned.Asks = cloneLevels(h.Asks)
+	return &cloned
+}
+
+func cloneLevels(levels []Level) []Level {
+	if levels == nil {
+		return nil
+	}
+	cloned := make([]Level, len(levels))
+	for i, lvl := range levels {
+		cloned[i] = Level{Price: lvl.Price.Clone(), Amplitude: lvl.Amplitude.Clone()}
+	}
+	return cloned
+}
+
+func (h *Hook) UpdateBalance(swapInfo any) {
+	info, ok := swapInfo.(*SwapInfo)
+	if !ok || info == nil {
+		return
+	}
+	if info.ZeroForOne {
+		h.Bids = info.NewLevels
+	} else {
+		h.Asks = info.NewLevels
+	}
+}
+
+var _ uniswapv4.Hook = (*Hook)(nil)

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math.go
@@ -1,0 +1,86 @@
+package aegisprop
+
+import (
+	"github.com/holiman/uint256"
+
+	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+)
+
+var uPriceScale = u256.TenPow(18)
+
+// walkExactIn replicates the reference off-chain ladder traversal (integration guide §4 B3):
+// walk levels best-price-first, filling amountIn and accumulating the counter amount.
+// zeroForOne selects which side of the ladder is read: true walks Bids (selling token0 for
+// token1), false walks Asks (selling token1 for token0). Level.Amplitude is always denominated
+// in raw token0 units, on both sides.
+// filled is false if the ladder (as read) is too thin to fill the whole amountIn.
+func walkExactIn(levels []Level, amountIn *uint256.Int, zeroForOne bool) (amountOut *uint256.Int, updated []Level, filled bool) {
+	remaining := new(uint256.Int).Set(amountIn)
+	out := new(uint256.Int)
+	updated = make([]Level, len(levels))
+	copy(updated, levels)
+
+	for i := range updated {
+		if remaining.IsZero() {
+			break
+		}
+		lvl := updated[i]
+		if lvl.Price == nil || lvl.Amplitude == nil || lvl.Amplitude.IsZero() {
+			continue
+		}
+
+		if zeroForOne {
+			take := u256.Min(remaining, lvl.Amplitude).Clone()
+			out.Add(out, u256.MulDivDown(new(uint256.Int), take, lvl.Price, uPriceScale))
+			remaining.Sub(remaining, take)
+			updated[i].Amplitude = new(uint256.Int).Sub(lvl.Amplitude, take)
+		} else {
+			cap1 := u256.MulDivDown(new(uint256.Int), lvl.Amplitude, lvl.Price, uPriceScale)
+			take := u256.Min(remaining, cap1).Clone()
+			levelOut := u256.MulDivDown(new(uint256.Int), take, uPriceScale, lvl.Price)
+			out.Add(out, levelOut)
+			remaining.Sub(remaining, take)
+			updated[i].Amplitude = new(uint256.Int).Sub(lvl.Amplitude, levelOut)
+		}
+	}
+
+	return out, updated, remaining.IsZero()
+}
+
+// walkExactOut is the exact-out counterpart of walkExactIn: given a desired amountOut, it finds
+// the required amountIn walking the same side, per integration guide §4 ("Exact-output quoting is
+// the same walk with the roles of the specified/derived legs swapped"). Required input at each
+// level is rounded up so the taker never underpays the venue.
+func walkExactOut(levels []Level, amountOut *uint256.Int, zeroForOne bool) (amountIn *uint256.Int, updated []Level, filled bool) {
+	remaining := new(uint256.Int).Set(amountOut)
+	in := new(uint256.Int)
+	updated = make([]Level, len(levels))
+	copy(updated, levels)
+
+	for i := range updated {
+		if remaining.IsZero() {
+			break
+		}
+		lvl := updated[i]
+		if lvl.Price == nil || lvl.Amplitude == nil || lvl.Amplitude.IsZero() {
+			continue
+		}
+
+		if zeroForOne {
+			cap1 := u256.MulDivDown(new(uint256.Int), lvl.Amplitude, lvl.Price, uPriceScale)
+			takeOut := u256.Min(remaining, cap1).Clone()
+			takeIn := u256.Min(u256.MulDivUp(new(uint256.Int), takeOut, uPriceScale, lvl.Price), lvl.Amplitude).Clone()
+			in.Add(in, takeIn)
+			remaining.Sub(remaining, takeOut)
+			updated[i].Amplitude = new(uint256.Int).Sub(lvl.Amplitude, takeIn)
+		} else {
+			takeOut := u256.Min(remaining, lvl.Amplitude).Clone()
+			takeIn := u256.MulDivUp(new(uint256.Int), takeOut, lvl.Price, uPriceScale)
+			in.Add(in, takeIn)
+			remaining.Sub(remaining, takeOut)
+			updated[i].Amplitude = new(uint256.Int).Sub(lvl.Amplitude, takeOut)
+		}
+	}
+
+	return in, updated, remaining.IsZero()
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math_test.go
@@ -1,0 +1,66 @@
+package aegisprop
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+// price expressed directly in token1-per-token0 * 1e18 units, built from a human-readable multiplier.
+func priceLevel(priceMultiplier, amplitude uint64) Level {
+	price := new(uint256.Int).Mul(uint256.NewInt(priceMultiplier), uPriceScale)
+	return Level{Price: price, Amplitude: uint256.NewInt(amplitude)}
+}
+
+func TestWalkExactIn_Bids_SpansMultipleLevels(t *testing.T) {
+	// price 2000 (best) then 1990, matching integration guide §4 B3 semantics for the bid side.
+	levels := []Level{priceLevel(2000, 100), priceLevel(1990, 50)}
+
+	out, updated, filled := walkExactIn(levels, uint256.NewInt(120), true)
+
+	assert.True(t, filled)
+	// 100 * 2000 + 20 * 1990 = 200000 + 39800 = 239800
+	assert.Equal(t, "239800", out.Dec())
+	assert.Equal(t, "0", updated[0].Amplitude.Dec())
+	assert.Equal(t, "30", updated[1].Amplitude.Dec())
+}
+
+func TestWalkExactIn_Asks_ConvertsThroughPrice(t *testing.T) {
+	levels := []Level{priceLevel(2, 100)} // cap in token1 = 100 * 2 = 200
+
+	out, updated, filled := walkExactIn(levels, uint256.NewInt(150), false)
+
+	assert.True(t, filled)
+	// 150 token1 in / price(2) = 75 token0 out
+	assert.Equal(t, "75", out.Dec())
+	assert.Equal(t, "25", updated[0].Amplitude.Dec())
+}
+
+func TestWalkExactIn_InsufficientDepth(t *testing.T) {
+	levels := []Level{priceLevel(2000, 100)}
+
+	_, _, filled := walkExactIn(levels, uint256.NewInt(150), true)
+
+	assert.False(t, filled)
+}
+
+func TestWalkExactOut_Bids_MatchesExactInInverse(t *testing.T) {
+	levels := []Level{priceLevel(2, 100)}
+
+	in, updated, filled := walkExactOut(levels, uint256.NewInt(100), true)
+
+	assert.True(t, filled)
+	assert.Equal(t, "50", in.Dec())
+	assert.Equal(t, "50", updated[0].Amplitude.Dec())
+}
+
+func TestWalkExactOut_Asks_MatchesExactInInverse(t *testing.T) {
+	levels := []Level{priceLevel(2, 100)}
+
+	in, updated, filled := walkExactOut(levels, uint256.NewInt(75), false)
+
+	assert.True(t, filled)
+	assert.Equal(t, "150", in.Dec())
+	assert.Equal(t, "25", updated[0].Amplitude.Dec())
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -174,6 +174,7 @@ import (
 	pkg_liquiditysource_uniswap_v3 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v3"
 	pkg_liquiditysource_uniswap_v4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
 	pkg_liquiditysource_uniswap_v4_hooks_aegis "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/aegis"
+	pkg_liquiditysource_uniswap_v4_hooks_aegisprop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/aegisprop"
 	pkg_liquiditysource_uniswap_v4_hooks_alpha "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/alpha"
 	pkg_liquiditysource_uniswap_v4_hooks_alphix "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/alphix"
 	pkg_liquiditysource_uniswap_v4_hooks_angstrom "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/angstrom"
@@ -421,6 +422,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v3.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_aegis.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_aegisprop.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_alpha.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_alphix.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_angstrom.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -279,6 +279,7 @@ const (
 	ExchangeUniSwapV3                   = "uniswapv3"
 	ExchangeUniswapV4                   = "uniswap-v4"
 	ExchangeUniswapV4Aegis              = "uniswap-v4-aegis"
+	ExchangeUniswapV4AegisProp          = "uniswap-v4-aegisprop"
 	ExchangeUniswapV4Alpha              = "uniswap-v4-alpha"
 	ExchangeUniswapV4Alphix             = "uniswap-v4-alphix"
 	ExchangeUniswapV4Angstrom           = "uniswap-v4-angstrom"


### PR DESCRIPTION
Adds a new hook package (pkg/liquidity-source/uniswap/v4/hooks/aegispropamm)
that tracks the venue's on-chain bid/ask ladder and prices swaps off-chain by
walking it, following the same full-fill hook pattern as uniswap-v4-st0x.
Registers exchange uniswap-v4-aegis-propamm and wires the deployed Base hook
address (0x7e00422559c4c6a9b1592a25074a420a96412088).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
