### PR TITLE
fix: brownfi v3 pyth update data now returns 2 separate VAA blobs

### DIFF
--- a/pkg/liquidity-source/brownfi/v3/pool_tracker.go
+++ b/pkg/liquidity-source/brownfi/v3/pool_tracker.go
@@ -174,7 +174,7 @@ func (d *PoolTracker) GetNewPoolState(
 		AddCall(&ethrpc.Call{
 			ABI: brownFiV3OracleABI, Target: staticExtra.PriceOracle,
 			Method: oracleMethodGetUpdateFee,
-			Params: []any{[][]byte{extra.PriceUpdateData}},
+			Params: []any{extra.PriceUpdateData},
 		}, []any{&updateFee}).
 		AddCall(&ethrpc.Call{
 			ABI: abi.Multicall3ABI, Target: d.config.Multicall3,
@@ -247,7 +247,10 @@ func (d *PoolTracker) GetNewPoolState(
 		extra.Price1.Set(pythToQ64(pythUpdateData.Parsed[1].Price.Price, expo))
 		extra.Conf1.Set(pythToQ64(pythUpdateData.Parsed[1].Price.Conf, expo))
 
-		extra.PriceUpdateData, _ = hex.DecodeString(pythUpdateData.Binary.Data[0])
+		extra.PriceUpdateData = lo.Map(pythUpdateData.Binary.Data, func(d string, _ int) []byte {
+			b, _ := hex.DecodeString(d)
+			return b
+		})
 		extra.PythTimestamp = pythUpdateData.Parsed[0].Price.PublishTime
 		p.Timestamp = startTime.Unix()
 	} else if time.Since(time.Unix(extra.PythTimestamp, 0)) >= 5*time.Second {

--- a/pkg/liquidity-source/brownfi/v3/types.go
+++ b/pkg/liquidity-source/brownfi/v3/types.go
@@ -64,8 +64,8 @@ type Extra struct {
 	Conf1    *uint256.Int `json:"c1,omitempty"` // Pyth confidence of token1
 	AmmPrice *uint256.Int `json:"am,omitempty"` // on-chain AMM relative price Q64 (quote/base), 0 if no valid pool
 
-	PriceUpdateData []byte `json:"u,omitempty"`
-	PythTimestamp   int64  `json:"pt,omitempty"`
+	PriceUpdateData [][]byte `json:"u,omitempty"`
+	PythTimestamp   int64    `json:"pt,omitempty"`
 }
 
 // StaticExtra holds infrequently-changing pool configuration (updated hourly).
@@ -79,7 +79,7 @@ type StaticExtra struct {
 
 // SwapInfo is returned to the on-chain executor.
 type SwapInfo struct {
-	PriceUpdateData []byte `json:"u,omitempty"`
+	PriceUpdateData [][]byte `json:"u,omitempty"`
 }
 
 // PoolMeta carries approval and fee metadata.


### PR DESCRIPTION
Brownfi's new Pyth v2 API returns binary.data as 2 distinct update
blobs (one per price feed), not a single combined blob. Decode and
submit all elements instead of assuming index 0 covers both prices.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
