### PR TITLE
fix(euler-swap-v2): implement whitelist swap hook and getFee sentinel handling

### DIFF
--- a/pkg/liquidity-source/euler-swap/v2/hooks/abis/EulerSwapHook.json
+++ b/pkg/liquidity-source/euler-swap/v2/hooks/abis/EulerSwapHook.json
@@ -99,5 +99,22 @@
         ],
         "outputs": [],
         "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "poolEnabled",
+        "inputs": [
+            {
+                "name": "pool",
+                "type": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view"
     }
 ]

--- a/pkg/liquidity-source/euler-swap/v2/hooks/base_hook.go
+++ b/pkg/liquidity-source/euler-swap/v2/hooks/base_hook.go
@@ -6,8 +6,10 @@ import (
 )
 
 var (
-	ErrHookNotSupported = errors.New("hook not supported")
-	ErrHookCallFailed   = errors.New("hook call failed")
+	ErrHookNotSupported     = errors.New("hook not supported")
+	ErrHookCallFailed       = errors.New("hook call failed")
+	ErrSwapperNotAuthorized = errors.New("swapper not authorized by swap hook")
+	ErrPoolDisabled         = errors.New("pool disabled by swap hook")
 )
 
 type BaseHook struct{}

--- a/pkg/liquidity-source/euler-swap/v2/hooks/whitelist_hook.go
+++ b/pkg/liquidity-source/euler-swap/v2/hooks/whitelist_hook.go
@@ -1,0 +1,101 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+const (
+	// FeeUseStaticFee mirrors EulerSwap's QuoteLib.getFee/getFeeReadOnly: when
+	// the swap hook answers getFee with type(uint64).max, the pool falls back
+	// to its static fee0/fee1.
+	FeeUseStaticFee uint64 = math.MaxUint64
+)
+
+// WhitelistHookAddresses lists the deployed access-control EulerSwap swap
+// hooks. These contracts register pools by address, gate every swap behind an
+// owner-managed swapper whitelist inside beforeSwap (reverting with
+// Unauthorized() otherwise), verify output amounts against EVault cash, and
+// always answer getFee with type(uint64).max so pools keep their static fees.
+var WhitelistHookAddresses = []common.Address{
+	common.HexToAddress("0x4B18F757c90856718DE70Be35aF6683b44bf72CA"),
+}
+
+// WhitelistExtra is the tracked hook state persisted into Extra.HookExtra.
+type WhitelistExtra struct {
+	Enabled bool `json:"e"` // pool registered and not paused/disabled on the hook
+}
+
+type WhitelistHook struct {
+	Extra WhitelistExtra
+}
+
+var _ Hook = (*WhitelistHook)(nil)
+
+func init() {
+	RegisterHooksFactory(NewWhitelistHook, WhitelistHookAddresses...)
+}
+
+func NewWhitelistHook(param *HookParam) Hook {
+	hook := &WhitelistHook{Extra: WhitelistExtra{Enabled: true}}
+	if param != nil && len(param.HookExtra) > 0 {
+		if err := json.Unmarshal([]byte(param.HookExtra), &hook.Extra); err != nil {
+			hook.Extra = WhitelistExtra{Enabled: true}
+		}
+	}
+	return hook
+}
+
+func (h *WhitelistHook) GetFee(_ *GetFeeParams) (uint64, error) {
+	return FeeUseStaticFee, nil
+}
+
+func (h *WhitelistHook) BeforeSwap(_ *BeforeSwapParams) error {
+	if !h.Extra.Enabled {
+		return ErrPoolDisabled
+	}
+
+	// The hook only allows whitelisted swappers past beforeSwap. dex-lib has no
+	// notion of the taker address and public routers are not whitelisted, so
+	// any swap we could simulate would revert with Unauthorized() on-chain.
+	return ErrSwapperNotAuthorized
+}
+
+func (h *WhitelistHook) AfterSwap(_ *AfterSwapParams) error {
+	return nil
+}
+
+func (h *WhitelistHook) Track(ctx context.Context, param *HookParam) (string, error) {
+	if param == nil || param.RpcClient == nil || param.Pool == nil {
+		return "", ErrHookCallFailed
+	}
+
+	var enabled bool
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber)
+	req.AddCall(&ethrpc.Call{
+		ABI:    HookABI,
+		Target: hexutil.Encode(param.HookAddress[:]),
+		Method: "poolEnabled",
+		Params: []any{common.HexToAddress(param.Pool.Address)},
+	}, []any{&enabled})
+
+	if _, err := req.TryAggregate(); err != nil {
+		return "", err
+	}
+
+	bz, err := json.Marshal(WhitelistExtra{Enabled: enabled})
+	if err != nil {
+		return "", err
+	}
+	return string(bz), nil
+}
+
+func (h *WhitelistHook) CloneState() Hook {
+	cloned := *h
+	return &cloned
+}

--- a/pkg/liquidity-source/euler-swap/v2/hooks/whitelist_hook_test.go
+++ b/pkg/liquidity-source/euler-swap/v2/hooks/whitelist_hook_test.go
@@ -1,0 +1,66 @@
+package hooks
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhitelistHook_GetFeeReturnsStaticFeeSentinel(t *testing.T) {
+	h := NewWhitelistHook(nil)
+
+	fee, err := h.GetFee(&GetFeeParams{Asset0IsInput: true})
+	require.NoError(t, err)
+	require.Equal(t, FeeUseStaticFee, fee)
+	assert.Equal(t, uint64(math.MaxUint64), fee)
+}
+
+func TestWhitelistHook_BeforeSwap(t *testing.T) {
+	enabled := NewWhitelistHook(nil).(*WhitelistHook)
+	require.True(t, enabled.Extra.Enabled)
+	assert.ErrorIs(t, enabled.BeforeSwap(&BeforeSwapParams{}), ErrSwapperNotAuthorized)
+
+	disabled := NewWhitelistHook(&HookParam{HookExtra: `{"e":false}`}).(*WhitelistHook)
+	require.False(t, disabled.Extra.Enabled)
+	assert.ErrorIs(t, disabled.BeforeSwap(&BeforeSwapParams{}), ErrPoolDisabled)
+
+	broken := NewWhitelistHook(&HookParam{HookExtra: `not-json`}).(*WhitelistHook)
+	require.True(t, broken.Extra.Enabled)
+}
+
+func TestWhitelistHook_AfterSwapNoop(t *testing.T) {
+	h := NewWhitelistHook(nil).(*WhitelistHook)
+	assert.NoError(t, h.AfterSwap(&AfterSwapParams{}))
+}
+
+func TestWhitelistHook_FactoryRegistered(t *testing.T) {
+	require.NotEmpty(t, WhitelistHookAddresses)
+
+	for _, addr := range WhitelistHookAddresses {
+		hook := GetHook(addr, &HookParam{HookExtra: `{"e":false}`})
+		wl, ok := hook.(*WhitelistHook)
+		require.True(t, ok)
+		assert.False(t, wl.Extra.Enabled)
+
+		assert.ErrorIs(t, hook.BeforeSwap(&BeforeSwapParams{}), ErrPoolDisabled)
+	}
+}
+
+func TestWhitelistHook_UnknownAddressFallsBackToBase(t *testing.T) {
+	hook := GetHook(common.HexToAddress("0x0000000000000000000000000000000000000001"), &HookParam{})
+	_, ok := hook.(*BaseHook)
+	assert.True(t, ok)
+}
+
+func TestWhitelistHook_CloneStateIsolation(t *testing.T) {
+	h := NewWhitelistHook(&HookParam{HookExtra: `{"e":true}`}).(*WhitelistHook)
+
+	cloned := h.CloneState().(*WhitelistHook)
+	cloned.Extra.Enabled = false
+
+	assert.True(t, h.Extra.Enabled)
+	assert.ErrorIs(t, cloned.BeforeSwap(&BeforeSwapParams{}), ErrPoolDisabled)
+}

--- a/pkg/liquidity-source/euler-swap/v2/integration_test.go
+++ b/pkg/liquidity-source/euler-swap/v2/integration_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/shared"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/v2/hooks"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
@@ -49,6 +51,28 @@ func TestIntegration_V2_ComputeQuote(t *testing.T) {
 
 			simulator, err := NewPoolSimulator(updatedPool)
 			require.NoError(t, err)
+
+			// Whitelist swap hooks revert inside beforeSwap for any
+			// non-whitelisted taker during execution, while on-chain
+			// computeQuote is a read-only view that never reaches beforeSwap.
+			// Such pools must fail quoting here and cannot be validated
+			// against computeQuote.
+			if _, gated := simulator.hook.(*hooks.WhitelistHook); gated {
+				_, simErr := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+					TokenAmountIn: pool.TokenAmount{
+						Token:  updatedPool.Tokens[0].Address,
+						Amount: bignumber.TenPowInt(6),
+					},
+					TokenOut: updatedPool.Tokens[1].Address,
+				})
+				require.Error(t, simErr)
+				assert.True(t,
+					errors.Is(simErr, hooks.ErrSwapperNotAuthorized) || errors.Is(simErr, hooks.ErrPoolDisabled),
+					"Pool %s is whitelist-gated, quotes must be rejected", updatedPool.Address)
+				fmt.Printf("Pool: %s - gated by whitelist swap hook (%v), skipping computeQuote comparison\n",
+					updatedPool.Address, simErr)
+				return
+			}
 
 			amounts := []*big.Int{
 				bignumber.TenPowInt(18),

--- a/pkg/liquidity-source/euler-swap/v2/pool_simulator.go
+++ b/pkg/liquidity-source/euler-swap/v2/pool_simulator.go
@@ -370,7 +370,9 @@ func (p *PoolSimulator) getFee(zeroForOne bool) *uint256.Int {
 			Reserve0:      p.reserves[0],
 			Reserve1:      p.reserves[1],
 		})
-		if err == nil {
+		// Mirrors EulerSwap's QuoteLib.getFee: type(uint64).max means the hook
+		// defers to the pool's static fee0/fee1.
+		if err == nil && fee != hooks.FeeUseStaticFee {
 			return uint256.NewInt(fee)
 		}
 	}

--- a/pkg/liquidity-source/euler-swap/v2/pool_simulator_test.go
+++ b/pkg/liquidity-source/euler-swap/v2/pool_simulator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/v2/hooks"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
@@ -41,4 +42,69 @@ func TestPoolSimulator_InsolvencyReproduction(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected insolvency error, but got result: %v", result.TokenAmountOut.Amount.String())
 	}
+}
+
+// whitelistedHookPoolData is mainnet pool 0x8d67f3ae412d2dfa702a5c6ce96d1f98f447a8a8
+// (cbBTC/USDT), whose dynamic params point at the access-control swap hook
+// 0x4b18f757c90856718de70be35af6683b44bf72ca with ops BeforeSwap|GetFee.
+const whitelistedHookPoolData = `{"address":"0x8d67f3ae412d2dfa702a5c6ce96d1f98f447a8a8","exchange":"uniswap-v4-euler-v2","type":"euler-swap-v2","timestamp":1787507311,"reserves":["79597070109","61425577806424"],"tokens":[{"address":"0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf","symbol":"cbBTC","decimals":8,"swappable":true},{"address":"0xdac17f958d2ee523a2206206994597c13d831ec7","symbol":"USDT","decimals":6,"swappable":true}],"extra":"{\"er0\":\"79597070109\",\"er1\":\"61425577806424\",\"mr0\":\"2316051\",\"mr1\":\"1500000000\",\"px\":\"60783830856435\",\"py\":\"78808980306\",\"cx\":\"500000000000000000\",\"cy\":\"500000000000000000\",\"f0\":\"3000000000000000\",\"f1\":\"3000000000000000\",\"sho\":3,\"sh\":\"0x4b18f757c90856718de70be35af6683b44bf72ca\",\"p\":1,\"sv\":[{\"c\":\"122521492\",\"d\":\"0\",\"mD\":\"49855466052\",\"tB\":\"22012455\",\"eAA\":\"8357\",\"bC\":\"42500000000\",\"dP\":\"772757048144300\",\"vP\":[\"772757048144300\",\"999950590000\"],\"vVP\":[\"772757048144300\",\"999950590000\"],\"ltv\":[0,8000],\"vLtv\":[0,8000]},{\"c\":\"11403020538\",\"d\":\"0\",\"mD\":\"49674157145008\",\"tB\":\"314439834453\",\"eAA\":\"1766592\",\"bC\":\"45000000000000\",\"dP\":\"999950590000\",\"vP\":[\"772757048144300\",\"999950590000\"],\"vVP\":[\"772757048144300\",\"999950590000\"],\"ltv\":[8400,0],\"vLtv\":[8400,0]}],\"bv\":[{\"c\":\"122521492\",\"d\":\"0\",\"mD\":\"49855466052\",\"tB\":\"22012455\",\"eAA\":\"8357\",\"bC\":\"42500000000\",\"dP\":\"772757048144300\",\"vP\":[\"772757048144300\",\"999950590000\"],\"vVP\":[\"772757048144300\",\"999950590000\"],\"ltv\":[0,8000],\"vLtv\":[0,8000]},{\"c\":\"11403020538\",\"d\":\"0\",\"mD\":\"49674157145008\",\"tB\":\"314439834453\",\"eAA\":\"1766592\",\"bC\":\"45000000000000\",\"dP\":\"999950590000\",\"vP\":[\"772757048144300\",\"999950590000\"],\"vVP\":[\"772757048144300\",\"999950590000\"],\"ltv\":[8400,0],\"vLtv\":[8400,0]},null],\"c\":[\"8357\",\"1766592\"]}","staticExtra":"{\"sv0\":\"0x056f3a2E41d2778D3a0c0714439c53af2987718E\",\"sv1\":\"0x313603FA690301b0CaeEf8069c065862f9162162\",\"bv0\":\"0x056f3a2E41d2778D3a0c0714439c53af2987718E\",\"bv1\":\"0x313603FA690301b0CaeEf8069c065862f9162162\",\"ea\":\"0xc6038dF81B26d2B79b639D16379925Ed54367183\",\"fr\":\"0xc6038DF81b26D2B79B639D16379925ED54367186\",\"evc\":\"0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383\"}","blockNumber":25819453}`
+
+func newWhitelistedHookSimulator(t *testing.T) (*PoolSimulator, entity.Pool) {
+	t.Helper()
+
+	var entityPool entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(whitelistedHookPoolData), &entityPool))
+
+	simulator, err := NewPoolSimulator(entityPool)
+	require.NoError(t, err)
+	return simulator, entityPool
+}
+
+// The hook gates every swap behind a private swapper whitelist (reverting in
+// beforeSwap on-chain), so quotes through dex-lib must fail as well.
+func TestPoolSimulator_WhitelistHookRejectsQuotes(t *testing.T) {
+	simulator, entityPool := newWhitelistedHookSimulator(t)
+
+	_, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: entityPool.Tokens[1].Address, Amount: big.NewInt(1_000_000)},
+		TokenOut:      entityPool.Tokens[0].Address,
+	})
+	assert.ErrorIs(t, err, hooks.ErrSwapperNotAuthorized)
+
+	_, err = simulator.CalcAmountIn(pool.CalcAmountInParams{
+		TokenAmountOut: pool.TokenAmount{Token: entityPool.Tokens[0].Address, Amount: big.NewInt(10_000)},
+		TokenIn:        entityPool.Tokens[1].Address,
+	})
+	assert.ErrorIs(t, err, hooks.ErrSwapperNotAuthorized)
+}
+
+// The hook always answers getFee with type(uint64).max, which EulerSwap's
+// QuoteLib treats as "keep the static fee" — quoting must use fee0/fee1.
+func TestPoolSimulator_HookFeeSentinelFallsBackToStaticFee(t *testing.T) {
+	simulator, _ := newWhitelistedHookSimulator(t)
+
+	require.NotNil(t, simulator.hook)
+	assert.Equal(t, simulator.Fee0.String(), simulator.getFee(true).String())
+	assert.Equal(t, simulator.Fee1.String(), simulator.getFee(false).String())
+}
+
+func TestPoolSimulator_WhitelistHookDisabledByTracker(t *testing.T) {
+	var entityPool entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(whitelistedHookPoolData), &entityPool))
+
+	var extra Extra
+	require.NoError(t, json.Unmarshal([]byte(entityPool.Extra), &extra))
+	extra.HookExtra = `{"e":false}`
+	extraBytes, err := json.Marshal(&extra)
+	require.NoError(t, err)
+	entityPool.Extra = string(extraBytes)
+
+	simulator, err := NewPoolSimulator(entityPool)
+	require.NoError(t, err)
+
+	_, err = simulator.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: entityPool.Tokens[1].Address, Amount: big.NewInt(1_000_000)},
+		TokenOut:      entityPool.Tokens[0].Address,
+	})
+	assert.ErrorIs(t, err, hooks.ErrPoolDisabled)
 }


### PR DESCRIPTION
EulerSwap v2 pools can point their dynamic params at an access-control swap hook (e.g. 0x4B18F757c90856718DE70Be35aF6683b44bf72CA on mainnet, ops BeforeSwap|GetFee). That hook gates every swap behind an owner-managed swapper whitelist in beforeSwap (Unauthorized revert for anyone else), verifies output amounts against EVault cash, and can disable pools at runtime. dex-lib previously fell back to a no-op BaseHook, so it kept quoting these pools while real swaps reverted on-chain.

- add WhitelistHook registered for the deployed hook address: BeforeSwap rejects with ErrSwapperNotAuthorized/ErrPoolDisabled, Track persists poolEnabled state into HookExtra
- mirror EulerSwap QuoteLib.getFee: type(uint64).max returned by a hook now falls back to the pool's static fee0/fee1 instead of rejecting all
- extend integration test to skip computeQuote comparison for gated pools (computeQuote is read-only and never reaches beforeSwap)


<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
