### PR TITLE
refactor(testutil): use WaitGroup.Go in concurrent checks

### DIFF
--- a/pkg/util/testutil/concurrent.go
+++ b/pkg/util/testutil/concurrent.go
@@ -29,12 +29,10 @@ func mustReturnSameOutputAndConcurrentSafe[R any](t testing.TB, f func() (R, err
 		outputs = make([]lo.Tuple2[R, error], concurrentFactor)
 	)
 	for i := 0; i < concurrentFactor; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			value, err := f()
 			outputs[i] = lo.T2(value, err)
-		}(i)
+		})
 	}
 	wg.Wait()
 


### PR DESCRIPTION
## Why did we need it?

The concurrent test helper manually pairs `WaitGroup.Add` and `Done` for each task. `WaitGroup.Go` keeps goroutine startup and wait-group accounting together, making the helper less error-prone while retaining the same execution and wait semantics.

## Related Issue

Fixes #ISSUE

## Release Note

No release note required. This only refactors an internal test utility and introduces no production or configuration changes.

## How Has This Been Tested?

- Ran `goimports` on `pkg/util/testutil/concurrent.go`.
- Ran `go test ./pkg/util/testutil` successfully.

## Screenshots (if appropriate)

Not applicable.