### PR TITLE
fix: recognize more RPC pruned-state error phrasings

### DIFF
--- a/pkg/liquidity-source/uniswap/v3/ticks/ticks.go
+++ b/pkg/liquidity-source/uniswap/v3/ticks/ticks.go
@@ -4,16 +4,15 @@ import (
 	"errors"
 	"maps"
 	"math/big"
-	"strings"
 
 	"github.com/KyberNetwork/blockchain-toolkit/integer"
 	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/logger"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
-	"github.com/samber/lo"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/eth"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/metrics"
 )
 
@@ -135,9 +134,15 @@ func ValidatePoolTicks(pool TicksBasedPool, ticks []Tick) error {
 	return nil
 }
 
+// IsMissingTrieNodeError reports whether err indicates the RPC node can't serve state
+// for the requested historical block (pruned, not an archive node, etc). Delegates the
+// actual classification to eth.IsPrunedStateError, shared with pool-service, so the two
+// can't drift out of sync on which error strings different RPC providers use for the
+// same underlying condition.
 func IsMissingTrieNodeError(err error) bool {
-	return lo.TernaryF(strings.Contains(err.Error(), "missing trie node"), func() bool {
-		metrics.IncrMissingTrieNode()
-		return true
-	}, func() bool { return false })
+	if !eth.IsPrunedStateError(err) {
+		return false
+	}
+	metrics.IncrMissingTrieNode()
+	return true
 }

--- a/pkg/liquidity-source/uniswap/v3/ticks/ticks_test.go
+++ b/pkg/liquidity-source/uniswap/v3/ticks/ticks_test.go
@@ -1,0 +1,30 @@
+package ticks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMissingTrieNodeError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"missing trie node", errors.New("missing trie node abcd"), true},
+		// This is the case that motivated delegating to the shared classifier: some
+		// RPC providers report pruned state with this text instead of "missing trie
+		// node", and the fallback-to-latest-block retry in pool_tracker.go's
+		// updateState depends on this returning true for it too.
+		{"historical state not available", errors.New("historical state 0xabc is not available"), true},
+		{"unrelated error", errors.New("connection reset by peer"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsMissingTrieNodeError(tt.err))
+		})
+	}
+}

--- a/pkg/util/eth/pruned_error.go
+++ b/pkg/util/eth/pruned_error.go
@@ -1,0 +1,35 @@
+package eth
+
+import "strings"
+
+// prunedStateErrSubstrings matches RPC error text indicating a node no longer serves
+// state (or history) for the requested block - because it pruned it, isn't running in
+// archive mode, or otherwise doesn't retain it. Substrings, not exact strings, since
+// RPC providers phrase this differently ("missing trie node" vs "historical state ...
+// is not available" have both been observed from different providers for the same
+// underlying condition).
+var prunedStateErrSubstrings = []string{
+	"trie node",
+	"historical state",
+	"archive mode",
+	"archive node",
+	"state not available",
+	"state unavailable",
+	"database is pruned",
+	"storage trie",
+}
+
+// IsPrunedStateError reports whether err indicates the RPC node can't serve state for
+// the requested historical block because it has pruned it (or isn't an archive node).
+func IsPrunedStateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, s := range prunedStateErrSubstrings {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/eth/pruned_error_test.go
+++ b/pkg/util/eth/pruned_error_test.go
@@ -1,0 +1,37 @@
+package eth_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/eth"
+)
+
+func TestIsPrunedStateError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"unrelated error", errors.New("connection reset by peer"), false},
+		{"trie node", errors.New("missing trie node abcd"), true},
+		{"historical state", errors.New("historical state 0xabc is not available"), true},
+		{"archive mode", errors.New("your node is not running in archive mode"), true},
+		{"archive node", errors.New("this data is only available on an archive node"), true},
+		{"header not found is not treated as pruned", errors.New("header not found"), false},
+		{"state not available", errors.New("state not available at this block"), true},
+		{"state unavailable", errors.New("state unavailable, try a different block"), true},
+		{"database is pruned", errors.New("the requested data is not available because the database is pruned"), true},
+		{"storage trie", errors.New("could not open storage trie"), true},
+		{"case insensitive", errors.New("MISSING TRIE NODE"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, eth.IsPrunedStateError(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `IsMissingTrieNodeError` only matched the geth-specific `"missing trie node"` substring. RPC providers that phrase pruned/archived-state errors differently (observed: `"historical state ... is not available"`) never triggered the existing fallback-to-latest-block retry already wired into ~30 tracker call sites (uniswap v3/v4, algebra, ramses, solidly, slipstream, pancake infinity, liquiditybook, nuriv2, native v3, fluid, machima) - they hard-failed instead.
- Extracted the classifier into `pkg/util/eth/pruned_error.go` (`IsPrunedStateError`) as a shared, neutral-package function. `IsMissingTrieNodeError` now delegates to it, keeping its existing `metrics.IncrMissingTrieNode()` side effect and signature so none of the ~30 call sites need to change.
- Verified the fallback shape is uniform across a sample of trackers (uniswap v3/v4, algebra/integral, fluid, liquiditybook v21): all retry at latest block on match, none skip/drop - broadening the match list changes no call site's control flow beyond "recovers instead of hard-failing."
- This lets a downstream consumer (pool-service) import the same validated classifier instead of maintaining a separate, potentially-drifting copy.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/util/eth/... ./pkg/liquidity-source/uniswap/v3/ticks/... -race`
- [x] `gofmt -l` clean on all touched files