### PR TITLE
fix: apply taker fee + staleness haircut in aegisprop hook pricing

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/abis/AegisPropHook.json
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/abis/AegisPropHook.json
@@ -37,5 +37,36 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "PoolId", "name": "poolId", "type": "bytes32" }
+    ],
+    "name": "poolConfig",
+    "outputs": [
+      { "internalType": "MmId", "name": "mmId", "type": "uint16" },
+      { "internalType": "uint8", "name": "token0Decimals", "type": "uint8" },
+      { "internalType": "uint8", "name": "token1Decimals", "type": "uint8" },
+      { "internalType": "SlackBps", "name": "slackBps", "type": "uint16" },
+      { "internalType": "TakerFeeBps", "name": "takerFeeBps", "type": "uint16" },
+      { "internalType": "HaircutBps", "name": "haircutBpsAtStaleThreshold", "type": "uint16" },
+      { "internalType": "uint32", "name": "freshThresholdSec", "type": "uint32" },
+      { "internalType": "uint32", "name": "staleThresholdSec", "type": "uint32" },
+      {
+        "components": [
+          { "internalType": "address", "name": "feedA", "type": "address" },
+          { "internalType": "uint8", "name": "feedADecimals", "type": "uint8" },
+          { "internalType": "bool", "name": "isCrossRate", "type": "bool" },
+          { "internalType": "bool", "name": "requiresSequencerFeed", "type": "bool" },
+          { "internalType": "address", "name": "feedB", "type": "address" },
+          { "internalType": "uint8", "name": "feedBDecimals", "type": "uint8" }
+        ],
+        "internalType": "struct OracleConfig",
+        "name": "oracle",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/constant.go
@@ -6,7 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const gasBeforeSwap int64 = 39838 // same order as other PropAMM-family hooks (st0x); refine once measured on-chain
+const (
+	gasBeforeSwap int64  = 75160
+	bpsDenom      uint64 = 10_000
+)
 
 var (
 	ErrInvalidAmount           = errors.New("aegisprop: invalid swap amount")

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/hook.go
@@ -41,8 +41,33 @@ type LadderRPC struct {
 	AskLen     uint8
 }
 
-// Hook holds the last-tracked ladder (integration guide §4 Path B), used to compute indicative
-// swap amounts off-chain during route simulation.
+// PoolConfigRPC mirrors the hook's poolConfig(poolId) getter. Oracle is decoded because it's part
+// of the same ABI tuple, but only the fee/staleness fields are actually used.
+type PoolConfigRPC struct {
+	MmId                       uint16
+	Token0Decimals             uint8
+	Token1Decimals             uint8
+	SlackBps                   uint16
+	TakerFeeBps                uint16
+	HaircutBpsAtStaleThreshold uint16
+	FreshThresholdSec          uint32
+	StaleThresholdSec          uint32
+	Oracle                     OracleConfigRPC
+}
+
+type OracleConfigRPC struct {
+	FeedA                 common.Address
+	FeedADecimals         uint8
+	IsCrossRate           bool
+	RequiresSequencerFeed bool
+	FeedB                 common.Address
+	FeedBDecimals         uint8
+}
+
+// Hook holds the last-tracked ladder (integration guide §4 Path B) plus the venue's taker fee and
+// staleness-haircut config, used to compute indicative swap amounts off-chain during route
+// simulation. The ladder walk alone (as documented) omits fees/protective adjustments the on-chain
+// hook applies in beforeSwap; TakerFeeBps and the staleness ramp fields replicate that on top.
 type Hook struct {
 	uniswapv4.Hook `json:"-"`
 
@@ -50,6 +75,12 @@ type Hook struct {
 	Asks []Level `json:"k"`
 
 	Expiration uint64 `json:"e"` // unix ts; ladder valid while now < Expiration
+
+	TakerFeeBps                uint64 `json:"f"`
+	HaircutBpsAtStaleThreshold uint64 `json:"h"`
+	FreshThresholdSec          uint64 `json:"fs"`
+	StaleThresholdSec          uint64 `json:"ss"`
+	TrackedAt                  uint64 `json:"t"` // unix ts when Track last ran; used as the staleness-ramp age baseline
 }
 
 type SwapInfo struct {
@@ -96,6 +127,7 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 	hookAddr := param.HookAddress.Hex()
 
 	var ladder LadderRPC
+	var poolConfig PoolConfigRPC
 	req := param.RpcClient.NewRequest().SetContext(ctx)
 	if param.BlockNumber != nil {
 		req.SetBlockNumber(param.BlockNumber)
@@ -105,7 +137,12 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 		Target: hookAddr,
 		Method: "ladder",
 		Params: []any{poolId},
-	}, []any{&struct{*LadderRPC}{&ladder}})
+	}, []any{&struct{ *LadderRPC }{&ladder}}).AddCall(&ethrpc.Call{
+		ABI:    aegisPropHookABI,
+		Target: hookAddr,
+		Method: "poolConfig",
+		Params: []any{poolId},
+	}, []any{&poolConfig})
 
 	if _, err := req.Aggregate(); err != nil {
 		return nil, fmt.Errorf("failed to track aegis propamm ladder: %w", err)
@@ -114,6 +151,12 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 	h.Bids = toLevels(ladder.Bids[:], ladder.BidLen)
 	h.Asks = toLevels(ladder.Asks[:], ladder.AskLen)
 	h.Expiration = uint64(ladder.Expiration)
+
+	h.TakerFeeBps = uint64(poolConfig.TakerFeeBps)
+	h.HaircutBpsAtStaleThreshold = uint64(poolConfig.HaircutBpsAtStaleThreshold)
+	h.FreshThresholdSec = uint64(poolConfig.FreshThresholdSec)
+	h.StaleThresholdSec = uint64(poolConfig.StaleThresholdSec)
+	h.TrackedAt = uint64(time.Now().Unix())
 
 	return json.Marshal(h)
 }
@@ -141,8 +184,22 @@ func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.Before
 		}, nil
 	}
 
-	if h.Expiration != 0 && time.Now().Unix() >= int64(h.Expiration) {
+	now := uint64(time.Now().Unix())
+	if h.Expiration != 0 && now >= h.Expiration {
 		return nil, ErrStaleLadder
+	}
+
+	age := now - h.TrackedAt
+	if now < h.TrackedAt {
+		age = 0
+	}
+	haircutBps, freshEnough := stalenessHaircutBps(age, h.FreshThresholdSec, h.StaleThresholdSec, uint16(h.HaircutBpsAtStaleThreshold))
+	if !freshEnough {
+		return nil, ErrStaleLadder
+	}
+	totalBps := h.TakerFeeBps + haircutBps
+	if totalBps >= bpsDenom {
+		return nil, ErrInvalidAmount
 	}
 
 	amtU, overflow := uint256.FromBig(amt)
@@ -163,15 +220,19 @@ func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.Before
 		updated                          []Level
 	)
 	if params.CalcOut {
-		out, upd, filled := walkExactIn(levels, amtU, params.ZeroForOne)
+		rawOut, upd, filled := walkExactIn(levels, amtU, params.ZeroForOne)
 		if !filled {
 			return nil, ErrInsufficientLadderDepth
 		}
 		updated = upd
+		out := applyFeeOut(rawOut, totalBps)
 		deltaSpecified = new(big.Int).Set(amt)
 		deltaUnspecified = new(big.Int).Neg(out.ToBig())
 	} else {
-		in, upd, filled := walkExactOut(levels, amtU, params.ZeroForOne)
+		// The taker fee/haircut is applied to the amount the taker pays, so the ladder must be
+		// walked for the larger pre-fee input that nets the requested output after the haircut.
+		grossAmt := applyFeeIn(amtU, totalBps)
+		in, upd, filled := walkExactOut(levels, grossAmt, params.ZeroForOne)
 		if !filled {
 			return nil, ErrInsufficientLadderDepth
 		}

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math.go
@@ -6,7 +6,40 @@ import (
 	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 )
 
-var uPriceScale = u256.TenPow(18)
+var (
+	uPriceScale = u256.TenPow(18)
+	uBpsDenom   = uint256.NewInt(bpsDenom)
+)
+
+// stalenessHaircutBps linearly ramps from 0 at age==freshThresholdSec up to haircutBpsAtStale at
+// age==staleThresholdSec, matching the on-chain hook's ceil-rounded interpolation. filled is false
+// once age exceeds staleThresholdSec, mirroring the hook's own reject-on-stale behavior.
+func stalenessHaircutBps(age, freshThresholdSec, staleThresholdSec uint64, haircutBpsAtStale uint16) (bps uint64, ok bool) {
+	if age > staleThresholdSec {
+		return 0, false
+	}
+	if age <= freshThresholdSec || staleThresholdSec <= freshThresholdSec {
+		return 0, true
+	}
+	span := staleThresholdSec - freshThresholdSec
+	num := (age - freshThresholdSec) * uint64(haircutBpsAtStale)
+	return (num + span - 1) / span, true // ceil division
+}
+
+// applyFeeOut applies the combined taker fee + staleness haircut to a raw ladder-walk output
+// amount, rounding down in the venue's favor: out = floor(raw * (10000-totalBps) / 10000).
+func applyFeeOut(raw *uint256.Int, totalBps uint64) *uint256.Int {
+	mult := uint256.NewInt(bpsDenom - totalBps)
+	return u256.MulDivDown(new(uint256.Int), raw, mult, uBpsDenom)
+}
+
+// applyFeeIn is the exact-out counterpart of applyFeeOut: it inflates a raw ladder-walk input
+// requirement so the taker pays for the fee/haircut, rounding up in the venue's favor:
+// in = ceil(raw * 10000 / (10000-totalBps)).
+func applyFeeIn(raw *uint256.Int, totalBps uint64) *uint256.Int {
+	mult := uint256.NewInt(bpsDenom - totalBps)
+	return u256.MulDivUp(new(uint256.Int), raw, uBpsDenom, mult)
+}
 
 // walkExactIn replicates the reference off-chain ladder traversal (integration guide §4 B3):
 // walk levels best-price-first, filling amountIn and accumulating the counter amount.

--- a/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/aegisprop/math_test.go
@@ -64,3 +64,36 @@ func TestWalkExactOut_Asks_MatchesExactInInverse(t *testing.T) {
 	assert.Equal(t, "150", in.Dec())
 	assert.Equal(t, "25", updated[0].Amplitude.Dec())
 }
+
+func TestStalenessHaircutBps(t *testing.T) {
+	// fresh: no ramp yet
+	bps, ok := stalenessHaircutBps(30, 60, 300, 500)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(0), bps)
+
+	// halfway between fresh(60) and stale(300) thresholds -> half of the 500bps cap, rounded up
+	bps, ok = stalenessHaircutBps(180, 60, 300, 500)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(250), bps)
+
+	// at the stale threshold -> full haircut
+	bps, ok = stalenessHaircutBps(300, 60, 300, 500)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(500), bps)
+
+	// past the stale threshold -> reject, mirrors the on-chain hook's error 62
+	_, ok = stalenessHaircutBps(301, 60, 300, 500)
+	assert.False(t, ok)
+}
+
+func TestApplyFee_OutInRoundTrip(t *testing.T) {
+	raw := uint256.NewInt(1_000_000)
+	totalBps := uint64(10) // 10bps, matching the reported overquote
+
+	out := applyFeeOut(raw, totalBps)
+	assert.Equal(t, "999000", out.Dec())
+
+	// applyFeeIn should recover (>=) the raw amount needed to net `out` after the same haircut.
+	grossBack := applyFeeIn(out, totalBps)
+	assert.True(t, grossBack.Cmp(raw) <= 0)
+}


### PR DESCRIPTION
The ladder-walk math only implemented the venue's documented Path B
indicative pricing, which explicitly omits fees and protective
adjustments (integration guide §4 B4). This caused a systematic ~10bps
overquote versus the real hook.

Fetches poolConfig(poolId) (takerFeeBps, haircutBpsAtStaleThreshold,
freshThresholdSec, staleThresholdSec) alongside the ladder in Track(),
and applies a combined taker-fee + linearly-interpolated staleness
haircut on the raw ladder-walk amount in BeforeSwap, mirroring the
on-chain hook's beforeSwap haircut formula (confirmed via decompiled
bytecode: ceil-rounded linear ramp between the fresh/stale thresholds,
identical shape to the on-chain 0x3d55 helper).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
