### PR TITLE
feat(univ4-hooks): thread override state into aegis and stable-stable Track

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/aegis/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegis/hook.go
@@ -47,7 +47,7 @@ var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv
 func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
 	hook := hexutil.Encode(param.HookAddress[:])
 	if valueobject.IsZeroAddress(h.DynamicFeeManagerAddress) {
-		if _, err := param.RpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
 			ABI:    aegisHookABI,
 			Target: hook,
 			Method: "policyManager",
@@ -69,7 +69,7 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 	var dynamicFeeState DynamicFeeStateRPC
 	var manualFee ManualFeeRPC
 	var poolPOLShare *big.Int
-	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber)
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).SetOverrides(param.Overrides)
 	newVersion := valueobject.IsZeroAddress(h.PolicyManagerAddress)
 	if newVersion {
 		req = req.AddCall(&ethrpc.Call{

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/hook.go
@@ -63,7 +63,7 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 		state feeStateRPC
 	)
 
-	req := param.RpcClient.NewRequest().SetContext(ctx)
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetOverrides(param.Overrides)
 	if param.BlockNumber != nil {
 		req.SetBlockNumber(param.BlockNumber)
 	}


### PR DESCRIPTION
## What

The `aegis` and `stable-stable` uniswap-v4 dynamic-fee hooks recompute their swap fee from **live hook-side state** that a victim swap moves:

- **aegis** — reads the `dynamicFeeManager` (`feeQuote`/`getFeeState` → `BaseFee`+`SurgeFee`) and protocol-fee share.
- **stable-stable** — reads `feeConfig`/`feeState` (block-decaying fee) off the hook.

But both hooks' `Track()` built their `ethrpc` requests **without** `.SetOverrides(...)`. So when `PoolTracker.GetNewPoolStateWithOverrides` runs on the dexdex-arb backrun path, the base slot0/liquidity read honors the pending-tx prestate override but the **hook fee read did not** — it returned the pre-victim confirmed state. Result: the backrun sim uses a stale fee → over-quotes → phantom backruns.

## Change

Thread `param.Overrides` into every `ethrpc` request in both hooks' `Track()`, exactly mirroring the already-override-aware hooks `angstrom` (`req := ...SetContext(ctx).SetOverrides(param.Overrides)`) and `arrakis` (`.SetContext(ctx).SetOverrides(param.Overrides).AddCall(...)`).

- aegis: added `.SetOverrides(param.Overrides)` to both the manager-address discovery batch and the fee-state batch.
- stable-stable: added `.SetOverrides(param.Overrides)` to the `feeConfig`/`feeState` batch.

## Safety

Behavior is **byte-identical on the normal-flow `GetNewPoolState` path**, which passes `nil` overrides — `SetOverrides(nil)` is a no-op (same as angstrom/arrakis today). Only the override path (`GetNewPoolStateWithOverrides`) changes, now correctly reading hook fee state under the victim's post-swap prestate.

## Test

`gofmt` clean, `go build` ok, `golangci-lint` 0 issues, `go test` on both packages green (8 passed). No `Track` tests exist in either package to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)