### PR TITLE
fix(euler-swap): nil-guard ConvertToAssets against unfetched vault totals

### DIFF
--- a/pkg/liquidity-source/euler-swap/shared/utils.go
+++ b/pkg/liquidity-source/euler-swap/shared/utils.go
@@ -13,7 +13,15 @@ var (
 )
 
 func ConvertToAssets(shares, totalAssets, totalSupply *big.Int) *big.Int {
-	if totalSupply.Sign() == 0 {
+	if shares == nil {
+		return big.NewInt(0)
+	}
+	// A nil total means the vault's balances were never fetched (e.g. the
+	// controller-only vault v2's pool_tracker appends past the batch RPC has no
+	// totalAssets/totalSupply call), and a zero supply means no shares are
+	// outstanding — in both cases assets == shares 1:1. Guarding here avoids the
+	// nil *big.Int deref in totalSupply.Sign()/Add that otherwise panics.
+	if totalSupply == nil || totalAssets == nil || totalSupply.Sign() == 0 {
 		return shares
 	}
 	// (shares * (totalAssets + VirtualAmount)) / (totalSupply + VirtualAmount)

--- a/pkg/liquidity-source/euler-swap/shared/utils.go
+++ b/pkg/liquidity-source/euler-swap/shared/utils.go
@@ -14,7 +14,7 @@ var (
 
 func ConvertToAssets(shares, totalAssets, totalSupply *big.Int) *big.Int {
 	if shares == nil {
-		return big.NewInt(0)
+		return bignumber.ZeroBI
 	}
 	// A nil total means the vault's balances were never fetched (e.g. the
 	// controller-only vault v2's pool_tracker appends past the batch RPC has no

--- a/pkg/liquidity-source/euler-swap/shared/utils.go
+++ b/pkg/liquidity-source/euler-swap/shared/utils.go
@@ -14,7 +14,7 @@ var (
 
 func ConvertToAssets(shares, totalAssets, totalSupply *big.Int) *big.Int {
 	if shares == nil {
-		return bignumber.ZeroBI
+		return big.NewInt(0)
 	}
 	// A nil total means the vault's balances were never fetched (e.g. the
 	// controller-only vault v2's pool_tracker appends past the batch RPC has no

--- a/pkg/liquidity-source/euler-swap/shared/utils_test.go
+++ b/pkg/liquidity-source/euler-swap/shared/utils_test.go
@@ -1,0 +1,80 @@
+package shared
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToAssets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		shares      *big.Int
+		totalAssets *big.Int
+		totalSupply *big.Int
+		want        *big.Int
+	}{
+		{
+			// Controller-only vault appended by v2's pool_tracker: EulerAccountBalance
+			// is set to 0 but totalAssets/totalSupply are never fetched (nil). Must not
+			// panic — this is the exact prod SIGSEGV at utils.go:16.
+			name:        "nil totals with zero shares -> 0 (controller-only vault)",
+			shares:      big.NewInt(0),
+			totalAssets: nil,
+			totalSupply: nil,
+			want:        big.NewInt(0),
+		},
+		{
+			name:        "nil shares -> 0",
+			shares:      nil,
+			totalAssets: big.NewInt(100),
+			totalSupply: big.NewInt(100),
+			want:        big.NewInt(0),
+		},
+		{
+			name:        "nil totalSupply -> shares 1:1",
+			shares:      big.NewInt(42),
+			totalAssets: big.NewInt(100),
+			totalSupply: nil,
+			want:        big.NewInt(42),
+		},
+		{
+			name:        "nil totalAssets -> shares 1:1",
+			shares:      big.NewInt(42),
+			totalAssets: nil,
+			totalSupply: big.NewInt(100),
+			want:        big.NewInt(42),
+		},
+		{
+			name:        "zero supply -> shares 1:1",
+			shares:      big.NewInt(42),
+			totalAssets: big.NewInt(0),
+			totalSupply: big.NewInt(0),
+			want:        big.NewInt(42),
+		},
+		{
+			// (shares * (totalAssets + VirtualAmount)) / (totalSupply + VirtualAmount)
+			// VirtualAmount = 1e6: (2 * (2e6 + 1e6)) / (1e6 + 1e6) = 6e6 / 2e6 = 3
+			name:        "normal conversion",
+			shares:      big.NewInt(2),
+			totalAssets: big.NewInt(2_000_000),
+			totalSupply: big.NewInt(1_000_000),
+			want:        big.NewInt(3),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, func() {
+				got := ConvertToAssets(tt.shares, tt.totalAssets, tt.totalSupply)
+				assert.Zero(t, got.Cmp(tt.want), "got %s want %s", got, tt.want)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

Prod panic in dexdex-arb (`pending_pool_state_from_logs_count{result="panic"}` nonzero for `euler-swap-v2`, ~100/7d). The recovered SIGSEGV stack is:

```
math/big.(*Int).Sign(...)  int.go:48
euler-swap/shared.ConvertToAssets(...)  shared/utils.go:16
euler-swap/v2.(*PoolTracker).getPoolData(...)  v2/pool_tracker.go:444
```

`euler-swap/v2`'s `getPoolData` appends a **controller-only vault** past the batch RPC when the euler account's enabled controller is not one of its supply/borrow vaults:

```go
vaults = append(vaults, shared.VaultRPC{}) // TotalAssets/TotalSupply left nil
...
vaults[idx].EulerAccountBalance = big.NewInt(0) // only this is set
```

The post-RPC loop then converts **every** vault with no bounds guard:

```go
for i := range vaults {
    vaults[i].EulerAccountBalance = shared.ConvertToAssets(
        vaults[i].EulerAccountBalance, vaults[i].TotalAssets, vaults[i].TotalSupply)
}
```

For the appended controller vault `TotalSupply` is `nil`, so `ConvertToAssets` panics at `totalSupply.Sign()`. `euler-swap/v1` never hit this because its equivalent loop is guarded `if i < 2` — v2 dropped that guard.

This tracker is only exercised on dexdex-arb's pending/backrun path (normal-flow sims come from pool-service snapshots), which is why it surfaced only there. dexdex-arb's updater recovers the panic, so the process does not crash — but the victim's backrun is silently skipped.

## Fix

Nil-guard `ConvertToAssets` — the single choke point shared by v1 and v2 and the exact panic frame. A nil total (vault balances never fetched) or a zero supply means there are no shares to price against, so assets == shares 1:1. For the appended controller vault (`shares = 0`) this yields the correct `0`; no skip, backrun keeps working. Added unit tests for every nil path plus the happy-path conversion.

## Test

- `go build ./pkg/liquidity-source/euler-swap/...` clean
- `go test ./pkg/liquidity-source/euler-swap/shared/...` pass (new `utils_test.go`)
- `golangci-lint run ./pkg/liquidity-source/euler-swap/shared/...` — 0 issues

`TestIntegration_V2_ComputeQuote` is a live-mainnet-RPC integration test; it is flaky/failing on the base branch independently of this change and is unrelated (a separate `index out of range` in RPC-response handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)