### PR TITLE
feat: recognize pmm- prefix as RFQ source

### DIFF
--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -1,5 +1,7 @@
 package valueobject
 
+import "strings"
+
 type Exchange string
 
 const (
@@ -364,9 +366,15 @@ var RFQSourceSet = map[Exchange]struct{}{
 	ExchangeUniswapLO:  {},
 }
 
+// pmmSourcePrefix matches the "pmm-N" generic maker slot family, so a newly onboarded pmm-N
+// is classified as an RFQ source purely by config (no dex-lib release needed for the next N).
+const pmmSourcePrefix = "pmm-"
+
 func IsRFQSource[T ~string](exchange T) bool {
-	_, ok := RFQSourceSet[Exchange(exchange)]
-	return ok
+	if _, ok := RFQSourceSet[Exchange(exchange)]; ok {
+		return true
+	}
+	return strings.HasPrefix(string(exchange), pmmSourcePrefix)
 }
 
 // needFallbackSourceSet is a set of exchanges that


### PR DESCRIPTION
Future pmm-N maker slots are classified as RFQ sources by prefix match
instead of an explicit RFQSourceSet entry, so onboarding a new one
doesn't require a dex-lib release.
