### PR TITLE
fix: restore big.Int Extra shape after uniswap-v3 fork merge, fix machima

### DIFF
--- a/pkg/liquidity-source/machima/pool_simulator_test.go
+++ b/pkg/liquidity-source/machima/pool_simulator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/msgpack/v5"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
@@ -527,6 +528,43 @@ func TestExtraRoundTripsBothDirections(t *testing.T) {
 	assert.Equal(t, sqrtPrice.String(), tickU256.SqrtPriceX96.Dec())
 	require.Len(t, tickU256.Ticks, 2)
 	assert.Equal(t, "-1000", tickU256.Ticks[1].LiquidityNet.Dec())
+}
+
+// TestUnmarshalExtraReadsUint256Shape is the regression test for the production incident: the
+// delegated UniV3 tracker writes ExtraTickU256 (quoted decimal strings) for every fork now,
+// which used to fail with `math/big: cannot unmarshal "\"...\"" into a *big.Int`. Pins that
+// unmarshalExtra produces the same big.Int values a pre-merge, unquoted payload would have.
+func TestUnmarshalExtraReadsUint256Shape(t *testing.T) {
+	sqrtPrice, ok := new(big.Int).SetString("1053589212355731537798233", 10)
+	require.True(t, ok)
+	tick := -183000
+
+	v3Written := uniswapv3.ExtraTickU256{
+		Liquidity:    uint256.NewInt(123456789),
+		SqrtPriceX96: uint256.MustFromBig(sqrtPrice),
+		TickSpacing:  defaultTickSpacing,
+		Tick:         &tick,
+		Ticks: []uniswapv3.TickU256{
+			{Index: -887200, LiquidityGross: uint256.NewInt(1000), LiquidityNet: int256.NewInt(1000)},
+			{Index: 887200, LiquidityGross: uint256.NewInt(1000), LiquidityNet: int256.NewInt(-1000)},
+		},
+	}
+	raw, err := json.Marshal(v3Written)
+	require.NoError(t, err)
+	// Confirms the fixture actually reproduces the incident's wire format: quoted decimal strings,
+	// not the plain numbers big.Int would have written.
+	require.Contains(t, string(raw), `"liquidity":"123456789"`)
+	require.Contains(t, string(raw), `"sqrtPriceX96":"1053589212355731537798233"`)
+
+	extra, err := unmarshalExtra(string(raw))
+	require.NoError(t, err, "unmarshalExtra must read the uint256 shape uniswapv3.Tracker actually writes")
+
+	assert.Equal(t, "123456789", extra.Liquidity.String())
+	assert.Equal(t, sqrtPrice.String(), extra.SqrtPriceX96.String())
+	assert.Equal(t, defaultTickSpacing, extra.TickSpacing)
+	assert.Equal(t, "-183000", extra.Tick.String())
+	require.Len(t, extra.Ticks, 2)
+	assert.Equal(t, "-1000", extra.Ticks[1].LiquidityNet.String())
 }
 
 // TestProtocolStateSurvivesUniswapV3Rewrite is the regression test for pools landing in Redis with

--- a/pkg/liquidity-source/machima/pool_tracker.go
+++ b/pkg/liquidity-source/machima/pool_tracker.go
@@ -233,14 +233,48 @@ func (t *PoolTracker) applyMachimaState(ctx context.Context, p entity.Pool,
 
 // unmarshalExtra decodes the Extra written by either layer. Machima's Extra is a superset of the
 // UniV3 one and shares its JSON field names, so the UniV3 output round-trips through it.
+// unmarshalExtra decodes Extra written by either layer. uniswapv3.Tracker now always writes the
+// uint256-based ExtraTickU256 (quoted decimal strings), which math/big refuses to read, so this
+// reads through that tolerant shape (uint256.Int/int256.Int accept quoted or plain numbers) and
+// converts back to the big.Int Extra this package writes - keeping Extra's own JSON output
+// byte-compatible with consumers that unmarshal it as big.Int directly.
 func unmarshalExtra(raw string) (Extra, error) {
 	var extra Extra
 	if raw == "" {
 		return extra, nil
 	}
-	if err := json.Unmarshal([]byte(raw), &extra); err != nil {
+
+	var u256 struct {
+		uniswapv3.ExtraTickU256
+		ProtocolState
+	}
+	if err := json.Unmarshal([]byte(raw), &u256); err != nil {
 		return Extra{}, errors.WithMessage(err, "unmarshal extra")
 	}
+
+	extra.ProtocolState = u256.ProtocolState
+	extra.TickSpacing = u256.TickSpacing
+	extra.BuyRestrictedToken = u256.BuyRestrictedToken
+	if u256.Liquidity != nil {
+		extra.Liquidity = u256.Liquidity.ToBig()
+	}
+	if u256.SqrtPriceX96 != nil {
+		extra.SqrtPriceX96 = u256.SqrtPriceX96.ToBig()
+	}
+	if u256.Tick != nil {
+		extra.Tick = big.NewInt(int64(*u256.Tick))
+	}
+	if len(u256.Ticks) > 0 {
+		extra.Ticks = make([]uniswapv3.Tick, len(u256.Ticks))
+		for i, tick := range u256.Ticks {
+			extra.Ticks[i] = uniswapv3.Tick{
+				Index:          tick.Index,
+				LiquidityGross: tick.LiquidityGross.ToBig(),
+				LiquidityNet:   tick.LiquidityNet.ToBig(),
+			}
+		}
+	}
+
 	return extra, nil
 }
 

--- a/pkg/liquidity-source/uniswap/v3/pool_factory.go
+++ b/pkg/liquidity-source/uniswap/v3/pool_factory.go
@@ -12,49 +12,28 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/poolfactory"
 )
 
+// Every DexType merged into this package registers the same NewPoolFactory, and every pool it
+// creates is stamped Type: DexTypeUniswapV3 regardless of which one - the underlying logic is
+// identical across all six, so any of the six registered types resolves the same simulator/
+// tracker/factory. Exchange (Config.DexID) still carries the real per-deployment identity.
 var (
-	_ = poolfactory.RegisterFactoryC(DexTypeUniswapV3, NewUniswapV3PoolFactory)
-	_ = poolfactory.RegisterFactoryC(DexTypePancakeV3, NewPancakeV3PoolFactory)
-	_ = poolfactory.RegisterFactoryC(DexTypeRamsesV2, NewRamsesV2PoolFactory)
-	_ = poolfactory.RegisterFactoryC(DexTypeSolidlyV3, NewSolidlyV3PoolFactory)
-	_ = poolfactory.RegisterFactoryC(DexTypeSlipstream, NewSlipstreamPoolFactory)
-	_ = poolfactory.RegisterFactoryC(DexTypeNuriV2, NewNuriV2PoolFactory)
+	_ = poolfactory.RegisterFactoryC(DexTypeUniswapV3, NewPoolFactory)
+	_ = poolfactory.RegisterFactoryC(DexTypePancakeV3, NewPoolFactory)
+	_ = poolfactory.RegisterFactoryC(DexTypeRamsesV2, NewPoolFactory)
+	_ = poolfactory.RegisterFactoryC(DexTypeSolidlyV3, NewPoolFactory)
+	_ = poolfactory.RegisterFactoryC(DexTypeSlipstream, NewPoolFactory)
+	_ = poolfactory.RegisterFactoryC(DexTypeNuriV2, NewPoolFactory)
 )
-
-func NewUniswapV3PoolFactory(config *Config) *PoolFactory {
-	return newPoolFactory(config, DexTypeUniswapV3)
-}
-
-func NewPancakeV3PoolFactory(config *Config) *PoolFactory {
-	return newPoolFactory(config, DexTypePancakeV3)
-}
-
-func NewRamsesV2PoolFactory(config *Config) *PoolFactory {
-	return newPoolFactory(config, DexTypeRamsesV2)
-}
-
-func NewSolidlyV3PoolFactory(config *Config) *PoolFactory {
-	return newPoolFactory(config, DexTypeSolidlyV3)
-}
-
-func NewSlipstreamPoolFactory(config *Config) *PoolFactory {
-	return newPoolFactory(config, DexTypeSlipstream)
-}
-
-func NewNuriV2PoolFactory(config *Config) *PoolFactory {
-	return newPoolFactory(config, DexTypeNuriV2)
-}
 
 // PoolFactory decodes PoolCreated events for every uniswap-v3 fork merged into this
 // package. It needs no per-fork ABI: see the topic0 comment on poolCreatedEventIDWithFee
 // in constant.go for why token0/token1/pool can always be read positionally.
 type PoolFactory struct {
-	config  *Config
-	dexType string
+	config *Config
 }
 
-func newPoolFactory(config *Config, dexType string) *PoolFactory {
-	return &PoolFactory{config: config, dexType: dexType}
+func NewPoolFactory(config *Config) *PoolFactory {
+	return &PoolFactory{config: config}
 }
 
 func (f *PoolFactory) DecodePoolCreated(event ethtypes.Log) (*entity.Pool, error) {
@@ -96,7 +75,7 @@ func (f *PoolFactory) newPool(token0, token1, poolAddress common.Address, blockN
 	return &entity.Pool{
 		Address:     poolAddressHex,
 		Exchange:    f.config.DexID,
-		Type:        f.dexType,
+		Type:        DexTypeUniswapV3,
 		Timestamp:   time.Now().Unix(),
 		Reserves:    entity.PoolReserves{"0", "0"},
 		Tokens:      []*entity.PoolToken{&t0, &t1},

--- a/pkg/liquidity-source/uniswap/v3/pool_factory_test.go
+++ b/pkg/liquidity-source/uniswap/v3/pool_factory_test.go
@@ -28,7 +28,7 @@ func TestDecodePoolCreated_SolidlyShape(t *testing.T) {
 		Data: common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000027100000000000000000000000006339962d8b80749ce86d65affc0b2a4290aef42f"),
 	}
 
-	factory := NewSolidlyV3PoolFactory(&Config{DexID: "solidlyv3"})
+	factory := NewPoolFactory(&Config{DexID: "solidlyv3"})
 	require.True(t, factory.IsEventSupported(event.Topics[0]))
 
 	p, err := factory.DecodePoolCreated(event)
@@ -37,7 +37,7 @@ func TestDecodePoolCreated_SolidlyShape(t *testing.T) {
 	assert.Equal(t, "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", p.Tokens[0].Address)
 	assert.Equal(t, "0xd555498a524612c67f286df0e0a9a64a73a7cdc7", p.Tokens[1].Address)
 	assert.Equal(t, "0x6339962d8b80749ce86d65affc0b2a4290aef42f", p.Address)
-	assert.Equal(t, DexTypeSolidlyV3, p.Type)
+	assert.Equal(t, DexTypeUniswapV3, p.Type)
 	assert.Equal(t, "solidlyv3", p.Exchange)
 	// fee/tickSpacing are deliberately left at zero here; the tracker's first refresh
 	// resolves them generically regardless of which fork this pool belongs to.
@@ -61,7 +61,7 @@ func TestDecodePoolCreated_SlipstreamShape(t *testing.T) {
 		Data: common.Hex2Bytes("00000000000000000000000020efb6b14640fa4e20cd04456ccf8bba9937307b"),
 	}
 
-	factory := NewSlipstreamPoolFactory(&Config{DexID: "slipstream-x"})
+	factory := NewPoolFactory(&Config{DexID: "slipstream-x"})
 	require.True(t, factory.IsEventSupported(event.Topics[0]))
 
 	p, err := factory.DecodePoolCreated(event)
@@ -70,7 +70,7 @@ func TestDecodePoolCreated_SlipstreamShape(t *testing.T) {
 	assert.Equal(t, "0x0b2c639c533813f4aa9d7837caf62653d097ff85", p.Tokens[0].Address)
 	assert.Equal(t, "0xdfa46478f9e5ea86d57387849598dbfb2e964b02", p.Tokens[1].Address)
 	assert.Equal(t, "0x20efb6b14640fa4e20cd04456ccf8bba9937307b", p.Address)
-	assert.Equal(t, DexTypeSlipstream, p.Type)
+	assert.Equal(t, DexTypeUniswapV3, p.Type)
 	assert.Equal(t, "slipstream-x", p.Exchange)
 	assert.Equal(t, float64(0), p.SwapFee)
 }
@@ -78,7 +78,7 @@ func TestDecodePoolCreated_SlipstreamShape(t *testing.T) {
 func TestPoolFactory_IsEventSupported(t *testing.T) {
 	t.Parallel()
 
-	factory := NewUniswapV3PoolFactory(&Config{DexID: "uniswapv3"})
+	factory := NewPoolFactory(&Config{DexID: "uniswapv3"})
 	assert.True(t, factory.IsEventSupported(poolCreatedEventIDWithFee))
 	assert.True(t, factory.IsEventSupported(poolCreatedEventIDNoFee))
 	assert.False(t, factory.IsEventSupported(mintEventID))

--- a/pkg/liquidity-source/uniswap/v3/pool_tracker.go
+++ b/pkg/liquidity-source/uniswap/v3/pool_tracker.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/KyberNetwork/ethrpc"
-	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/logger"
 	ethabi "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/goccy/go-json"
-	"github.com/holiman/uint256"
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"
 
@@ -144,6 +142,9 @@ func (t *Tracker) GetNewPoolState(ctx context.Context, p entity.Pool, param pool
 }
 
 func (t *Tracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Pool, error) {
+	// Reads through the uint256 shape - tolerant of both quoted and plain numbers - since some
+	// already-persisted pools still carry the uint256-shaped Extra written before buildExtra
+	// switched back to the big.Int Extra. Only Ticks[i].Index is used, unaffected either way.
 	var extra ExtraTickU256
 	if len(p.Extra) > 0 {
 		if err := json.Unmarshal([]byte(p.Extra), &extra); err != nil {
@@ -165,9 +166,10 @@ func (t *Tracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Poo
 		return entity.Pool{}, err
 	}
 
-	extra.Ticks = toTickU256s(refetchedTicks)
+	out := extraTickU256ToExtra(extra)
+	out.Ticks = toTicks(refetchedTicks)
 
-	extraBytes, err := json.Marshal(extra)
+	extraBytes, err := json.Marshal(out)
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err,
@@ -181,17 +183,31 @@ func (t *Tracker) FetchPoolTicks(ctx context.Context, p entity.Pool) (entity.Poo
 	return p, nil
 }
 
-func toTickU256s(ticks []tickspkg.Tick) []TickU256 {
-	result := make([]TickU256, 0, len(ticks))
+// extraTickU256ToExtra carries the scalar fields of a tolerant uint256 read over to the big.Int
+// Extra this package writes. Ticks is left for the caller to fill in.
+func extraTickU256ToExtra(u ExtraTickU256) Extra {
+	out := Extra{TickSpacing: u.TickSpacing, BuyRestrictedToken: u.BuyRestrictedToken}
+	if u.Liquidity != nil {
+		out.Liquidity = u.Liquidity.ToBig()
+	}
+	if u.SqrtPriceX96 != nil {
+		out.SqrtPriceX96 = u.SqrtPriceX96.ToBig()
+	}
+	if u.Tick != nil {
+		out.Tick = big.NewInt(int64(*u.Tick))
+	}
+	return out
+}
+
+func toTicks(ticks []tickspkg.Tick) []Tick {
+	result := make([]Tick, 0, len(ticks))
 	for _, tick := range ticks {
 		// skip uninitialized ticks
 		if tick.LiquidityGross.Sign() == 0 {
 			continue
 		}
 
-		lg, _ := uint256.FromBig(tick.LiquidityGross)
-		ln, _ := int256.FromBig(tick.LiquidityNet)
-		result = append(result, TickU256{Index: tick.TickIdx, LiquidityGross: lg, LiquidityNet: ln})
+		result = append(result, Tick{Index: tick.TickIdx, LiquidityGross: tick.LiquidityGross, LiquidityNet: tick.LiquidityNet})
 	}
 
 	sort.Slice(result, func(i, j int) bool { return result[i].Index < result[j].Index })
@@ -419,7 +435,7 @@ func (t *Tracker) updateState(
 		return p, err
 	}
 
-	extra := buildExtra(rpcState, toTickU256sFromMap(ticksBasedPool.Ticks))
+	extra := buildExtra(rpcState, toTicksFromMap(ticksBasedPool.Ticks))
 	extraBytes, err := json.Marshal(extra)
 	if err != nil {
 		l.WithFields(logger.Fields{
@@ -440,18 +456,14 @@ func (t *Tracker) updateState(
 	return p, nil
 }
 
-func toTickU256sFromMap(ticks map[int]tickspkg.Tick) []TickU256 {
-	return toTickU256s(lo.Values(ticks))
+func toTicksFromMap(ticks map[int]tickspkg.Tick) []Tick {
+	return toTicks(lo.Values(ticks))
 }
 
-func buildExtra(rpcData *FetchRPCResult, ticks []TickU256) ExtraTickU256 {
-	liq, _ := uint256.FromBig(rpcData.Liquidity)
-	sqrtP, _ := uint256.FromBig(rpcData.Slot0.SqrtPriceX96)
-
-	var tick *int
+func buildExtra(rpcData *FetchRPCResult, ticks []Tick) Extra {
+	var tick *big.Int
 	if rpcData.Slot0.Unlocked {
-		tickInt := int(rpcData.Slot0.Tick.Int64())
-		tick = &tickInt
+		tick = rpcData.Slot0.Tick
 	}
 
 	var tickSpacing uint64
@@ -459,9 +471,9 @@ func buildExtra(rpcData *FetchRPCResult, ticks []TickU256) ExtraTickU256 {
 		tickSpacing = rpcData.TickSpacing.Uint64()
 	}
 
-	return ExtraTickU256{
-		Liquidity:          liq,
-		SqrtPriceX96:       sqrtP,
+	return Extra{
+		Liquidity:          rpcData.Liquidity,
+		SqrtPriceX96:       rpcData.Slot0.SqrtPriceX96,
 		TickSpacing:        tickSpacing,
 		Tick:               tick,
 		Ticks:              ticks,
@@ -734,14 +746,7 @@ func (t *Tracker) BootstrapPoolState(ctx context.Context, p entity.Pool, param p
 		ticks = append(ticks, tick)
 	}
 
-	ticks256 := make([]TickU256, 0, len(ticks))
-	for _, tick := range ticks {
-		lg, _ := uint256.FromBig(tick.LiquidityGross)
-		ln, _ := int256.FromBig(tick.LiquidityNet)
-		ticks256 = append(ticks256, TickU256{Index: tick.Index, LiquidityGross: lg, LiquidityNet: ln})
-	}
-
-	extraBytes, err := json.Marshal(buildExtra(rpcData, ticks256))
+	extraBytes, err := json.Marshal(buildExtra(rpcData, ticks))
 	if err != nil {
 		l.WithFields(logger.Fields{
 			"error": err,

--- a/pkg/liquidity-source/uniswap/v3/pools_list_updater.go
+++ b/pkg/liquidity-source/uniswap/v3/pools_list_updater.go
@@ -17,40 +17,18 @@ import (
 	graphqlpkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/graphql"
 )
 
+// Every DexType stamps Type: DexTypeUniswapV3 on the pools it lists, same as PoolFactory - see
+// the comment there. slipstream is the one real exception: its subgraph has no feeTier field at
+// all (fee is fully dynamic, unknown until the tracker's first fee()/currentFee() refresh), so
+// it alone gets its own constructor instead of reusing NewPoolsListUpdater.
 var (
-	_ = poollist.RegisterFactoryCEG(DexTypeUniswapV3, NewUniswapV3PoolsListUpdater)
-	_ = poollist.RegisterFactoryCEG(DexTypePancakeV3, NewPancakeV3PoolsListUpdater)
-	_ = poollist.RegisterFactoryCEG(DexTypeRamsesV2, NewRamsesV2PoolsListUpdater)
-	_ = poollist.RegisterFactoryCEG(DexTypeSolidlyV3, NewSolidlyV3PoolsListUpdater)
+	_ = poollist.RegisterFactoryCEG(DexTypeUniswapV3, NewPoolsListUpdater)
+	_ = poollist.RegisterFactoryCEG(DexTypePancakeV3, NewPoolsListUpdater)
+	_ = poollist.RegisterFactoryCEG(DexTypeRamsesV2, NewPoolsListUpdater)
+	_ = poollist.RegisterFactoryCEG(DexTypeSolidlyV3, NewPoolsListUpdater)
 	_ = poollist.RegisterFactoryCEG(DexTypeSlipstream, NewSlipstreamPoolsListUpdater)
-	_ = poollist.RegisterFactoryCEG(DexTypeNuriV2, NewNuriV2PoolsListUpdater)
+	_ = poollist.RegisterFactoryCEG(DexTypeNuriV2, NewPoolsListUpdater)
 )
-
-func NewUniswapV3PoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
-	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, DexTypeUniswapV3, true)
-}
-
-func NewPancakeV3PoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
-	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, DexTypePancakeV3, true)
-}
-
-func NewRamsesV2PoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
-	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, DexTypeRamsesV2, true)
-}
-
-func NewSolidlyV3PoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
-	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, DexTypeSolidlyV3, true)
-}
-
-func NewSlipstreamPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
-	// slipstream's subgraph has no feeTier field at all (fee is fully dynamic, unknown
-	// until the tracker's first fee()/currentFee() refresh).
-	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, DexTypeSlipstream, false)
-}
-
-func NewNuriV2PoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
-	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, DexTypeNuriV2, true)
-}
 
 // PoolsListUpdater discovers pools for every uniswap-v3 fork merged into this package purely
 // from the subgraph. It deliberately does not fetch tickSpacing (or fee) over RPC at listing
@@ -61,22 +39,27 @@ type PoolsListUpdater struct {
 	config         *Config
 	ethrpcClient   *ethrpc.Client
 	graphqlClient  *graphqlpkg.Client
-	dexType        string
 	includeFeeTier bool
+}
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
+	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, true)
+}
+
+func NewSlipstreamPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client, graphqlClient *graphqlpkg.Client) *PoolsListUpdater {
+	return newPoolsListUpdater(cfg, ethrpcClient, graphqlClient, false)
 }
 
 func newPoolsListUpdater(
 	cfg *Config,
 	ethrpcClient *ethrpc.Client,
 	graphqlClient *graphqlpkg.Client,
-	dexType string,
 	includeFeeTier bool,
 ) *PoolsListUpdater {
 	return &PoolsListUpdater{
 		config:         cfg,
 		ethrpcClient:   ethrpcClient,
 		graphqlClient:  graphqlClient,
-		dexType:        dexType,
 		includeFeeTier: includeFeeTier,
 	}
 }
@@ -181,7 +164,7 @@ func (d *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte
 			Address:     p.ID,
 			SwapFee:     swapFee,
 			Exchange:    d.config.DexID,
-			Type:        d.dexType,
+			Type:        DexTypeUniswapV3,
 			Timestamp:   createdAtTimestamp,
 			Reserves:    reserves,
 			Tokens:      tokens,


### PR DESCRIPTION
The uniswap-v3 fork merge (#1592) made uniswap/v3.Tracker always write
ExtraTickU256 (uint256/int256, quoted decimal strings) regardless of which
merged DexType it was tracking. Three of the six (uniswapv3, pancake-v3,
slipstream) used to write the big.Int Extra (plain numbers) before the
merge; ramses-v2/solidly-v3/nuri-v2 already wrote the uint256 shape.

machima embeds uniswapv3.Tracker directly and round-trips entity.Pool.Extra
through its own big.Int-typed Extra on every refresh, so it broke
immediately in production: `math/big: cannot unmarshal a quoted string`.

- pool_tracker.go: buildExtra builds Extra (big.Int) again instead of
  ExtraTickU256. FetchPoolTicks still reads through the tolerant
  ExtraTickU256 shape (accepts both quoted and plain numbers) since some
  already-persisted pools currently carry the uint256 shape, then converts
  back to Extra for writing.
- machima/pool_tracker.go: unmarshalExtra now reads through that same
  tolerant uint256 shape and converts to the big.Int Extra machima itself
  writes, so it works regardless of which shape produced entityPool.Extra.
  Extra's own wire format is untouched, so no other machima code changes.
- pool_factory.go/pools_list_updater.go: also dropped the per-DexType
  closures added during the merge - every DexType now registers the same
  NewPoolFactory/NewPoolsListUpdater and stamps Type: DexTypeUniswapV3
  unconditionally, since all six DexTypes are already byte-identical in
  behavior. slipstream keeps its own constructor only because its subgraph
  genuinely lacks a feeTier field, not for Type-stamping.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
