### PR TITLE
fix(limitorder): give the HTTP client a timeout and let callers inject it

### DIFF
--- a/pkg/source/limitorder/config.go
+++ b/pkg/source/limitorder/config.go
@@ -1,5 +1,11 @@
 package limitorder
 
+import (
+	"net/http"
+
+	"github.com/KyberNetwork/blockchain-toolkit/time/durationjson"
+)
+
 type Config struct {
 	DexID             string `json:"dexID"`
 	LimitOrderHTTPUrl string `json:"limitOrderHTTPUrl"`
@@ -10,4 +16,10 @@ type Config struct {
 
 	// default=false -> include orders with insufficient balance/allowance
 	DisableInsufficientBalance bool `json:"disableInsufficientBalance"`
+
+	HTTPTimeout    durationjson.Duration `json:"httpTimeout"`
+	HTTPRetryCount int                   `json:"httpRetryCount"`
+	// HTTPClient lets callers supply their own Transport. http.DefaultTransport keeps only
+	// 2 idle connections per host, which starves callers that fan RFQ out concurrently.
+	HTTPClient *http.Client `json:"-"`
 }

--- a/pkg/source/limitorder/http_client.go
+++ b/pkg/source/limitorder/http_client.go
@@ -29,7 +29,12 @@ func NewHTTPClient(baseURL string) *httpClient {
 
 // Deprecated: use NewHTTPClientWithConfig and set Config.HTTPClient instead.
 func NewHTTPClientWithRestyClient(baseURL string, client *resty.Client) *httpClient {
-	client.SetBaseURL(baseURL).SetTimeout(defaultHTTPTimeout)
+	client.SetBaseURL(baseURL)
+	// bound only a client that has none of its own; overwriting would silently retune
+	// a caller that already chose a timeout
+	if client.GetClient().Timeout <= 0 {
+		client.SetTimeout(defaultHTTPTimeout)
+	}
 
 	return &httpClient{
 		client: client,

--- a/pkg/source/limitorder/http_client.go
+++ b/pkg/source/limitorder/http_client.go
@@ -13,16 +13,52 @@ import (
 	"github.com/samber/lo"
 )
 
+// defaultHTTPTimeout exists only to bound a hung backend, so it is deliberately far
+// looser than any caller's SLO. Latency-sensitive callers set Config.HTTPTimeout.
+const defaultHTTPTimeout = 30 * time.Second
+
 type httpClient struct {
 	client *resty.Client
 }
 
+// Deprecated: use NewHTTPClientWithConfig, which also supports a timeout, retries and a
+// caller-supplied Transport.
 func NewHTTPClient(baseURL string) *httpClient {
-	return NewHTTPClientWithRestyClient(baseURL, resty.NewWithClient(lo.ToPtr(lo.FromPtr(http.DefaultClient))))
+	return NewHTTPClientWithConfig(&Config{LimitOrderHTTPUrl: baseURL})
 }
 
+// Deprecated: use NewHTTPClientWithConfig and set Config.HTTPClient instead.
 func NewHTTPClientWithRestyClient(baseURL string, client *resty.Client) *httpClient {
-	client.SetBaseURL(baseURL)
+	client.SetBaseURL(baseURL).SetTimeout(defaultHTTPTimeout)
+
+	return &httpClient{
+		client: client,
+	}
+}
+
+func NewHTTPClientWithConfig(cfg *Config) *httpClient {
+	httpCli := cfg.HTTPClient
+	if httpCli == nil {
+		httpCli = http.DefaultClient
+	}
+
+	timeout := cfg.HTTPTimeout.Duration
+	if timeout <= 0 {
+		timeout = defaultHTTPTimeout
+	}
+
+	// resty skips its single-shot path for any non-zero retry count, then runs
+	// `for attempt := 0; attempt <= retries` — a negative count executes the request
+	// zero times and hands back a nil response for the caller to dereference.
+	retryCount := max(cfg.HTTPRetryCount, 0)
+
+	// shallow-copy so SetTimeout writes a per-dex Timeout instead of mutating the
+	// caller's client; the Transport pointer, and so the connection pool, is shared.
+	client := resty.NewWithClient(lo.ToPtr(lo.FromPtr(httpCli))).
+		SetBaseURL(cfg.LimitOrderHTTPUrl).
+		SetTimeout(timeout).
+		SetRetryCount(retryCount)
+
 	return &httpClient{
 		client: client,
 	}

--- a/pkg/source/limitorder/http_client_test.go
+++ b/pkg/source/limitorder/http_client_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/KyberNetwork/blockchain-toolkit/time/durationjson"
+	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -112,5 +113,24 @@ func TestNewHTTPClientWithConfig(t *testing.T) {
 		assert.Same(t, transport, c.client.GetClient().Transport, "connection pool must be shared")
 		assert.Equal(t, 250*time.Millisecond, c.client.GetClient().Timeout)
 		assert.Equal(t, time.Hour, shared.Timeout, "caller's client must not be mutated")
+	})
+}
+
+// TestNewHTTPClientWithRestyClient covers the deprecated wrapper: it must bound a client
+// that has no timeout without retuning one that already does.
+func TestNewHTTPClientWithRestyClient(t *testing.T) {
+	const baseURL = "http://example.invalid"
+
+	t.Run("injected client without a timeout gets the default", func(t *testing.T) {
+		c := NewHTTPClientWithRestyClient(baseURL, resty.New())
+		assert.Equal(t, defaultHTTPTimeout, c.client.GetClient().Timeout)
+		assert.Equal(t, baseURL, c.client.BaseURL)
+	})
+
+	t.Run("injected client keeps its own timeout", func(t *testing.T) {
+		injected := resty.New().SetTimeout(5 * time.Second)
+		c := NewHTTPClientWithRestyClient(baseURL, injected)
+		assert.Equal(t, 5*time.Second, c.client.GetClient().Timeout)
+		assert.Equal(t, baseURL, c.client.BaseURL)
 	})
 }

--- a/pkg/source/limitorder/http_client_test.go
+++ b/pkg/source/limitorder/http_client_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
-	"github.com/go-resty/resty/v2"
+	"github.com/KyberNetwork/blockchain-toolkit/time/durationjson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -45,7 +46,7 @@ func TestGetOpSignatures_ErrorWrapping(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewHTTPClientWithRestyClient(srv.URL, resty.New())
+		c := NewHTTPClient(srv.URL)
 		_, err := c.GetOpSignatures(t.Context(), 1, []int64{123})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrGetOpSignaturesFailed), "got: %v", err)
@@ -57,16 +58,59 @@ func TestGetOpSignatures_ErrorWrapping(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewHTTPClientWithRestyClient(srv.URL, resty.New())
+		c := NewHTTPClient(srv.URL)
 		_, err := c.GetOpSignatures(t.Context(), 1, []int64{123})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrGetOpSignaturesFailed), "got: %v", err)
 	})
 
 	t.Run("transport/network error wraps ErrGetOpSignaturesFailed", func(t *testing.T) {
-		c := NewHTTPClientWithRestyClient("http://127.0.0.1:1", resty.New())
+		c := NewHTTPClient("http://127.0.0.1:1")
 		_, err := c.GetOpSignatures(t.Context(), 1, []int64{123})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrGetOpSignaturesFailed), "got: %v", err)
+	})
+}
+
+// TestNewHTTPClientWithConfig covers the knobs the Config-taking constructor adds.
+func TestNewHTTPClientWithConfig(t *testing.T) {
+	t.Run("negative retry count does not disable the request", func(t *testing.T) {
+		// resty takes its single-shot path only when RetryCount == 0; any other value goes
+		// through Backoff, whose `attempt <= retries` loop never runs for a negative count
+		// and returns a nil response. Clamping keeps that out of the caller's hands.
+		var hits int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"data":{"operatorSignatures":[]}}`))
+		}))
+		defer srv.Close()
+
+		c := NewHTTPClientWithConfig(&Config{LimitOrderHTTPUrl: srv.URL, HTTPRetryCount: -1})
+		require.NotPanics(t, func() {
+			_, err := c.GetOpSignatures(t.Context(), 1, []int64{123})
+			require.NoError(t, err)
+		})
+		assert.Equal(t, 1, hits)
+	})
+
+	t.Run("unset timeout falls back to the default", func(t *testing.T) {
+		c := NewHTTPClientWithConfig(&Config{LimitOrderHTTPUrl: "http://example.invalid"})
+		assert.Equal(t, defaultHTTPTimeout, c.client.GetClient().Timeout)
+	})
+
+	t.Run("injected client shares its Transport but keeps its own Timeout", func(t *testing.T) {
+		transport := &http.Transport{MaxIdleConnsPerHost: 64}
+		shared := &http.Client{Transport: transport, Timeout: time.Hour}
+
+		c := NewHTTPClientWithConfig(&Config{
+			LimitOrderHTTPUrl: "http://example.invalid",
+			HTTPClient:        shared,
+			HTTPTimeout:       durationjson.Duration{Duration: 250 * time.Millisecond},
+		})
+
+		assert.Same(t, transport, c.client.GetClient().Transport, "connection pool must be shared")
+		assert.Equal(t, 250*time.Millisecond, c.client.GetClient().Timeout)
+		assert.Equal(t, time.Hour, shared.Timeout, "caller's client must not be mutated")
 	})
 }

--- a/pkg/source/limitorder/pool_tracker.go
+++ b/pkg/source/limitorder/pool_tracker.go
@@ -23,7 +23,7 @@ type PoolTracker struct {
 var _ = pooltrack.RegisterFactoryC(DexTypeLimitOrder, NewPoolTracker)
 
 func NewPoolTracker(cfg *Config) *PoolTracker {
-	limitOrderClient := NewHTTPClient(cfg.LimitOrderHTTPUrl)
+	limitOrderClient := NewHTTPClientWithConfig(cfg)
 
 	return &PoolTracker{
 		config:           cfg,

--- a/pkg/source/limitorder/pools_list_updater.go
+++ b/pkg/source/limitorder/pools_list_updater.go
@@ -25,7 +25,7 @@ var _ = poollist.RegisterFactoryC(DexTypeLimitOrder, NewPoolsListUpdater)
 func NewPoolsListUpdater(
 	cfg *Config,
 ) *PoolsListUpdater {
-	limitOrderClient := NewHTTPClient(cfg.LimitOrderHTTPUrl)
+	limitOrderClient := NewHTTPClientWithConfig(cfg)
 	contractAddresses := lo.Map(cfg.ContractAddresses, func(c string, _ int) string { return strings.ToLower(c) })
 	return &PoolsListUpdater{
 		config:           cfg,

--- a/pkg/source/limitorder/rfq.go
+++ b/pkg/source/limitorder/rfq.go
@@ -19,7 +19,7 @@ type RFQHandler struct {
 }
 
 func NewRFQHandler(config *Config) *RFQHandler {
-	client := NewHTTPClient(config.LimitOrderHTTPUrl)
+	client := NewHTTPClientWithConfig(config)
 	return &RFQHandler{
 		config: config,
 		client: client,


### PR DESCRIPTION
## Problem

`pkg/source/limitorder` is the only RFQ handler in this library that talks to the network without a timeout and without a way for the caller to supply its own HTTP client.

Survey of the 17 RFQ handlers across `kyberswap-dex-lib` + `kyberswap-dex-lib-private`:

| Handler | HTTP | Timeout | Injectable client |
|---|---|---|---|
| **`source/limitorder`** | yes | **no** | **no** |
| `clipper`, `bebop`, `dexalot`, `kyber-pmm`, `native/v2`, `swaap-v2` | yes | yes | — |
| `hashflow-v3` | yes | yes | yes (`HTTPClientConfig.Client`) |
| `mx-trading` | yes | yes | yes (`pmm.HTTPConfig.Client`) |
| `lo1inch`, `onebit`, `tokka`, `kipseli-prop`, `fairflow` x2, `kyber-exclusive-amm` | no (signs locally) | n/a | n/a |

Two consequences for consumers:

**1. No timeout.** `NewHTTPClient` never called `SetTimeout`, so the only bound on a request was whatever context the caller passed. A caller without one — and `RFQHandler.RFQ` is reached from call sites that pass `context.Background()` — could pin goroutines on a stalled backend indefinitely.

**2. Two idle connections per host, with no way to change it.** `resty.NewWithClient(lo.ToPtr(lo.FromPtr(http.DefaultClient)))` shallow-copies the client, and `http.DefaultClient` has a nil `Transport`, so requests resolve to `http.DefaultTransport` — whose `MaxIdleConnsPerHost` is the package default of **2** (`net/http/transport.go`: `DefaultTransport` does not set the field; `DefaultMaxIdleConnsPerHost = 2`). A consumer that fans RFQ out concurrently keeps at most 2 idle connections to the limit-order host and pays a fresh TCP handshake — plus TLS against the public endpoint — on everything past that. `Config` exposed no seam to pass a tuned `Transport`.

## Change

`Config` gains `HTTPTimeout`, `HTTPRetryCount` and `HTTPClient`, consumed by a new `NewHTTPClientWithConfig`.

**Source compatibility.** `NewHTTPClient(baseURL string)` and `NewHTTPClientWithRestyClient` keep their existing signatures and are marked `Deprecated:` rather than changed or removed — an earlier revision of this PR replaced them, on the mistaken reasoning that returning an unexported type made them unusable outside the package. It does not: callers can hold the result via type inference and call its exported methods. Both legacy constructors now apply the default timeout, so a consumer that never migrates still loses the unbounded case.

**`HTTPClient` is a `*http.Client`, not a `*resty.Client`.** A deliberate divergence from `clipper.HTTPClientConfig` / `pmm.HTTPConfig`:

- the `Transport` is what a caller actually wants to share; resty stays an implementation detail of this package rather than leaking into every consumer's config type;
- the constructor shallow-copies before `SetTimeout`, so several dexes can share one `*http.Client` — and so one connection pool — without clobbering each other's timeout. The resty-shaped siblings mutate the injected client in place and cannot offer that.

**Retry count is clamped to >= 0.** resty takes its single-shot path only when `RetryCount == 0` (`request.go:1047`); any other value goes through `Backoff`, whose `for attempt := 0; attempt <= retries` loop (`retry.go:114`) never runs for a negative count. The request is then never issued and the caller is handed a nil `*resty.Response` to dereference. Verified: before the clamp, `HTTPRetryCount: -1` made `GetOpSignatures` panic with a nil pointer dereference. Covered by a regression test.

**Defaults.** An unset timeout falls back to 30s instead of staying unbounded. The default exists to bound a hung backend, not to enforce any caller's SLO, so it is deliberately far looser than one — bumping to this version cannot turn a slow-but-successful call into a client timeout. Latency-sensitive consumers set `httpTimeout` explicitly. Retry count still defaults to 0, so request volume is unchanged.

## Config compatibility

Both consumers decode `limitorder.Config` from JSON (`router-service` via `util.AnyToStruct`, `reserve-taker` via `PropertiesToStruct`), so the new `json`-tagged fields are additive and optional. `durationjson.Duration` accepts both `"300ms"` and a raw nanosecond number, and `blockchain-toolkit` is already a direct dependency. Existing configs keep working and pick up the 30s bound on bump.

## Not included

`liquidity-source/uniswap/lo` shares `http.DefaultTransport` too, but it already sets a 10s timeout, is a pool-list fetch client rather than an RFQ handler, and has no call sites in this library outside its own test — so it is left out to keep this PR scoped.

## Test plan

- `go build ./...` — clean
- `go vet ./pkg/source/limitorder/...` — clean
- `go test ./pkg/source/limitorder/...` — 75 pass
- `go generate ./...` leaves the tree clean (`generate-check` CI job)
- `gofmt -l` / `gci` clean on all changed files

New `TestNewHTTPClientWithConfig` covers: negative retry count still issues exactly one request and does not panic; an unset timeout falls back to the default; an injected `*http.Client` has its `Transport` shared with the resty client while its own `Timeout` is left untouched.

`TestGetOpSignatures_LiveAPI` fails locally against `limit-order.kyberswap.com`, which currently answers `403` with a Cloudflare "access from your country is restricted" HTML page. That is unrelated to this change; the test is `test.SkipCI(t)`-guarded so CI does not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)