### PR TITLE
refactor: switch 1010-prop to shared ladder tracker and simulator

### DIFF
--- a/pkg/liquidity-source/1010-prop/constant.go
+++ b/pkg/liquidity-source/1010-prop/constant.go
@@ -7,16 +7,6 @@ import (
 const (
 	DexType    = "1010-prop"
 	defaultGas = 135_000
-	sampleSize = 15 // power-of-10 levels
 )
 
-var maxInSampleBps = []int{
-	1000, 1500, 2200, 3200, 4000, // 10–40%
-	4500, 5000, 5600, 6200, 6800, // 40–68%
-	7300, 7900, 8500, 9100, 9900, // 73–99%
-}
-
-var (
-	ErrInvalidToken          = errors.New("invalid token")
-	ErrInsufficientLiquidity = errors.New("insufficient liquidity")
-)
+var ErrInsufficientLiquidity = errors.New("insufficient liquidity")

--- a/pkg/liquidity-source/1010-prop/pool_simulator.go
+++ b/pkg/liquidity-source/1010-prop/pool_simulator.go
@@ -1,27 +1,18 @@
 package prop
 
 import (
-	"math/big"
-	"slices"
-	"sort"
-	"strings"
-
 	"github.com/goccy/go-json"
-	"github.com/holiman/uint256"
-	"github.com/samber/lo"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
 )
 
 type PoolSimulator struct {
-	pool.Pool
-	Extra
-	StaticExtra
-	remainingIn [2]*uint256.Int
+	*ladder.PoolSimulator
+
+	staticExtra StaticExtra
 }
 
 var (
@@ -30,186 +21,29 @@ var (
 )
 
 func NewPoolSimulator(p entity.Pool) (*PoolSimulator, error) {
-	var extra Extra
-	if err := json.Unmarshal([]byte(p.Extra), &extra); err != nil {
+	base, err := ladder.NewPoolSimulator(p)
+	if err != nil {
 		return nil, err
 	}
+	base.Gas = defaultGas
 
 	var staticExtra StaticExtra
 	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
 		return nil, err
 	}
 
-	tokens := lo.Map(p.Tokens, func(e *entity.PoolToken, _ int) string { return strings.ToLower(e.Address) })
-	reserves := lo.Map(p.Reserves, func(e string, _ int) *big.Int { return bignumber.NewBig(e) })
-
-	sim := &PoolSimulator{
-		Pool: pool.Pool{Info: pool.PoolInfo{
-			Address:     p.Address,
-			Exchange:    p.Exchange,
-			Type:        p.Type,
-			Tokens:      tokens,
-			Reserves:    reserves,
-			BlockNumber: p.BlockNumber,
-		}},
-		Extra:       extra,
-		StaticExtra: staticExtra,
-	}
-
-	// cumulative cap: prefer MaxIn, otherwise fallback to sampleMaxIn
-	for dir := range 2 {
-		var rem *uint256.Int
-		if dir < len(extra.MaxIn) && extra.MaxIn[dir] != nil {
-			rem = new(uint256.Int)
-			if rem.SetFromBig(extra.MaxIn[dir]) {
-				rem = nil // overflow: treat as uncapped
-			}
-		} else if dir < len(extra.Samples) && len(extra.Samples[dir]) > 0 {
-			last := extra.Samples[dir][len(extra.Samples[dir])-1][0]
-			if last != nil {
-				rem = new(uint256.Int)
-				if rem.SetFromBig(last) {
-					rem = nil // overflow: treat as uncapped
-				}
-			}
-		}
-		sim.remainingIn[dir] = rem
-	}
-
-	return sim, nil
-}
-
-func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
-	tokenAmountIn := params.TokenAmountIn
-	tokenOut := strings.ToLower(params.TokenOut)
-	tokenIn := strings.ToLower(tokenAmountIn.Token)
-
-	indexIn, indexOut := s.GetTokenIndex(tokenIn), s.GetTokenIndex(tokenOut)
-	if indexIn < 0 || indexOut < 0 || len(s.Info.Tokens) != 2 {
-		return nil, ErrInvalidToken
-	}
-
-	if indexIn >= len(s.Samples) || len(s.Samples[indexIn]) == 0 {
-		return nil, ErrInsufficientLiquidity
-	}
-
-	var amtIn uint256.Int
-	if amtIn.SetFromBig(tokenAmountIn.Amount) {
-		return nil, ErrInsufficientLiquidity
-	}
-
-	if rem := s.remainingIn[indexIn]; rem != nil && amtIn.Gt(rem) {
-		return nil, ErrInsufficientLiquidity
-	}
-
-	samples := s.Samples[indexIn]
-	idx := sort.Search(len(samples), func(i int) bool {
-		var si uint256.Int
-		si.SetFromBig(samples[i][0])
-		return si.Gt(&amtIn)
-	})
-
-	var amountOut uint256.Int
-	if idx == 0 {
-		var s0in, s0out uint256.Int
-		s0in.SetFromBig(samples[0][0])
-		s0out.SetFromBig(samples[0][1])
-		big256.MulDivDown(&amountOut, &amtIn, &s0out, &s0in)
-	} else if idx >= len(samples) {
-		last := samples[len(samples)-1]
-		var lastIn, lastOut uint256.Int
-		lastIn.SetFromBig(last[0])
-		lastOut.SetFromBig(last[1])
-		big256.MulDivDown(&amountOut, &amtIn, &lastOut, &lastIn)
-	} else {
-		L, R := samples[idx-1], samples[idx]
-		var lIn, lOut, rIn, rOut, span, step, delta uint256.Int
-		lIn.SetFromBig(L[0])
-		lOut.SetFromBig(L[1])
-		rIn.SetFromBig(R[0])
-		rOut.SetFromBig(R[1])
-		span.Sub(&rIn, &lIn)
-		step.Sub(&amtIn, &lIn)
-		delta.Sub(&rOut, &lOut)
-		big256.MulDivDown(&amountOut, &step, &delta, &span)
-		amountOut.Add(&amountOut, &lOut)
-	}
-
-	if amountOut.IsZero() {
-		return nil, ErrInsufficientLiquidity
-	}
-
-	if limit := params.Limit; limit != nil {
-		inventoryLimit := limit.GetLimit(tokenOut)
-		if amountOut.ToBig().Cmp(inventoryLimit) > 0 {
-			return nil, pool.ErrNotEnoughInventory
-		}
-	}
-
-	return &pool.CalcAmountOutResult{
-		TokenAmountOut: &pool.TokenAmount{Token: tokenOut, Amount: amountOut.ToBig()},
-		Fee:            &pool.TokenAmount{Token: tokenAmountIn.Token, Amount: big.NewInt(0)},
-		Gas:            defaultGas,
-	}, nil
-}
-
-func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
-	indexIn, indexOut := s.GetTokenIndex(params.TokenAmountIn.Token), s.GetTokenIndex(params.TokenAmountOut.Token)
-	if indexIn < 0 || indexOut < 0 {
-		return
-	}
-	s.Info.Reserves[indexIn] = new(big.Int).Add(s.Info.Reserves[indexIn], params.TokenAmountIn.Amount)
-	s.Info.Reserves[indexOut] = new(big.Int).Sub(s.Info.Reserves[indexOut], params.TokenAmountOut.Amount)
-	if rem := s.remainingIn[indexIn]; rem != nil {
-		var amtIn uint256.Int
-		amtIn.SetFromBig(params.TokenAmountIn.Amount)
-		if rem.Lt(&amtIn) {
-			rem.Clear()
-		} else {
-			rem.Sub(rem, &amtIn)
-		}
-	}
-
-	if limit := params.SwapLimit; limit != nil {
-		_, _, _ = limit.UpdateLimit(
-			params.TokenAmountOut.Token,
-			params.TokenAmountIn.Token,
-			params.TokenAmountOut.Amount,
-			params.TokenAmountIn.Amount,
-		)
-	}
+	return &PoolSimulator{PoolSimulator: base, staticExtra: staticExtra}, nil
 }
 
 func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
 	cloned := *s
-	cloned.Info.Reserves = slices.Clone(s.Info.Reserves)
-	cloned.Samples = make([][][2]*big.Int, len(s.Samples))
-	for i, dir := range s.Samples {
-		cloned.Samples[i] = make([][2]*big.Int, len(dir))
-		for j, pair := range dir {
-			cloned.Samples[i][j] = [2]*big.Int{
-				new(big.Int).Set(pair[0]),
-				new(big.Int).Set(pair[1]),
-			}
-		}
-	}
-	for i := range s.remainingIn {
-		if s.remainingIn[i] != nil {
-			cloned.remainingIn[i] = new(uint256.Int).Set(s.remainingIn[i])
-		}
-	}
+	cloned.PoolSimulator = s.PoolSimulator.CloneState().(*ladder.PoolSimulator)
 	return &cloned
 }
 
+// GetMetaInfo keeps ApprovalAddress (rather than ladder.PoolMeta's default
+// shape) so callers that read pool.ApprovalInfo off it still resolve the
+// router to approve.
 func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
-	return pool.MetaInfo{ApprovalAddress: s.RouterAddress, BlockNumber: s.Info.BlockNumber}
-}
-
-func (s *PoolSimulator) CalculateLimit() map[string]*big.Int {
-	tokens, reserves := s.GetTokens(), s.GetReserves()
-	inventory := make(map[string]*big.Int, len(tokens))
-	for i, token := range tokens {
-		inventory[token] = reserves[i]
-	}
-	return inventory
+	return pool.MetaInfo{ApprovalAddress: s.staticExtra.RouterAddress, BlockNumber: s.Info.BlockNumber}
 }

--- a/pkg/liquidity-source/1010-prop/pool_simulator_test.go
+++ b/pkg/liquidity-source/1010-prop/pool_simulator_test.go
@@ -1,0 +1,82 @@
+package prop
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+)
+
+// Synthetic pool: both ladders lie on a straight line through the origin
+// (dir0 rate=2, dir1 rate=0.5), so the spline's implicit (0,0) anchor makes
+// every point on the curve -- not just the sampled ones -- an exact linear
+// interpolation, letting expected outputs be hand-computed.
+var (
+	entityAB entity.Pool
+	_        = json.Unmarshal([]byte(`{
+		"address":"0x1010000000000000000000000000000000000c",
+		"exchange":"1010-prop",
+		"type":"1010-prop",
+		"reserves":["1000000","1000000"],
+		"tokens":[
+			{"address":"0x1010000000000000000000000000000000000a","symbol":"A","decimals":18,"swappable":true},
+			{"address":"0x1010000000000000000000000000000000000b","symbol":"B","decimals":6,"swappable":true}
+		],
+		"extra":"{\"l\":[[[1000,2000],[2000,4000],[3000,6000]],[[20,10],[40,20],[60,30]]]}",
+		"staticExtra":"{\"routerAddress\":\"0x1010000000000000000000000000000000001\"}",
+		"blockNumber":100
+	}`), &entityAB)
+	poolSimAB = lo.Must(NewPoolSimulator(entityAB))
+)
+
+func TestPoolSimulator_CalcAmountOut(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountOut(t, poolSimAB, map[int]map[int]map[string]string{
+		0: {
+			1: {
+				"500":  "1000", // below first ladder entry -> spline toward origin
+				"1000": "2000", // exact first ladder entry
+				"1500": "3000", // between entries -> spline-interpolated
+				"3000": "6000", // exact last ladder entry
+				"3001": ladder.ErrAmountInTooLarge.Error(),
+				"0":    "",
+			},
+		},
+		1: {
+			0: {
+				"10": "5",  // below first ladder entry -> spline toward origin
+				"20": "10", // exact first ladder entry
+				"30": "15", // between entries -> spline-interpolated
+				"60": "30", // exact last ladder entry
+				"61": ladder.ErrAmountInTooLarge.Error(),
+				"0":  "",
+			},
+		},
+	})
+}
+
+func TestPoolSimulator_UpdateBalance(t *testing.T) {
+	t.Parallel()
+	// Two sequential B->A swaps on a fresh clone; consumedIn/consumedOut track
+	// correctly since the curve is linear (no depletion within the range tested).
+	testutil.TestCalcAmountOutWithUpdateBalance(t, poolSimAB, map[int]map[int][][][2]string{
+		1: {
+			0: {{{"20", "10"}, {"20", "10"}}},
+		},
+	})
+}
+
+func TestPoolSimulator_GetMetaInfo(t *testing.T) {
+	t.Parallel()
+	meta := poolSimAB.GetMetaInfo("", "")
+	assert.Equal(t, pool.MetaInfo{
+		ApprovalAddress: "0x1010000000000000000000000000000000001",
+		BlockNumber:     100,
+	}, meta)
+}

--- a/pkg/liquidity-source/1010-prop/pool_tracker.go
+++ b/pkg/liquidity-source/1010-prop/pool_tracker.go
@@ -3,7 +3,6 @@ package prop
 import (
 	"context"
 	"math/big"
-	"sort"
 	"strings"
 	"time"
 
@@ -12,8 +11,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
@@ -48,28 +49,26 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, err
 	}
 
-	samples, err := t.fetchQuotes(ctx, p, staticExtra.RouterAddress, balances, blockNumber)
+	points := [2][]*big.Int{
+		ladder.SamplePoints(p, 0, balances[0], balances[1]),
+		ladder.SamplePoints(p, 1, balances[1], balances[0]),
+	}
+
+	outputs, err := t.fetchQuotes(ctx, p, staticExtra.RouterAddress, points, blockNumber)
 	if err != nil {
 		return p, err
 	}
 
-	t.warnGapInQuotes(p, samples)
-	t.applyBuffer(samples)
-	samples = filterSamples(samples)
+	t.warnGapInQuotes(p, points, outputs)
+	t.applyBuffer(outputs)
 
-	p.Reserves = []string{balances[0].String(), balances[1].String()}
-
-	extra := Extra{Samples: samples}
-	extraBytes, err := json.Marshal(extra)
-	if err != nil {
-		return p, err
+	ladders := [2][]ladder.Point{
+		ladder.CollectLadder(points[0], outputs[0]),
+		ladder.CollectLadder(points[1], outputs[1]),
 	}
 
-	p.Extra = string(extraBytes)
-	p.Timestamp = time.Now().Unix()
-	p.BlockNumber = blockNumber.Uint64()
-
-	return p, nil
+	r0, r1 := uint256.MustFromBig(balances[0]), uint256.MustFromBig(balances[1])
+	return t.persist(p, ladder.Extra{Ladders: ladders}, r0, r1, blockNumber), nil
 }
 
 // fetchBalances calls getAssetReserves on the router and returns the two balances
@@ -108,114 +107,86 @@ func (t *PoolTracker) fetchBalances(ctx context.Context, routerAddr string, toke
 	return balances, res.BlockNumber, nil
 }
 
+// fetchQuotes probes the router's quote(account, tokenIn, tokenOut, amountIn) for every
+// point in each direction's grid, returning the raw (possibly nil, on revert) outputs
+// aligned index-for-index with points.
 func (t *PoolTracker) fetchQuotes(
 	ctx context.Context,
 	p entity.Pool,
 	routerAddr string,
-	balances []*big.Int,
+	points [2][]*big.Int,
 	blockNumber *big.Int,
-) ([][][2]*big.Int, error) {
+) ([2][]*big.Int, error) {
 	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
-	samples := make([][][2]*big.Int, 2)
 	account := common.Address{}
+	tokenAddr := [2]common.Address{
+		common.HexToAddress(p.Tokens[0].Address),
+		common.HexToAddress(p.Tokens[1].Address),
+	}
 
-	for i := range p.Tokens {
-		tokenIn := common.HexToAddress(p.Tokens[i].Address)
-		tokenOut := common.HexToAddress(p.Tokens[1-i].Address)
-
-		points := make([]*big.Int, 0, sampleSize+len(maxInSampleBps))
-
-		dec := int(p.Tokens[i].Decimals)
-		start := max(0, dec-sampleSize/2)
-		for idx, k := 0, start; idx < sampleSize; idx, k = idx+1, k+1 {
-			points = append(points, bignumber.TenPowInt(k))
-		}
-
-		if i < len(balances) && balances[i] != nil && balances[i].Sign() > 0 {
-			for _, bps := range maxInSampleBps {
-				pt := new(big.Int).Mul(balances[i], big.NewInt(int64(bps)))
-				pt.Div(pt, bignumber.BasisPoint)
-				if pt.Sign() > 0 {
-					points = append(points, pt)
-				}
-			}
-		}
-
-		sort.Slice(points, func(a, b int) bool {
-			return points[a].Cmp(points[b]) < 0
-		})
-		points = dedupSorted(points)
-
-		samples[i] = make([][2]*big.Int, len(points))
-		for j, pt := range points {
-			samples[i][j] = [2]*big.Int{new(big.Int).Set(pt), new(big.Int)}
+	var outputs [2][]*big.Int
+	callCount := 0
+	for dir := range points {
+		tokenIn, tokenOut := tokenAddr[dir], tokenAddr[1-dir]
+		outputs[dir] = make([]*big.Int, len(points[dir]))
+		for i, pt := range points[dir] {
+			outputs[dir][i] = new(big.Int)
 			req.AddCall(&ethrpc.Call{
 				ABI:    routerABI,
 				Target: routerAddr,
 				Method: "quote",
-				Params: []any{account, tokenIn, tokenOut, samples[i][j][0]},
-			}, []any{&samples[i][j][1]})
+				Params: []any{account, tokenIn, tokenOut, pt},
+			}, []any{&outputs[dir][i]})
+			callCount++
 		}
+	}
+	if callCount == 0 {
+		return outputs, nil
 	}
 
 	if _, err := req.TryAggregate(); err != nil {
-		return nil, err
+		return [2][]*big.Int{}, err
 	}
 
-	return samples, nil
+	return outputs, nil
 }
 
-func (t *PoolTracker) applyBuffer(samples [][][2]*big.Int) {
+func (t *PoolTracker) applyBuffer(outputs [2][]*big.Int) {
 	if t.cfg.Buffer <= 0 {
 		return
 	}
 	buf := big.NewInt(t.cfg.Buffer)
-	for i := range samples {
-		for j := range samples[i] {
-			if s1 := samples[i][j][1]; s1 != nil {
-				s1.Mul(s1, buf)
-				s1.Div(s1, bignumber.BasisPoint)
-			}
-		}
-	}
-}
-
-func filterSamples(samples [][][2]*big.Int) [][][2]*big.Int {
-	for dir := range samples {
-		valid := samples[dir][:0]
-		for _, s := range samples[dir] {
-			if s[0] == nil || s[1] == nil || s[1].Sign() <= 0 {
+	for dir := range outputs {
+		for _, out := range outputs[dir] {
+			if out == nil {
 				continue
 			}
-			valid = append(valid, s)
+			out.Mul(out, buf)
+			out.Div(out, bignumber.BasisPoint)
 		}
-		samples[dir] = valid
 	}
-	return samples
 }
 
-func (t *PoolTracker) warnGapInQuotes(p entity.Pool, samples [][][2]*big.Int) {
-	for dir := range samples {
+func (t *PoolTracker) warnGapInQuotes(p entity.Pool, points, outputs [2][]*big.Int) {
+	for dir := range outputs {
+		pts, outs := points[dir], outputs[dir]
 		seenPositive := false
 		zeroRunStart := -1
 
-		for i := range samples[dir] {
-			pt := samples[dir][i]
-			if pt[0] == nil || pt[1] == nil {
+		for i, out := range outs {
+			if out == nil {
 				continue
 			}
-			if pt[1].Sign() > 0 {
+			if out.Sign() > 0 {
 				if zeroRunStart >= 0 {
-					startAmt := samples[dir][zeroRunStart][0]
-					endAmt := samples[dir][i-1][0]
 					logger.WithFields(logger.Fields{
 						"pool":           p.Address,
 						"dir":            dir,
 						"tokenIn":        p.Tokens[dir].Address,
 						"tokenOut":       p.Tokens[1-dir].Address,
-						"holeFromAmount": startAmt.String(),
-						"holeToAmount":   endAmt.String(),
-						"resumeAmount":   pt[0].String(),
+						"holeFromAmount": pts[zeroRunStart].String(),
+						"holeToAmount":   pts[i-1].String(),
+						"resumeAmount":   pts[i].String(),
 					}).Warn("1010-prop quote gap detected (positive -> zero -> positive)")
 					zeroRunStart = -1
 				}
@@ -229,15 +200,13 @@ func (t *PoolTracker) warnGapInQuotes(p entity.Pool, samples [][][2]*big.Int) {
 	}
 }
 
-func dedupSorted(sorted []*big.Int) []*big.Int {
-	if len(sorted) <= 1 {
-		return sorted
+func (t *PoolTracker) persist(p entity.Pool, extra ladder.Extra, r0, r1 *uint256.Int, blockNumber *big.Int) entity.Pool {
+	extraBytes, _ := json.Marshal(extra)
+	p.Extra = string(extraBytes)
+	p.Reserves = entity.PoolReserves{r0.Dec(), r1.Dec()}
+	if blockNumber != nil {
+		p.BlockNumber = blockNumber.Uint64()
 	}
-	result := sorted[:1]
-	for _, v := range sorted[1:] {
-		if v.Cmp(result[len(result)-1]) != 0 {
-			result = append(result, v)
-		}
-	}
-	return result
+	p.Timestamp = time.Now().Unix()
+	return p
 }

--- a/pkg/liquidity-source/1010-prop/type.go
+++ b/pkg/liquidity-source/1010-prop/type.go
@@ -11,16 +11,6 @@ type AssetReserves struct {
 	Balances []*big.Int
 }
 
-type Extra struct {
-	Samples [][][2]*big.Int `json:"samples"`
-	MaxIn   []*big.Int      `json:"maxIn,omitempty"`
-}
-
 type StaticExtra struct {
-	RouterAddress string `json:"routerAddress"`
-}
-
-type PoolMetaInfo struct {
-	BlockNumber   uint64 `json:"blockNumber"`
 	RouterAddress string `json:"routerAddress"`
 }


### PR DESCRIPTION
Replaces the pool's hand-rolled samples/piecewise-linear quoting with the
shared ladder package (spline quoting, self-tuning probe grid), matching
caliberprop's pattern. GetMetaInfo keeps returning ApprovalAddress so
callers relying on pool.ApprovalInfo still resolve the router to approve.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
