### PR TITLE
fix: ticks-based trackers fetch scalar state at latest, never a historical block

### DIFF
--- a/pkg/liquidity-source/algebra/integral/pool_tracker.go
+++ b/pkg/liquidity-source/algebra/integral/pool_tracker.go
@@ -483,7 +483,7 @@ func (d *PoolTracker) getPoolTicks(ctx context.Context, poolAddress string) ([]T
 }
 
 func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param sourcePool.GetNewPoolStateParams) (entity.Pool, error) {
-	return t.getNewPoolState(ctx, p, param.Logs, nil)
+	return t.getNewPoolState(ctx, p, param.Logs, param.BlockHeaders, nil)
 }
 
 // GetNewPoolStateWithOverrides behaves like GetNewPoolState but reads all pool/plugin/tick state
@@ -492,10 +492,11 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 // (e.g. post-victim-tx) storage rather than the latest on-chain state.
 func (t *PoolTracker) GetNewPoolStateWithOverrides(ctx context.Context, p entity.Pool,
 	params sourcePool.GetNewPoolStateWithOverridesParams) (entity.Pool, error) {
-	return t.getNewPoolState(ctx, p, params.Logs, params.Overrides)
+	return t.getNewPoolState(ctx, p, params.Logs, nil, params.Overrides)
 }
 
 func (t *PoolTracker) getNewPoolState(ctx context.Context, p entity.Pool, logs []ethtypes.Log,
+	blockHeaders map[uint64]entity.BlockHeader,
 	overrides map[common.Address]gethclient.OverrideAccount) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"address":  p.Address,
@@ -508,7 +509,7 @@ func (t *PoolTracker) getNewPoolState(ctx context.Context, p entity.Pool, logs [
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool, overrides)
+	return t.updateState(ctx, p, ticksBasedPool, logs, blockHeaders, overrides)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -646,30 +647,20 @@ func (t *PoolTracker) newTicksBasedPool(ctx context.Context, p entity.Pool, logs
 }
 
 func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader,
 	overrides map[common.Address]gethclient.OverrideAccount) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber, overrides)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0, overrides)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0, overrides)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]v3Entities.Tick, 0, len(ticksBasedPool.Ticks))
@@ -710,7 +701,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 
 	p.SwapFee = float64(rpcState.State.LastFee)
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),

--- a/pkg/liquidity-source/algebra/v1/pool_tracker.go
+++ b/pkg/liquidity-source/algebra/v1/pool_tracker.go
@@ -523,7 +523,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -656,30 +656,20 @@ func (t *PoolTracker) newTicksBasedPool(ctx context.Context, p entity.Pool, logs
 	return ticksBasedPool, nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool, error) {
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]v3Entities.Tick, 0, len(ticksBasedPool.Ticks))
@@ -715,7 +705,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 	}
 
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),

--- a/pkg/liquidity-source/fluid/dex-v2/pool_tracker_ticks_based.go
+++ b/pkg/liquidity-source/fluid/dex-v2/pool_tracker_ticks_based.go
@@ -452,25 +452,14 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
@@ -516,7 +505,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 	}
 
 	p.Extra = string(extraBytes)
-	p.Timestamp = t.estimateLastActivityTime(&p, logs, blockHeaders)
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 
 	reserve0Adjusted, reserve1Adjusted := extractTokenReserves(extra.TokenReserves)
 	c, err := _calculateVars(extra.DexVariables2, extra.Token0ExchangePricesAndConfig, extra.Token1ExchangePricesAndConfig)
@@ -618,17 +607,4 @@ func (t *PoolTracker) queryRPCTicksByChunk(
 	}
 
 	return result, nil
-}
-
-func (t *PoolTracker) estimateLastActivityTime(p *entity.Pool, logs []ethtypes.Log,
-	blockHeaders map[uint64]entity.BlockHeader) int64 {
-	if len(logs) > 0 && blockHeaders != nil {
-		latestLog := logs[len(logs)-1]
-		if blockHeader, ok := blockHeaders[latestLog.BlockNumber]; ok {
-			return max(p.Timestamp, int64(blockHeader.Timestamp))
-		}
-	}
-
-	// Do not update the timestamp as the pool triggered state update via a custom empty log.
-	return p.Timestamp
 }

--- a/pkg/liquidity-source/native/v3/pool_tracker.go
+++ b/pkg/liquidity-source/native/v3/pool_tracker.go
@@ -334,7 +334,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -502,12 +502,11 @@ func (t *PoolTracker) fetchAllTicksForPool(
 	return lo.Values(ticksMap), nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool, error) {
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
-
-	blockNumber := ticksBasedPool.BlockNumber
 
 	var (
 		rpcState    *FetchRPCResult
@@ -522,24 +521,15 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 		return p, err
 	}
 
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
 	newCtx := NewContextWithUnderlyingScanned(ctx, staticExtra.NeedScanUnderlying)
-	rpcState, err = t.FetchRPCData(newCtx, &p, blockNumber)
+	rpcState, err = t.FetchRPCData(newCtx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	// Only process underlying tokens if we haven't checked before
@@ -623,7 +613,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 
 	p.StaticExtra = string(staticExtraBytes)
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.BlockNumber = rpcState.BlockNumber
 
 	return p, nil

--- a/pkg/liquidity-source/nuriv2/pool_tracker.go
+++ b/pkg/liquidity-source/nuriv2/pool_tracker.go
@@ -287,7 +287,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -407,30 +407,20 @@ func (t *PoolTracker) newTicksBasedPool(
 	return ticksBasedPool, nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool, error) {
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	ticks256 := make([]uniswapv3.TickU256, 0, len(ticksBasedPool.Ticks))
@@ -455,7 +445,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 
 	p.SwapFee = float64(rpcState.FeeTier)
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),

--- a/pkg/liquidity-source/pancake/infinity/cl/pool_tracker.go
+++ b/pkg/liquidity-source/pancake/infinity/cl/pool_tracker.go
@@ -437,7 +437,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) newTicksBasedPool(
@@ -690,30 +690,20 @@ func (t *PoolTracker) fetchAllTicksForPool(
 	return lo.Values(ticksMap), nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool, error) {
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, hook, hookParam, err := t.fetchOnchainState(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, hook, hookParam, err := t.fetchOnchainState(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, hook, hookParam, err = t.fetchOnchainState(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
@@ -767,7 +757,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 	p.SwapFee = float64(rpcState.SwapFee)
 	p.Extra = string(extraBytes)
 	p.Reserves = rpcState.Reserves
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 
 	return p, nil
 }

--- a/pkg/liquidity-source/pancake/v3/pool_tracker.go
+++ b/pkg/liquidity-source/pancake/v3/pool_tracker.go
@@ -673,25 +673,14 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
@@ -732,7 +721,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 	}
 
 	p.Extra = string(extraBytes)
-	p.Timestamp = t.estimateLastActivityTime(&p, logs, blockHeaders)
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),
@@ -817,17 +806,4 @@ func (t *PoolTracker) queryRPCTicksByChunk(
 	}
 
 	return result, nil
-}
-
-func (t *PoolTracker) estimateLastActivityTime(p *entity.Pool, logs []ethtypes.Log,
-	blockHeaders map[uint64]entity.BlockHeader) int64 {
-	if len(logs) > 0 && blockHeaders != nil {
-		latestLog := logs[len(logs)-1]
-		if blockHeader, ok := blockHeaders[latestLog.BlockNumber]; ok {
-			return max(p.Timestamp, int64(blockHeader.Timestamp))
-		}
-	}
-
-	// Do not update the timestamp as the pool triggered state update via a custom empty log.
-	return p.Timestamp
 }

--- a/pkg/liquidity-source/ramsesv2/pool_tracker.go
+++ b/pkg/liquidity-source/ramsesv2/pool_tracker.go
@@ -311,7 +311,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -417,27 +417,19 @@ func (t *PoolTracker) newTicksBasedPool(
 	return ticksBasedPool, nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool,
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool,
 	error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{"error": err}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{"error": err, "blockNumber": blockNumber}).
-				Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{"error": err}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	ticks256 := make([]uniswapv3.TickU256, 0, len(ticksBasedPool.Ticks))
@@ -464,7 +456,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 
 	p.SwapFee = float64(rpcState.FeeTier)
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),

--- a/pkg/liquidity-source/slipstream/pool_tracker.go
+++ b/pkg/liquidity-source/slipstream/pool_tracker.go
@@ -293,7 +293,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -460,30 +460,20 @@ func (t *PoolTracker) fetchAllTicksForPool(
 	return lo.Values(ticksMap), nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool, error) {
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
@@ -528,7 +518,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 
 	p.SwapFee, _ = rpcState.FeeTier.Float64()
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),

--- a/pkg/liquidity-source/solidly-v3/pool_tracker.go
+++ b/pkg/liquidity-source/solidly-v3/pool_tracker.go
@@ -280,7 +280,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, param 
 		return p, err
 	}
 
-	return t.updateState(ctx, p, ticksBasedPool)
+	return t.updateState(ctx, p, ticksBasedPool, param.Logs, param.BlockHeaders)
 }
 
 func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
@@ -333,30 +333,20 @@ func (t *PoolTracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity
 	return p, nil
 }
 
-func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool) (entity.Pool, error) {
+func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBasedPool tickspkg.TicksBasedPool,
+	logs []ethtypes.Log, blockHeaders map[uint64]entity.BlockHeader) (entity.Pool, error) {
 	l := logger.WithFields(logger.Fields{
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	ticks256 := make([]uniswapv3.TickU256, 0, len(ticksBasedPool.Ticks))
@@ -381,7 +371,7 @@ func (t *PoolTracker) updateState(ctx context.Context, p entity.Pool, ticksBased
 
 	p.SwapFee, _ = rpcState.Slot0.Fee.Float64()
 	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 	p.Reserves = entity.PoolReserves{
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),

--- a/pkg/liquidity-source/uniswap/v3/pool_tracker.go
+++ b/pkg/liquidity-source/uniswap/v3/pool_tracker.go
@@ -371,25 +371,16 @@ func (t *Tracker) updateState(
 	blockHeaders map[uint64]entity.BlockHeader,
 	l logger.Logger,
 ) (entity.Pool, error) {
-	blockNumber := ticksBasedPool.BlockNumber
-
-	rpcState, err := t.FetchRPCData(ctx, &p, blockNumber)
+	// Always fetch scalar state (sqrtPrice/tick/liquidity) at latest, never at this
+	// batch's own block: a catch-up/backfill batch's block can be older than the
+	// provider's pruning window, and there's no need for state "as of" that exact
+	// block anyway since ticks are already applied incrementally from decoded logs.
+	rpcState, err := t.FetchRPCData(ctx, &p, 0)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, err = t.FetchRPCData(ctx, &p, 0)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	}
 
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
@@ -435,7 +426,7 @@ func (t *Tracker) updateState(
 		rpcState.Reserve0.String(),
 		rpcState.Reserve1.String(),
 	}
-	p.Timestamp = t.estimateLastActivityTime(&p, logs, blockHeaders)
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 
 	return p, nil
 }
@@ -596,19 +587,6 @@ func (t *Tracker) queryRPCTicksByChunk(
 	}
 
 	return result, nil
-}
-
-func (t *Tracker) estimateLastActivityTime(p *entity.Pool, logs []ethtypes.Log,
-	blockHeaders map[uint64]entity.BlockHeader) int64 {
-	if len(logs) > 0 && blockHeaders != nil {
-		latestLog := logs[len(logs)-1]
-		if blockHeader, ok := blockHeaders[latestLog.BlockNumber]; ok {
-			return max(p.Timestamp, int64(blockHeader.Timestamp))
-		}
-	}
-
-	// Do not update the timestamp as the pool triggered state update via a custom empty log.
-	return p.Timestamp
 }
 
 func (t *Tracker) BootstrapPoolState(ctx context.Context, p entity.Pool, _ poolpkg.GetNewPoolStateParams) (entity.Pool, error) {

--- a/pkg/liquidity-source/uniswap/v3/ticks/ticks.go
+++ b/pkg/liquidity-source/uniswap/v3/ticks/ticks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KyberNetwork/blockchain-toolkit/integer"
 	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/logger"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
 
@@ -132,6 +133,25 @@ func ValidatePoolTicks(pool TicksBasedPool, ticks []Tick) error {
 	}
 
 	return nil
+}
+
+// EstimateLastActivityTime derives a pool's last-activity timestamp from the chain
+// timestamp of the latest log being applied, not from wall-clock processing time, so
+// replaying an old (e.g. backfilled) event can never make an abandoned pool look
+// freshly active - and a genuinely fresh event still advances the timestamp normally,
+// since max-wins is the only rule needed for both directions. Shared by every
+// ticks-based tracker's incremental update path.
+func EstimateLastActivityTime(p *entity.Pool, logs []ethtypes.Log,
+	blockHeaders map[uint64]entity.BlockHeader) int64 {
+	if len(logs) > 0 && blockHeaders != nil {
+		latestLog := logs[len(logs)-1]
+		if blockHeader, ok := blockHeaders[latestLog.BlockNumber]; ok {
+			return max(p.Timestamp, int64(blockHeader.Timestamp))
+		}
+	}
+
+	// Do not update the timestamp as the pool triggered state update via a custom empty log.
+	return p.Timestamp
 }
 
 // IsMissingTrieNodeError reports whether err indicates the RPC node can't serve state

--- a/pkg/liquidity-source/uniswap/v4/pool_tracker.go
+++ b/pkg/liquidity-source/uniswap/v4/pool_tracker.go
@@ -792,8 +792,6 @@ func (t *PoolTracker) updateState(
 		"poolAddress": p.Address,
 	})
 
-	blockNumber := ticksBasedPool.BlockNumber
-
 	entityPoolTicks := make([]Tick, 0, len(ticksBasedPool.Ticks))
 	for _, tick := range ticksBasedPool.Ticks {
 		// skip uninitialized ticks
@@ -813,23 +811,14 @@ func (t *PoolTracker) updateState(
 		return entityPoolTicks[i].Index < entityPoolTicks[j].Index
 	})
 
-	rpcState, hook, hookParam, err := t.fetchOnchainState(ctx, &p, blockNumber, overrides)
+	// Always fetch scalar state at latest, never at this batch's own block: see the
+	// comment on the equivalent fetch in uniswap/v3/pool_tracker.go's updateState.
+	rpcState, hook, hookParam, err := t.fetchOnchainState(ctx, &p, 0, overrides)
 	if err != nil {
-		if blockNumber > 0 && tickspkg.IsMissingTrieNodeError(err) {
-			rpcState, hook, hookParam, err = t.fetchOnchainState(ctx, &p, 0, overrides)
-			if err != nil {
-				l.WithFields(logger.Fields{
-					"error": err,
-				}).Error("failed to fetch latest state from RPC")
-				return p, err
-			}
-		} else {
-			l.WithFields(logger.Fields{
-				"error":       err,
-				"blockNumber": blockNumber,
-			}).Error("failed to fetch state from RPC")
-			return p, err
-		}
+		l.WithFields(logger.Fields{
+			"error": err,
+		}).Error("failed to fetch state from RPC")
+		return p, err
 	} else if rpcState.Slot0.SqrtPriceX96.Sign() == 0 {
 		l.Error("sqrtPriceX96 is 0")
 		return p, errors.New("sqrtPriceX96 is 0")
@@ -862,22 +851,9 @@ func (t *PoolTracker) updateState(
 
 	p.SwapFee, _ = rpcState.Slot0.LpFee.Float64()
 	p.Extra = string(extraBytes)
-	p.Timestamp = t.estimateLastActivityTime(&p, logs, blockHeaders)
+	p.Timestamp = tickspkg.EstimateLastActivityTime(&p, logs, blockHeaders)
 
 	return p, nil
-}
-
-func (t *PoolTracker) estimateLastActivityTime(p *entity.Pool, logs []ethtypes.Log,
-	blockHeaders map[uint64]entity.BlockHeader) int64 {
-	if len(logs) > 0 && blockHeaders != nil {
-		latestLog := logs[len(logs)-1]
-		if blockHeader, ok := blockHeaders[latestLog.BlockNumber]; ok {
-			return max(p.Timestamp, int64(blockHeader.Timestamp))
-		}
-	}
-
-	// Do not update the timestamp as the pool triggered state update via a custom empty log.
-	return p.Timestamp
 }
 
 func stringToBytes32(str string) [32]byte {


### PR DESCRIPTION
Fetching sqrtPrice/tick/liquidity at a catch-up batch's own (potentially old)
block number hits pruned-state errors once that block falls outside the RPC
provider's retention window. Ticks are already applied incrementally from
decoded logs, so scalar state only ever needs to reflect "now" - fetch at
latest (blockNumber=0) instead, across all 12 ticks-based trackers.

Also hoists the duplicated last-activity-timestamp logic (chain-timestamp
max-wins, so replaying an old event can't make an abandoned pool look freshly
active) into a single shared tickspkg.EstimateLastActivityTime, extending it
to the 8 trackers that were previously using wall-clock time.Now() instead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
