### PR TITLE
fix(ekubo-v3): decode bytes32 poolId as [32]byte, not common.Hash

### DIFF
--- a/pkg/liquidity-source/ekubo/v3/event_parser.go
+++ b/pkg/liquidity-source/ekubo/v3/event_parser.go
@@ -78,7 +78,7 @@ func (e *EventParser) handleCoreLog(log types.Log) ([]string, error) {
 			return nil, err
 		}
 
-		poolId, ok := values[1].(common.Hash)
+		poolId, ok := values[1].([32]byte)
 		if !ok {
 			return nil, fmt.Errorf("failed to parse poolId from PositionUpdated event data")
 		}
@@ -158,7 +158,7 @@ func (e *EventParser) handleVe33Log(log types.Log) ([]string, error) {
 			len(log.Data), err,
 		)
 	}
-	poolID, ok := values[2].(common.Hash)
+	poolID, ok := values[2].([32]byte)
 	if !ok {
 		return nil, fmt.Errorf("failed to parse poolId from VoteWeightApplied event data")
 	}


### PR DESCRIPTION
## Bug
`abi.Unpack` returns **`[32]byte`** (Go `[32]uint8`) for a `bytes32` ABI field, never `common.Hash` (a distinct named type). Two poolId extractions in `ekubo/v3` `DecodePoolAddressesFromFactoryLog` used `values[N].(common.Hash)`, which **always** returns `ok=false`, so decoding failed:

- **Core `PositionUpdated`** (poolId at input index 1) — `event_parser.go:81`
- **Ve33 `VoteWeightApplied`** (poolId at input index 2) — `event_parser.go:161`

Both fields are `bytes32` (verified against `Core.json` / `Ve33.json`; confirmed empirically that `Inputs.Unpack` yields `[32]uint8` for them). The failed decode meant pool-service could not map these factory/Vault logs back to the affected pool, so **those pools were never event-refreshed** (they fell back to interval polling only).

## Fix
Assert `.([32]byte)` instead of `.(common.Hash)`. The following `hexutil.Encode(poolId[:])` is unchanged (works for `[32]byte`). Two-line change, no behavior change beyond making the decode succeed.

## Why now
These are the **deterministic** unit-test failures currently red on `main`, blocking `ci / test` on every open PR:
- `TestEventParserDecode/PositionUpdated`
- `TestEventParserDecodeVoteWeightApplied`

Both PASS with this fix. (The `VirtualOrdersExecuted*` subtests are network-dependent and unrelated — they hit public-RPC rate limits locally; they pass in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)