### PR TITLE
feat(balancer/v2): add balancer-vault-v2 Vault event decoder

### DIFF
--- a/pkg/liquidity-source/balancer/v2/vault/const.go
+++ b/pkg/liquidity-source/balancer/v2/vault/const.go
@@ -1,0 +1,5 @@
+package vault
+
+const (
+	Type = "balancer-vault-v2"
+)

--- a/pkg/liquidity-source/balancer/v2/vault/vault_event_parser.go
+++ b/pkg/liquidity-source/balancer/v2/vault/vault_event_parser.go
@@ -1,0 +1,81 @@
+package vault
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/balancer/v2/shared"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/poolfactory"
+)
+
+type Config struct {
+	Vault string `json:"vault,omitempty"`
+}
+
+type EventParser struct {
+	config *Config
+}
+
+var _ = poolfactory.RegisterFactoryC(Type, NewPoolFactory)
+
+func NewPoolFactory(config *Config) *EventParser {
+	return &EventParser{
+		config: config,
+	}
+}
+
+// Ported from the Balancer V3 vault event parser, adapted for V2.
+// https://github.com/KyberNetwork/kyberswap-dex-lib/blob/0b94bbfeae66b43cb64a52308bf52520145ab79c/pkg/liquidity-source/balancer/v3/vault/vault_event_parser.go#L31-L67
+func (p *EventParser) Decode(ctx context.Context, logs []types.Log) (map[string][]types.Log, error) {
+	addressLogs := make(map[string][]types.Log)
+	for _, log := range logs {
+		addresses, _ := p.DecodePoolAddressesFromFactoryLog(ctx, log)
+		for _, address := range addresses {
+			addressLogs[address] = append(addressLogs[address], log)
+		}
+	}
+	return addressLogs, nil
+}
+
+// DecodePoolAddressesFromFactoryLog extracts the affected pool address from a V2 Vault log.
+//
+// Unlike the V3 Vault (which emits a left-padded 32-byte pool address in topic1 and is
+// decoded via topic1[12:32]), the Balancer V2 Vault emits the pool's bytes32 poolId in
+// topic1. The poolId is abi.encodePacked(pool address (20B), specialization (2B), nonce
+// (10B)), so the pool address is the HIGH-ORDER 20 bytes of the poolId, i.e. topic1[0:20].
+//
+// Ported/mirrored from V3 DecodePoolAddressesFromFactoryLog:
+// https://github.com/KyberNetwork/kyberswap-dex-lib/blob/0b94bbfeae66b43cb64a52308bf52520145ab79c/pkg/liquidity-source/balancer/v3/vault/vault_event_parser.go#L42-L67
+func (p *EventParser) DecodePoolAddressesFromFactoryLog(_ context.Context, log types.Log) ([]string, error) {
+	if log.Address != common.HexToAddress(p.config.Vault) {
+		return nil, nil
+	}
+	switch log.Topics[0] {
+	case shared.VaultABI.Events["Swap"].ID,
+		shared.VaultABI.Events["PoolBalanceChanged"].ID,
+		shared.VaultABI.Events["PoolBalanceManaged"].ID: // these events carry the poolId in topic1
+		if len(log.Topics) < 2 {
+			return nil, nil
+		}
+		// poolId = abi.encodePacked(pool address (20B), specialization (2B), nonce (10B));
+		// the pool address is the high-order 20 bytes of the poolId.
+		poolAddress := hexutil.Encode(log.Topics[1][:common.AddressLength])
+		return []string{poolAddress}, nil
+	}
+	return nil, nil
+}
+
+func (ep *EventParser) DecodePoolCreated(event types.Log) (*entity.Pool, error) {
+	// TODO: Implement this (non tick-based pool creation)
+	return nil, errors.New("not implemented")
+}
+
+func (ep *EventParser) IsEventSupported(event common.Hash) bool {
+	// TODO: Implement this (non tick-based pool creation)
+	return false
+}

--- a/pkg/liquidity-source/balancer/v2/vault/vault_event_parser_test.go
+++ b/pkg/liquidity-source/balancer/v2/vault/vault_event_parser_test.go
@@ -1,0 +1,63 @@
+package vault
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/balancer/v2/shared"
+)
+
+const vaultV2 = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+
+func TestDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("1. Decode pool address from a real Vault Swap log", func(t *testing.T) {
+		// Real Balancer V2 Vault Swap log from eth_getLogs, tx
+		// 0x313952217900e31ae29f61d6f7fcb5c1406584824aa3f8f1816a03463c76838d (block 25635720).
+		// poolId topic1 = 0x3de27efa2f1aa663ae5d458857e731c129069f29000200000000000000000588,
+		// so the pool address is the high-order 20 bytes: 0x3de27efa2f1aa663ae5d458857e731c129069f29.
+		jsonStr := `[{"removed":false,"logIndex":"0x74","transactionIndex":"0x21","transactionHash":"0x313952217900e31ae29f61d6f7fcb5c1406584824aa3f8f1816a03463c76838d","blockHash":"0x21972b0234c764bcc4db7df588b768a6c488075869778d0e05fdd442640d6e54","blockNumber":"0x1872888","address":"0xba12222222228d8ba445958a75a0704d566bf2c8","data":"0x000000000000000000000000000000000000000000000000932eabea11d74a65000000000000000000000000000000000000000000000000064454de48666cab","topics":["0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b","0x3de27efa2f1aa663ae5d458857e731c129069f29000200000000000000000588","0x0000000000000000000000007fc66500c84a76ad7e9c93437bfc5ac33e2ddae9","0x0000000000000000000000007f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"]}]`
+		var logs []types.Log
+		require := assert.New(t)
+		_ = json.Unmarshal([]byte(jsonStr), &logs)
+
+		poolDecoder := NewPoolFactory(&Config{Vault: vaultV2})
+		addressLogs, err := poolDecoder.Decode(context.Background(), logs)
+		require.NoError(err)
+
+		const expected = "0x3de27efa2f1aa663ae5d458857e731c129069f29"
+		require.Len(addressLogs[expected], 1)
+		require.Equal(uint(0x74), addressLogs[expected][0].Index)
+	})
+
+	t.Run("2. Decode target pool (60WETH-40DAI) from its poolId", func(t *testing.T) {
+		require := assert.New(t)
+		// Real on-chain registered poolId of the Balancer 60WETH-40DAI weighted pool.
+		// High-order 20 bytes = 0x0b09dea16768f0799065c475be02919503cb2a35 (the pool address).
+		const poolID = "0x0b09dea16768f0799065c475be02919503cb2a350002000000000000000000fe"
+		// Derive the expectation from the poolId itself (non-circular vs the decoder).
+		expected := strings.ToLower(poolID[:42])
+
+		// Build a Swap log the way the V2 Vault emits it: topic0 = Swap event ID (from the
+		// ABI, not hand-typed), topic1 = poolId.
+		log := types.Log{
+			Address: common.HexToAddress(vaultV2),
+			Topics: []common.Hash{
+				shared.VaultABI.Events["Swap"].ID,
+				common.HexToHash(poolID),
+			},
+		}
+
+		poolDecoder := NewPoolFactory(&Config{Vault: vaultV2})
+		addresses, err := poolDecoder.DecodePoolAddressesFromFactoryLog(context.Background(), log)
+		require.NoError(err)
+		require.Equal([]string{expected}, addresses)
+	})
+}


### PR DESCRIPTION
## Why

Balancer V2 pools go stale between polls in pool-service. All V2 swaps and liquidity changes are emitted by the **V2 Vault** (`0xBA12222222228d8Ba445958a75a0704d566BF2C8`) as `Swap(bytes32 poolId,...)` / `PoolBalanceChanged(bytes32 poolId,...)`, keyed by `poolId` — **not** at the pool's own address. Pool-service's per-block event path (which keys dependencies by contract address) therefore never sees V2 activity, so V2 pools are only refreshed by a slow interval poll. The V3 Vault already has such a decoder (`balancer-vault-v3`); V2 does not.

This leaves V2 snapshots stale for up to a full poll interval, which:
- makes dexdex-arb build phantom backruns off a stale base (≈100% revert on `balancer-v2-weighted`), and
- degrades normal-arb + router/aggregator quotes for all Balancer V2 pools (+ Gyroscope V2-vault pools).

## What

Mirror the existing `balancer-vault-v3` decoder for V2. New package `pkg/liquidity-source/balancer/v2/vault` registers a `balancer-vault-v2` pool factory that maps a Vault log to the affected pool address so pool-service can re-snapshot that pool per block.

Events decoded (all carry `poolId` in `topic1` and change pool balances): `Swap`, `PoolBalanceChanged`, `PoolBalanceManaged`. Reuses the already-present `shared.VaultABI` for event IDs (no duplicate ABI embed).

### Key V2-vs-V3 difference
The Balancer V2 pool address is the **high-order 20 bytes of the `bytes32` poolId** (`poolId = abi.encodePacked(pool address (20B), specialization (2B), nonce (10B))`), i.e. `topic1[0:20]`. V3 instead carries a left-padded 32-byte address and is decoded via `topic1[12:32]`. The decoder reflects this difference and documents it inline, with the origin V3 source pinned to commit `0b94bbfe`.

## Test
`go test ./pkg/liquidity-source/balancer/v2/vault/...` — green. Two cases:
1. A **real on-chain Vault `Swap` log** (from `eth_getLogs`, tx `0x31395221…c76838d`) with poolId `0x3de27efa…0588` decodes to pool `0x3de27efa2f1aa663ae5d458857e731c129069f29`.
2. The **target 60WETH-40DAI pool**: poolId `0x0b09dea16768f0799065c475be02919503cb2a350002000000000000000000fe` decodes to `0x0b09dea16768f0799065c475be02919503cb2a35` (topic0 taken from the ABI, expectation derived from the poolId itself — non-circular).

`go build ./...` rc=0, `gofmt` clean, `golangci-lint` 0 issues on the new package.

## Follow-up
pool-service must register this `balancer-vault-v2` dependency (V2 Vault address) in `internal/config/files/prod/ethereum.yaml` and bump its dex-lib dependency to the version containing this decoder. That PR is gated on this one merging + tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)