### PR TITLE
feat: add Uniswap V4 GlueHook (passthrough hook, one address on all chains)

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/gluehook/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/gluehook/constant.go
@@ -1,0 +1,16 @@
+package gluehook
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// GlueHook is deployed via CREATE from a nonce-0 deployer, so it lives at the SAME address on
+// every chain it supports (Ethereum, Base, Unichain, Arbitrum, Optimism, BNB, Polygon,
+// Avalanche, Blast, Celo, Monad, X Layer, World Chain, Zora, Soneium, MegaETH, Robinhood, Tempo).
+var HookAddresses = []common.Address{
+	common.HexToAddress("0xb216070c3509047ea597E2E626A29cea427a60C8"),
+}
+
+// Worst-case extra gas a GlueHook pot action can add to a swap, from the audited gas suite
+// (idle ~8-12k, shield ~+38k, pump ~+88k, in-swap auto-harvest + compound ~+111k).
+const maxHookGas = 120_000

--- a/pkg/liquidity-source/uniswap/v4/hooks/gluehook/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/gluehook/constant.go
@@ -6,9 +6,9 @@ import (
 
 // GlueHook is deployed via CREATE from a nonce-0 deployer, so it lives at the SAME address on
 // every chain it supports (Ethereum, Base, Unichain, Arbitrum, Optimism, BNB, Polygon,
-// Avalanche, Blast, Celo, Monad, X Layer, World Chain, Zora, Soneium, MegaETH, Robinhood, Tempo).
+// Avalanche, X Layer, World Chain, Soneium, MegaETH, Robinhood).
 var HookAddresses = []common.Address{
-	common.HexToAddress("0xb216070c3509047ea597E2E626A29cea427a60C8"),
+	common.HexToAddress("0x0F41715dc432692b66A5aDF8dCfef6Ac407b20c8"),
 }
 
 // Worst-case extra gas a GlueHook pot action can add to a swap, from the audited gas suite

--- a/pkg/liquidity-source/uniswap/v4/hooks/gluehook/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/gluehook/hook.go
@@ -1,0 +1,38 @@
+package gluehook
+
+import (
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+// Hook of GlueHook (https://gluehook.trade) — a free, keyless, general-purpose hook that gives a
+// pool a permissionless buyback pot (it buys after buys and can absorb sells) plus a
+// self-compounding LP position owned by the hook itself.
+//
+// Quoting is a pure passthrough: the hook NEVER changes the swapper's amounts.
+//   - Pump executes after the swap, spending the pot's own balance;
+//   - Shield absorbs a sell while paying the seller the pool's EXACT output
+//     (fee and tick impact included), so the quoted output is identical either way;
+//   - auto-harvest/compound only moves the hook's own LP fees.
+//
+// Every hook action is wrapped in try/catch — a swap can never revert on hook state or
+// settings. The only difference from a vanilla pool is gas, budgeted at the audited
+// worst case here.
+type Hook struct {
+	*uniswapv4.BaseHook
+}
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	return &Hook{
+		BaseHook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4GlueHook},
+	}
+}, HookAddresses...)
+
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	result, err := h.BaseHook.BeforeSwap(params)
+	if err != nil {
+		return nil, err
+	}
+	result.Gas = maxHookGas
+	return result, nil
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/gluehook/hook_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/gluehook/hook_test.go
@@ -1,0 +1,50 @@
+package gluehook
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+func TestHookRegistered(t *testing.T) {
+	t.Parallel()
+	hook, ok := uniswapv4.GetHook(HookAddresses[0], nil)
+	require.True(t, ok)
+	assert.Equal(t, string(valueobject.ExchangeUniswapV4GlueHook), hook.GetExchange())
+}
+
+// GlueHook never changes the swapper's amounts (pump runs after the swap from the pot's own
+// balance; shield pays the seller the pool's exact output) — the simulation must be a pure
+// passthrough with only a gas budget on top.
+func TestPassthroughQuoting(t *testing.T) {
+	t.Parallel()
+	hook, _ := uniswapv4.GetHook(HookAddresses[0], nil)
+
+	for _, params := range []*uniswapv4.BeforeSwapParams{
+		{CalcOut: true, ZeroForOne: true, AmountSpecified: big.NewInt(1e18)},
+		{CalcOut: true, ZeroForOne: false, AmountSpecified: big.NewInt(1e18)},
+		{CalcOut: false, ZeroForOne: true, AmountSpecified: big.NewInt(1e18)},
+		{CalcOut: false, ZeroForOne: false, AmountSpecified: big.NewInt(1e18)},
+	} {
+		beforeSwapResult, err := hook.BeforeSwap(params)
+		require.NoError(t, err)
+		require.NoError(t, uniswapv4.ValidateBeforeSwapResult(beforeSwapResult))
+		assert.Zero(t, beforeSwapResult.DeltaSpecified.Sign())
+		assert.Zero(t, beforeSwapResult.DeltaUnspecified.Sign())
+		assert.EqualValues(t, maxHookGas, beforeSwapResult.Gas)
+
+		afterSwapResult, err := hook.AfterSwap(&uniswapv4.AfterSwapParams{
+			BeforeSwapParams: params,
+			AmountIn:         big.NewInt(1e18),
+			AmountOut:        big.NewInt(1e18),
+		})
+		require.NoError(t, err)
+		require.NoError(t, uniswapv4.ValidateAfterSwapResult(afterSwapResult))
+		assert.Zero(t, afterSwapResult.HookFee.Sign())
+	}
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -183,6 +183,7 @@ import (
 	pkg_liquiditysource_uniswap_v4_hooks_deli "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/deli"
 	pkg_liquiditysource_uniswap_v4_hooks_doppler "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/doppler"
 	pkg_liquiditysource_uniswap_v4_hooks_flaunch "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/flaunch"
+	pkg_liquiditysource_uniswap_v4_hooks_gluehook "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/gluehook"
 	pkg_liquiditysource_uniswap_v4_hooks_idle "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/idle"
 	pkg_liquiditysource_uniswap_v4_hooks_livo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/livo"
 	pkg_liquiditysource_uniswap_v4_hooks_nft_strategy "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/nft_strategy"
@@ -428,6 +429,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_deli.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_doppler.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_flaunch.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_gluehook.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_idle.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_livo.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_nft_strategy.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -298,6 +298,7 @@ const (
 	ExchangeUniswapV4EulerV2            = "uniswap-v4-euler-v2"
 	ExchangeUniswapV4FairFlow           = "uniswap-v4-fairflow"
 	ExchangeUniswapV4Flaunch            = "uniswap-v4-flaunch"
+	ExchangeUniswapV4GlueHook           = "uniswap-v4-gluehook"
 	ExchangeUniswapV4Kem                = "uniswap-v4-kem"
 	ExchangeUniswapV4Livo               = "uniswap-v4-livo"
 	ExchangeUniswapV4NftStrategy        = "uniswap-v4-nftstrat"


### PR DESCRIPTION
## Why did we need it?

Adds routing support for Uniswap V4 pools using **GlueHook** (`0x0F41715dc432692b66A5aDF8dCfef6Ac407b20c8`, identical on every chain — deployed via CREATE from a nonce-0 deployer). [GlueHook](https://gluehook.trade) is a free, keyless, general-purpose hook that gives any V4 pool a permissionless buyback pot (pump after buys, sell absorption at the pool's exact output) and a self-compounding LP owned by the hook. Without registration these pools are excluded from routing even though they quote exactly like vanilla V4 pools.

### What is GlueHook?

[GlueHook](https://gluehook.trade) is a **general-purpose Uniswap V4 hook** — not a platform-specific one. Any project, DAO or community attaches it to its own pool permissionlessly and gets, natively on Uniswap:

- **Buyback pot** — a permissionless per-pool treasury in the paired asset, fillable by anyone: the project, the community, a fee stream, or one-off donations.
- **Pump** — on buys, the pot buys too, in the same flow at the pool's live price. Buy pressure compounds buy pressure.
- **Shield** — on sells, the pot can absorb the sell: the seller receives the pool's **exact** output (fee and tick impact included), and the tokens go to the pot instead of dumping on the curve.
- **Burn cascade** — tokens the pot buys are burned via the token's own `burn()`, else sent to `0xdEaD`, else held forever inside the hook with a public per-asset counter. Deflation with proof.
- **Self-compounding LP** — the hook's own LP position auto-harvests its fees (swap-triggered, no keeper) and splits them by the owner's config between autocompound, pot refuel, burn, and a recipient.

**And it is infrastructure, not a product with privileged access:**

- **General purpose** — ONE deployment serves every pool on the chain, at the SAME address on all 13 mainnets.
- **Not upgradeable** — no proxy, no upgrade path, no pause switch. The verified bytecode is final; what you review today is what runs forever.
- **No owner, no admin keys** — the contract has no privileged role of any kind. Nobody (including its deployers) can change its behavior, censor a pool, or touch funds it holds.
- **Zero protocol fee** — the hook takes nothing for itself. 100% of what flows through it goes to the pool's own program: pot, burn, autocompound, or the recipients each pool's owner configures.
- **Swaps can never be blocked** — every hook action is fault-tolerant (try/catch); on any internal failure the hook no-ops and the swap settles exactly like a vanilla pool.

The integration is a **pure passthrough** (`BaseHook` semantics — zero before/after-swap deltas) plus a measured worst-case gas budget:

- The hook never changes the swapper's amounts: Pump executes *after* the swap from the pot's own balance; Shield absorbs a sell while paying the seller the pool's **exact** output (fee and tick impact included); auto-harvest/compound only moves the hook's own LP fees. Standard V4 tick math therefore quotes GlueHook pools exactly.
- Every hook action is wrapped in try/catch — a swap can never revert on hook state or settings.
- No custom hookData; not upgradeable; no oracle/keeper.
- `BeforeSwapResult.Gas = 120_000` — a ceiling over the audited measurements (idle ~8–12k, shield ~+38k, pump ~+88k, in-swap harvest+compound ~+111k).

Changes:
- `pkg/liquidity-source/uniswap/v4/hooks/gluehook/` — hook (registered for the single cross-chain address), constants, tests
- `pkg/valueobject/exchange.go` — `ExchangeUniswapV4GlueHook = "uniswap-v4-gluehook"`
- `pkg/msgpack/register_pool_types.gen.go` — regenerated via `go run ./generate`

## Related Issue

#1598

## Release Note

New liquidity-source exchange `uniswap-v4-gluehook`. GlueHook is live at the same address on Ethereum, Base, Unichain, Arbitrum, Optimism, BNB, Polygon, Avalanche, X Layer, World Chain, Soneium, MegaETH and Robinhood; enable per chain in kyber-application config as desired.

## How Has This Been Tested?

- `go build ./pkg/...` — clean
- `go test ./pkg/liquidity-source/uniswap/v4/...` — the new `hooks/gluehook` tests pass (registration, exchange id, passthrough deltas in all four CalcOut/ZeroForOne combinations, zero hook fee, gas budget). Pre-existing `hooks/clanker` Track tests fail on live-RPC unpacking in this environment, unrelated to this change.
- Contract-side behavior (exact-output shield, post-swap pump, fault tolerance) is covered by the project's Foundry suites incl. deterministic gas measurements and live-chain fork tests against deployed PoolManagers: https://github.com/glue-finance/GlueHook/tree/main/audit

**Live metrics:** activity, volume and TVL for GlueHook pools across all chains are tracked on a public Dune dashboard: https://dune.com/lalilulel0x0869/gluehook-live
