### PR TITLE
feat(brownfi-v3): add router address for robinhood chain

### DIFF
--- a/pkg/liquidity-source/brownfi/v3/constant.go
+++ b/pkg/liquidity-source/brownfi/v3/constant.go
@@ -54,6 +54,7 @@ var (
 		valueobject.ChainIDLinea:           common.HexToAddress("0xB3c31fDc0a22D5725C47B1fC430F5B87353D8C3e"),
 		valueobject.ChainIDMonad:           common.HexToAddress("0x43C08a1689e81EFF83bbAfA35617CcCf2EF463fD"),
 		valueobject.ChainIDPolygon:         common.HexToAddress("0x6739e1b16AC12cae7A233d9804DB8128DeA9886A"),
+		valueobject.ChainIDRobinhood:       common.HexToAddress("0x2A08Da7B6590ce5D217161F234069CfC54DBe554"),
 	}
 
 	q64        = big256.U2Pow64


### PR DESCRIPTION
## Summary
- BrownFi V3 deployed on robinhood (chainId 4663), adds router address `0x2A08Da7B6590ce5D217161F234069CfC54DBe554` to the `Router` map in `pkg/liquidity-source/brownfi/v3/constant.go`.
- Requested by BrownFi team for the robinhood chain deployment.
- Follow-up: pool-service and router-service configs for robinhood (separate PRs) depend on a dex-lib release including this change, then a go.mod bump in both repos.

## Test plan
- [x] `go build ./pkg/liquidity-source/brownfi/...`
- [x] Confirmed factory/router/wrappedNative addresses have deployed bytecode on robinhood RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)