### PR TITLE
feat: register Alandale (Algebra Integral) on Robinhood Chain

### DIFF
--- a/pkg/liquidity-source/algebra/integral/config.go
+++ b/pkg/liquidity-source/algebra/integral/config.go
@@ -12,4 +12,18 @@ type Config struct {
 	TickLensAddress   string
 
 	UseBasePluginV2 bool `json:"useBasePluginV2"`
+
+	// SkipBlockPinning stops the plugin reads being pinned to the block number
+	// that the first multicall reported. Multicall3 returns the EVM's
+	// block.number, which on most chains equals the RPC block height — but not
+	// on all of them. Robinhood Chain (4663) is one where it does not: at the
+	// time of writing eth_blockNumber is 37,204,546 while block.number is
+	// 25,761,193, and the latter does not advance in step (0 vs 70 blocks over
+	// the same 6 seconds). Feeding that value back as an eth_call block tag asks
+	// the node for state ~11.4M blocks in its past, which it answers with
+	// "metadata is not found" and the whole refresh fails.
+	//
+	// Leave false to keep pinning, which is what every currently-supported chain
+	// wants: it keeps a multi-call refresh consistent on one block.
+	SkipBlockPinning bool `json:"skipBlockPinning"`
 }

--- a/pkg/liquidity-source/algebra/integral/pool_simulator_alandale_test.go
+++ b/pkg/liquidity-source/algebra/integral/pool_simulator_alandale_test.go
@@ -1,0 +1,72 @@
+package integral
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+// Alandale is an Algebra Integral deployment on Robinhood Chain (4663). Its
+// plugin is BasePlugin V1: feeConfig() exists, feeZeroToOne() / feeOneToZero() /
+// s_feeFactors() do not.
+//
+// This fixture is a real USDG/LUTE pool state captured from that chain. It is
+// frozen deliberately — a test that queried Alandale live would start failing in
+// this repo the moment that deployment changed, went quiet, or went away, which
+// is not a dependency this repo should carry.
+//
+// What it pins:
+//
+//  1. the two absent selectors leave DynamicFeeConfig.ZeroToOne/OneToZero at 0,
+//     which is the sentinel beforeSwapV1 tests before falling through to the
+//     adaptive sigmoid path. Zero is the correct value here, not a failed read.
+//  2. Alpha1/Alpha2 are non-zero, so it does not take the flat BaseFee branch.
+//  3. no sliding-fee block, since this is a V1 plugin.
+//  4. the resulting quote, exact to the wei.
+//
+// When captured, the simulator agreed with an on-chain QuoterV2 call on the same
+// pool to the wei.
+const alandaleFixture = `{"address":"0xad8d8c09ab39bbf7e65f4b6896860d956dc8580e","exchange":"alandale","type":"algebra-integral","timestamp":1786808397,"reserves":["12144110932","4791606548818582251351530"],"tokens":[{"address":"0x5fc5360d0400a0fd4f2af552add042d716f1d168","symbol":"USDG","decimals":6,"swappable":true},{"address":"0xd1e861cc5eee7ea88649206b74504d78ccd7aeea","symbol":"LUTE","decimals":18,"swappable":true}],"extra":"{\"liq\":\"288232250710633324\",\"gS\":{\"price\":\"1543378334770342101239018989226542354\",\"tick\":335714,\"lF\":111,\"pC\":193,\"cF\":1000,\"un\":true},\"ticks\":[{\"Index\":-887220,\"LiquidityGross\":\"27767555552071542\",\"LiquidityNet\":\"27767555552071542\"},{\"Index\":299340,\"LiquidityGross\":\"260464695158561782\",\"LiquidityNet\":\"260464695158561782\"},{\"Index\":339480,\"LiquidityGross\":\"23596931931634372\",\"LiquidityNet\":\"-23596931931634372\"},{\"Index\":377580,\"LiquidityGross\":\"260464695158561782\",\"LiquidityNet\":\"-260464695158561782\"},{\"Index\":887220,\"LiquidityGross\":\"4170623620437170\",\"LiquidityNet\":\"-4170623620437170\"}],\"tS\":60,\"tP\":{\"0\":{\"init\":true,\"ts\":1786116633,\"vo\":\"0\",\"tick\":338473,\"avgT\":338473},\"80\":{\"init\":true,\"ts\":1786703106,\"cum\":198105211634,\"vo\":\"155744678405\",\"tick\":335742,\"avgT\":335783,\"wsI\":71},\"81\":{\"init\":true,\"ts\":1786722717,\"cum\":204689310719,\"vo\":\"155759431262\",\"tick\":335735,\"avgT\":335734,\"wsI\":77},\"82\":{\"init\":true,\"ts\":1786726392,\"cum\":205922982494,\"vo\":\"155765312407\",\"tick\":335693,\"avgT\":335732,\"wsI\":77},\"83\":{\"init\":true,\"ts\":1786805220,\"cum\":232385147954,\"vo\":\"155802282055\",\"tick\":335695,\"avgT\":335696,\"wsI\":80},\"84\":{\"vo\":\"0\"},\"85\":{\"vo\":\"0\"}},\"vo\":{\"init\":true,\"tpIdx\":83,\"lastTs\":1786805220},\"dF\":{\"a1\":2900,\"a2\":12000,\"b1\":360,\"b2\":60000,\"g1\":59,\"g2\":8500,\"bF\":100}}","staticExtra":"{\"pluginV2\":false}"}`
+
+func TestPoolSimulator_Alandale_BasePluginV1(t *testing.T) {
+	// The package pins blockTimestamp for its fixtures; this one was captured at a
+	// different moment, so it needs its own. Not parallel: the hook is package-level.
+	origBlockTimestamp := blockTimestamp
+	blockTimestamp = func() uint32 { return 1786808397 }
+	defer func() { blockTimestamp = origBlockTimestamp }()
+
+	var ep entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(alandaleFixture), &ep))
+
+	var extra Extra
+	require.NoError(t, json.Unmarshal([]byte(ep.Extra), &extra))
+
+	// (1) missing selectors -> 0 sentinel, not a corrupted read
+	require.NotNil(t, extra.DynamicFee)
+	require.Zero(t, extra.DynamicFee.ZeroToOne)
+	require.Zero(t, extra.DynamicFee.OneToZero)
+	// (2) adaptive path, not the flat baseFee branch
+	require.NotZero(t, extra.DynamicFee.Alpha1)
+	require.NotZero(t, extra.DynamicFee.Alpha2)
+	// (3) V1 plugin: no sliding fee, but the volatility oracle is required and live
+	require.Nil(t, extra.SlidingFee)
+	require.NotNil(t, extra.VolatilityOracle)
+	require.True(t, extra.VolatilityOracle.IsInitialized)
+
+	ps, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+
+	// (4) 1000 USDG -> LUTE, exact
+	res, err := ps.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: ep.Tokens[0].Address, Amount: bignumber.NewBig10("1000000000")},
+		TokenOut:      ep.Tokens[1].Address,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "355416851774847704658559", res.TokenAmountOut.Amount.String())
+	require.Equal(t, "111000", res.Fee.Amount.String())
+}

--- a/pkg/liquidity-source/algebra/integral/pool_tracker.go
+++ b/pkg/liquidity-source/algebra/integral/pool_tracker.go
@@ -233,8 +233,13 @@ func (d *PoolTracker) FetchRPCData(ctx context.Context, p *entity.Pool, blockNum
 		Unlocked:     rpcState.Unlocked,
 	}
 
+	pluginBlock := result.BlockNumber
+	if d.config.SkipBlockPinning {
+		pluginBlock = nil
+	}
+
 	timepoints, volatilityOracleData, dynamicFeeData, slidingFeeData, err := d.getPluginData(ctx, p, plugin,
-		result.BlockNumber, overrides)
+		pluginBlock, overrides)
 	if err != nil {
 		l.WithFields(logger.Fields{
 			"error": err,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -7,6 +7,7 @@ type Exchange string
 const (
 	Exchange1010Prop                    = "1010-prop"
 	ExchangeAeonV2                      = "aeon-v2"
+	ExchangeAlandale                    = "alandale"
 	ExchangeAlienBaseStableSwap         = "alien-base-stableswap"
 	ExchangeAltFun                      = "alt-fun"
 	ExchangeAmbient                     = "ambient"


### PR DESCRIPTION
## Why did we need it?

**Alandale** is a ve(3,3) DEX on **Robinhood Chain (4663)** whose concentrated pools are an
**Algebra Integral** deployment. The existing module prices them as-is, so this PR is a
registration: the exchange constant, a fixture test, and one config flag the chain
requires. **No new pool maths, no new `DexType`, no `pooltypes` entry, no msgpack regen.**

KyberSwap already routes 4663, but through a single venue (`metric-propamm`). Same trade,
same moment (2026-08-15 15:44 UTC):

| | 1 WETH → USDG |
|---|---|
| KyberSwap | 1,883.47 USDG |
| OpenOcean | 1,949.90 USDG |

3.53% worse. Alandale is ~$474k over 20 pools, including this chain's tokenised equities
(NVDA, TSLA, AAPL, SPY, GME, SHOP, SNDK).

### DEX background

ve(3,3): swap fees are taken as a community fee and paid to lockers who vote on emissions.
Concentrated pools are Algebra Integral with the adaptive (sigmoid) fee plugin. There is
also a classic Solidly side, deliberately **not** included here — it holds one pair at
~$0 TVL and would add a source that routes nothing.

### Pricing logic, and one thing worth flagging to a reviewer

Standard Algebra Integral. The plugin is **BasePlugin V1** — `feeConfig()` exists,
`feeZeroToOne()` / `feeOneToZero()` / `s_feeFactors()` do not. The existing code already
handles this, but it reads like a missing fetch, so:

- the two absent selectors revert; `TryAggregate` tolerates them, and `getDynamicFeeData`
  only errors when `feeConfig` **also** fails — it doesn't
- so `DynamicFeeConfig.ZeroToOne/OneToZero` stay `0`, which is exactly the sentinel
  `beforeSwapV1` tests before falling through to the adaptive sigmoid path
- `Alpha1`/`Alpha2` are non-zero, so it doesn't take the flat `BaseFee` branch either

**Zero is the correct value here, not a failed read.** Config is uniform across all 19 CL
pools: `α1 2900, α2 12000, β1 360, β2 60000, γ1 59, γ2 8500, baseFee 100` — β and γ are
identical to the Thena fixture already in this repo.

We also checked the strict path: `getVolatilityOracleData` fails the entire refresh if any
of `isInitialized` / `lastTimepointTimestamp` / `timepointIndex` is missing. All three are
present on **all 19 pools**, along with `BEFORE_SWAP_FLAG`.

### The one change to shared code

`SkipBlockPinning`, default `false` — no existing chain changes behaviour.

`getPluginData` pins its reads to the block number the first multicall returned, i.e. the
EVM's `block.number`. This module has only ever run on chains where that equals the RPC
block height. On 4663 it doesn't:

```
eth_blockNumber              37,204,546
Multicall3.getBlockNumber()  25,761,193     (chainId 4663, 3808 bytes — genuine Multicall3)

over the same 6 seconds:   RPC +70 blocks   |   block.number +0
```

`block.number` is the **L1 block** here — which this repo already documents, in
`uniswap/v3/forks/pons-fun/guard.go`, which reads the same value and calls it
`l1BlockNumber`. Passed back as an `eth_call` block tag it requests state ~11.4M blocks in
the node's past: `metadata is not found`, and every refresh fails. On an archive node it
would instead return ~13-day-old plugin state against current pool state, with no error.

No other source live on 4663 hits this — four never pin, and `uniswap/v3` / `uniswap/v4`
pin from event logs (RPC numbering) and only when `> 0`. We're the first Algebra source on
the chain. **If you'd prefer this solved in `ethrpc`, in per-chain config, or by sourcing
the pin from logs, we'll rework it — happy to follow your call.**

### Addresses (chain 4663)

| | |
|---|---|
| AlgebraFactory | `0x16494A80E08Bcb9285D87b67149d7b01774D82F8` |
| QuoterV2 | `0x58b90bA087fAa948128F84cFCfCBfB04639e0FE1` |
| SwapRouter | `0x8971d5A8F950F021e97583855925B021bfaE2b35` |
| NFT position manager | `0xe62a5F67516dBDBA2Aa28b1512C8Ff44E42cB5c3` |
| USDG/LUTE pool (fixture) | `0xad8d8c09ab39bbf7e65f4b6896860d956dc8580e` |
| WETH/USDG pool (deepest) | `0x7a35168956f129c032ec035cc47383a605a71df0` |
| ...its plugin (BasePlugin V1) | `0xe2cEf56542a5227C72f7967Bd81C15aF7C87E01A` |
| WETH | `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` |
| USDG (6dp) | `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` |
| LUTE | `0xD1e861CC5Eee7eA88649206b74504D78CCD7AEeA` |

Explorer: https://robinhoodchain.blockscout.com
Subgraph: `https://api.goldsky.com/api/public/project_cms6oy9216bwr01wahoyxhk79/subgraphs/alandale-cl-mainnet/1.0.0/gn`
App: https://app.alandale.xyz · Docs: https://alandale.xyz

## Related Issue

https://github.com/KyberNetwork/kyberswap-dex-lib/issues/1608

## Release Note

Adds `ExchangeAlandale = "alandale"`, reusing the existing `algebra-integral` `DexType` —
so no `pooltypes` entry and no `go generate ./pkg/msgpack/...` were needed.

Adds `Config.SkipBlockPinning` to `algebra/integral`, default `false`; existing chains are
unaffected. It must be enabled for 4663 or the source cannot refresh at all.

Two things outside this repo we'd appreciate guidance on:
- enabling the DexID for chain 4663 in the aggregator's per-chain registry
- confirming your executor handles Algebra swaps on 4663 — `ks-dex-adapter-lib`'s
  `multichain_config.toml` doesn't list the chain. The swap signature is v3-shaped so
  `uniswap-v3` encoding should cover it, but we can't verify that from outside.

## How Has This Been Tested?

`TestPoolSimulator_Alandale_BasePluginV1` — a **frozen fixture**, not a live query. A test
that hit our RPC and subgraph would start failing in your repo the moment our deployment
changed or went away, and that isn't a dependency to add here. The fixture is a real
USDG/LUTE state captured from 4663 (1.9KB, 7 timepoints, 5 ticks). It pins:

1. `ZeroToOne`/`OneToZero` at `0` — the sentinel, not a failed read
2. `Alpha1`/`Alpha2` non-zero, so the adaptive branch is the one taken
3. `SlidingFee` absent (V1 plugin), volatility oracle present and initialised
4. the resulting quote, exact: 1000 USDG → `355416851774847704658559` LUTE, fee `111000`

It runs in 0.00s with no network. It deliberately does **not** call `t.Parallel()`: it
overrides the package-level `blockTimestamp` hook that `pool_simulator_test.go` pins for
its own fixture, and running in parallel makes those tests read the wrong clock. We hit
exactly that during development — it silently produced a 1.5% fee instead of 0.0109%.

**Quote comparison against the chain, at capture time:**

| | amountOut | fee |
|---|---|---|
| `PoolSimulator.CalcAmountOut` | 1,872.919557 USDG | 109 (0.0109%) |
| on-chain `QuoterV2.quoteExactInputSingle` | 1,872.919557 USDG | 109 (0.0109%) |

Exact to the wei. (That comparison used the deeper WETH/USDG pool; the committed fixture
uses USDG/LUTE, which is far smaller and exercises the same adaptive path at fee 111.)

Separately we ported `adaptive_fee.go` and ran it against the live config: floor 0.0100%,
ceiling 1.5000%, bracketing every `lastFee` observed across the deployment (100–3093).

`go build ./...`, `go vet` and `gofmt` are clean, and the `goimports -local` step from
AGENTS.md was run on the changed files. Package test results are unchanged from `main`:
`TestPoolTracker_GetNewPoolState` (your Thena live test) fails identically before and after
this branch — we left that file untouched — and every other test passes.

## Screenshots (if appropriate)

n/a