### PR TITLE
feat: add uniswap-v4 hook for B20 launchpad

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/abis.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/abis.go
@@ -1,0 +1,65 @@
+package b20
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// launchHookABIJson covers the single getter this hook reads: the frozen per-pool
+// economics registered by the B20 factory at launch time (LaunchHook.sol's
+// `poolConfig` public mapping getter).
+const launchHookABIJson = `[
+	{
+		"inputs": [{"internalType": "PoolId", "name": "", "type": "bytes32"}],
+		"name": "poolConfig",
+		"outputs": [
+			{"internalType": "bool", "name": "initialized", "type": "bool"},
+			{"internalType": "bool", "name": "tokenIsCurrency0", "type": "bool"},
+			{"internalType": "address", "name": "creator", "type": "address"},
+			{"internalType": "address", "name": "platformTreasury", "type": "address"},
+			{"internalType": "uint16", "name": "baseFeeBps", "type": "uint16"},
+			{"internalType": "uint16", "name": "creatorBps", "type": "uint16"},
+			{"internalType": "uint16", "name": "platformBps", "type": "uint16"},
+			{"internalType": "uint16", "name": "referrerBps", "type": "uint16"},
+			{"internalType": "uint16", "name": "antiSnipeStartTotalBps", "type": "uint16"},
+			{"internalType": "uint32", "name": "antiSnipeWindowSeconds", "type": "uint32"},
+			{"internalType": "uint48", "name": "launchTime", "type": "uint48"}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+var LaunchHookABI abi.ABI
+
+func init() {
+	var err error
+	LaunchHookABI, err = abi.JSON(bytes.NewReader([]byte(launchHookABIJson)))
+	if err != nil {
+		panic(err)
+	}
+}
+
+// poolConfigRaw is the ethrpc.Call.AddCall decode target for `poolConfig`, field order
+// matching LaunchHookABI's outputs. Only the fields relevant to swap pricing are read;
+// creator/platformTreasury/creatorBps/platformBps/referrerBps affect fee *distribution*
+// inside the FeeEscrow, not the swap-visible fee amount, so they aren't decoded here --
+// go-ethereum's abi.Unpack fills struct fields positionally and skips absent ones
+// entirely, so a struct with fewer fields than outputs does not decode correctly; instead
+// every output is kept, unused ones just aren't read downstream.
+type poolConfigRaw struct {
+	Initialized            bool
+	TokenIsCurrency0       bool
+	Creator                common.Address
+	PlatformTreasury       common.Address
+	BaseFeeBps             uint16
+	CreatorBps             uint16
+	PlatformBps            uint16
+	ReferrerBps            uint16
+	AntiSnipeStartTotalBps uint16
+	AntiSnipeWindowSeconds uint32
+	LaunchTime             *big.Int
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/constant.go
@@ -1,0 +1,17 @@
+package b20
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// MaxTotalFeeBps mirrors LaunchHook.sol's MAX_TOTAL_FEE_BPS -- a hard ceiling on
+// base + anti-snipe surcharge, strictly below 100%.
+const MaxTotalFeeBps = 9_900
+
+const bps = 10_000
+
+// HookAddresses is the single shared LaunchHook instance reused by every B20 launch
+// (per-pool economics live in poolConfig, not in the hook's own address).
+var HookAddresses = []common.Address{
+	common.HexToAddress("0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc"),
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/direct_protocol_match_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/direct_protocol_match_test.go
@@ -1,0 +1,137 @@
+package b20
+
+import (
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	poolpkg "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+// TestDirectProtocolMatch_ReferenceLaunch is dex-verify step 4: the local simulator's
+// CalcAmountOut must agree with the deployed protocol's own quote source (Uniswap's
+// canonical V4Quoter, which executes the real LaunchHook via PoolManager.unlock) for
+// the reference pool used throughout this integration. Pool state (slot0, liquidity,
+// the single seeded tick band, hook config) was read directly via cast against a
+// Tenderly vnet fork of Base at block 50429052 on 2026-08-25 (see output/verify.md) --
+// hand-built here rather than via PoolTracker.BootstrapPoolState, which requires a
+// keyed thegraph.com subgraph client not available in this environment; production
+// bootstrap goes through the tracker, this test only needs the resulting state shape.
+//
+// maxDriftWei documents an inherited, non-b20-specific finding: the "buy" direction
+// (fee applied pre-swap via BeforeSwap, quote=input) shows a small absolute drift
+// (4-17 wei observed across outputs spanning 1e22-1e25, i.e. NOT proportional to
+// size) against the deployed quoter, traced to the shared v3-derived tick-crossing
+// math's fixed-point sqrtPrice arithmetic -- not this hook's fee math, which is
+// exact-floor mulDiv and matches on-chain bit-for-bit (confirmed by the "sell"
+// direction, fee applied post-swap via AfterSwap, being bit-exact at every size
+// tested, including 1e21 tokens sold). Bound kept as an absolute wei count, not a
+// relative tolerance, per the "not proportional to size" finding.
+const maxDriftWei = 20
+
+func assertWithinDrift(t *testing.T, want string, got *big.Int) {
+	t.Helper()
+	wantBI, ok := new(big.Int).SetString(want, 10)
+	require.True(t, ok)
+	diff := new(big.Int).Sub(wantBI, got)
+	diff.Abs(diff)
+	require.LessOrEqualf(t, diff.Int64(), int64(maxDriftWei),
+		"want=%s got=%s diff=%s exceeds the documented inherited-precision tolerance", wantBI, got, diff)
+}
+
+func TestDirectProtocolMatch_ReferenceLaunch(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	poolID := "0x68d39022eee9e18f82fe929f70dd8d2009e442e6d80c6c1ffc170c32b7d3b671"
+	hook := "0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc"
+	token := "0xb200000000000000000000216203b40c83837b7d"
+	native := "0x0000000000000000000000000000000000000000"
+
+	staticExtra := `{"0x0":[true,false],"fee":0,"tS":200,"hooks":"` + hook +
+		`","uR":"0x6fF5693b99212Da76ad316178A184AB56D299b43","pm2":"0x000000000022D473030F116dDEE9F6B43aC78BA3","mc3":"0xcA11bde05977b3631167028862bE2a173976CA11"}`
+
+	// slot0/liquidity/tick band read live via `cast call` against StateView
+	// (0xA3c0c9b65baD0b08107Aa264b0f3dB444b867A71) on the vnet; the seeded band
+	// itself (tickLower=-887200, tickUpper=199200) comes from the launch tx's
+	// ModifyLiquidity log (0x36b76594...cf636).
+	extra := `{"liquidity":34511678704448028213888,"sqrtPriceX96":1557825037365388960186678851882063,"tickSpacing":200,"tick":197739,` +
+		`"ticks":[{"index":-887200,"liquidityGross":34511678704448028213888,"liquidityNet":34511678704448028213888},` +
+		`{"index":199200,"liquidityGross":34511678704448028213888,"liquidityNet":-34511678704448028213888}],` +
+		`"hX":{"t0":false,"bf":100,"as":9900,"aw":16,"lt":1786986263}}`
+
+	pool := entity.Pool{
+		Address:  poolID,
+		Exchange: string(valueobject.ExchangeUniswapV4B20),
+		Type:     uniswapv4.DexType,
+		SwapFee:  0,
+		Tokens:   []*entity.PoolToken{{Address: native, Swappable: true}, {Address: token, Swappable: true}},
+		// Reserves are only a swap-size sanity cap here (real per-pool balances live in
+		// the shared PoolManager vault, not queryable per-pool via balanceOf) -- large
+		// enough to not clip any of this grid's input amounts.
+		Reserves:    entity.PoolReserves{"1000000000000000000000000", "1000000000000000000000000000000"},
+		StaticExtra: staticExtra,
+		Extra:       extra,
+	}
+
+	// The pool's launchTime (1786986263) is long past for all these fixtures (recorded
+	// 2026-08-25), so totalFeeBps resolves to the flat baseFeeBps=100 regardless of
+	// nowFn -- pinned explicitly anyway so this test's outcome never depends on another
+	// test file's leftover package-level nowFn override.
+	orig := nowFn
+	nowFn = func() int64 { return time.Now().Unix() }
+	defer func() { nowFn = orig }()
+
+	sim, err := uniswapv4.NewPoolSimulator(pool, valueobject.ChainIDBase)
+	require.NoError(t, err)
+
+	buyCases := []struct {
+		name, amountWei, wantOut string
+	}{
+		{"buy 1e14 wei ETH", "100000000000000", "38272681478685449659873"},
+		{"buy 1e15 wei ETH", "1000000000000000", "382532639159565385084466"},
+		{"buy 1e16 wei ETH", "10000000000000000", "3806016647895321434614353"},
+		{"buy 1e17 wei ETH", "100000000000000000", "36231260193184936831706671"},
+	}
+	for _, c := range buyCases {
+		t.Run(c.name, func(t *testing.T) {
+			amt, ok := new(big.Int).SetString(c.amountWei, 10)
+			require.True(t, ok)
+			res, err := sim.CalcAmountOut(poolpkg.CalcAmountOutParams{
+				TokenAmountIn: poolpkg.TokenAmount{Token: native, Amount: amt},
+				TokenOut:      token,
+			})
+			require.NoError(t, err)
+			assertWithinDrift(t, c.wantOut, res.TokenAmountOut.Amount)
+		})
+	}
+
+	sellCases := []struct {
+		name, amountToken, wantOut string
+	}{
+		{"sell 1 token", "1000000000000000000", "2560689982"},
+		{"sell 1000 tokens", "1000000000000000000000", "2560686211853"},
+	}
+	for _, c := range sellCases {
+		t.Run(c.name, func(t *testing.T) {
+			amt, ok := new(big.Int).SetString(c.amountToken, 10)
+			require.True(t, ok)
+			res, err := sim.CalcAmountOut(poolpkg.CalcAmountOutParams{
+				TokenAmountIn: poolpkg.TokenAmount{Token: token, Amount: amt},
+				TokenOut:      native,
+			})
+			require.NoError(t, err)
+			// Bit-exact at every size tested -- the AfterSwap (post-swap, fee-on-output)
+			// path doesn't touch the pre-swap sqrtPrice math that produces the buy-side drift.
+			require.Equal(t, c.wantOut, res.TokenAmountOut.Amount.String())
+		})
+	}
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/hook.go
@@ -1,0 +1,168 @@
+// Package b20 implements the Uniswap v4 hook shared by every B20 launchpad
+// pool. See LaunchHook.sol on Base (0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc):
+// liquidity is permanently locked to the factory-seeded band (no third-party LP),
+// and every swap pays a fee on the quote currency -- a base rate plus a
+// linearly-decaying anti-snipe surcharge over the first antiSnipeWindowSeconds
+// after launch. PoolKey.fee is always 0; all economics come from this overlay.
+package b20
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+var (
+	errNotRegistered     = errors.New("pool not registered with the B20 factory yet")
+	errNotTracked        = errors.New("b20-launch: pool config not yet tracked, refusing to quote at an unknown fee")
+	errCalcInUnsupported = errors.New("b20-launch: exact-out not supported (matches pool_simulator.go's CalcAmountOut-only scope)")
+)
+
+// Extra is the pricing-relevant subset of LaunchHook.sol's poolConfig -- frozen at
+// registration except for the live block.timestamp comparison against LaunchTime.
+// creator/platformTreasury/creatorBps/platformBps/referrerBps only affect how the
+// FeeEscrow later splits the fee, not the swap-visible amount, so they're omitted.
+type Extra struct {
+	TokenIsCurrency0       bool  `json:"t0,omitempty"`
+	BaseFeeBps             int64 `json:"bf"`
+	AntiSnipeStartTotalBps int64 `json:"as,omitempty"`
+	AntiSnipeWindowSeconds int64 `json:"aw,omitempty"`
+	LaunchTime             int64 `json:"lt,omitempty"`
+}
+
+// nowFn is a var so tests can pin the anti-snipe decay clock.
+var nowFn = func() int64 { return time.Now().Unix() }
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	h := &Hook{Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4B20}}
+	_ = param.HookExtra.Unmarshal(&h.Extra)
+	return h
+}, HookAddresses...)
+
+type Hook struct {
+	uniswapv4.Hook `json:"-"`
+	Extra
+}
+
+// Track reads the pool's frozen economics from the hook contract's poolConfig
+// getter. It only needs to run once per pool -- poolConfig never changes after
+// registration -- so an already-populated Extra with a non-zero LaunchTime is
+// reused as-is instead of re-reading on every tracker pass.
+func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	if h.LaunchTime != 0 {
+		return json.Marshal(h)
+	}
+
+	var raw poolConfigRaw
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
+		ABI:    LaunchHookABI,
+		Target: hexutil.Encode(param.HookAddress[:]),
+		Method: "poolConfig",
+		Params: []any{common.HexToHash(param.Pool.Address)},
+	}, []any{&raw})
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+	if !raw.Initialized {
+		return nil, errNotRegistered
+	}
+
+	h.Extra = Extra{
+		TokenIsCurrency0:       raw.TokenIsCurrency0,
+		BaseFeeBps:             int64(raw.BaseFeeBps),
+		AntiSnipeStartTotalBps: int64(raw.AntiSnipeStartTotalBps),
+		AntiSnipeWindowSeconds: int64(raw.AntiSnipeWindowSeconds),
+		LaunchTime:             raw.LaunchTime.Int64(),
+	}
+	return json.Marshal(h)
+}
+
+// totalFeeBps mirrors LaunchHook.sol's _totalFeeBps: base + a linearly-decaying
+// anti-snipe surcharge over the first AntiSnipeWindowSeconds after LaunchTime,
+// capped at MaxTotalFeeBps. Evaluated against wall-clock time, same as every
+// other time-decaying v4 hook in this package (see hooks/fairflow/hook.go).
+func (h *Hook) totalFeeBps() int64 {
+	elapsed := nowFn() - h.LaunchTime
+	if elapsed >= h.AntiSnipeWindowSeconds {
+		return h.BaseFeeBps
+	}
+	maxSurcharge := h.AntiSnipeStartTotalBps - h.BaseFeeBps
+	surcharge := maxSurcharge * (h.AntiSnipeWindowSeconds - elapsed) / h.AntiSnipeWindowSeconds
+	total := h.BaseFeeBps + surcharge
+	if total > MaxTotalFeeBps {
+		return MaxTotalFeeBps
+	}
+	return total
+}
+
+// quoteIsSpecified reports whether the swap's specified (input, exact-in) currency
+// is the quote currency -- i.e. the swap is buying the launch token with the quote.
+func (h *Hook) quoteIsSpecified(zeroForOne bool) bool {
+	// exact-in: specified currency is currency0 iff zeroForOne.
+	specifiedIsCurrency0 := zeroForOne
+	quoteIsCurrency0 := !h.TokenIsCurrency0
+	return specifiedIsCurrency0 == quoteIsCurrency0
+}
+
+// BeforeSwap only handles the exact-in (CalcOut) direction -- the only one
+// pool_simulator.go's CalcAmountOut ever drives. When the quote currency is the
+// swap's input, LaunchHook.sol charges the fee pre-swap (floor-rounded) so the
+// AMM sees a reduced input; see AfterSwap for the output-side case.
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	if !params.CalcOut {
+		return nil, errCalcInUnsupported
+	}
+	if h.LaunchTime == 0 {
+		// Never successfully Track()ed (RPC failure, or genuinely not yet registered
+		// with the factory): a zero-value Extra has BaseFeeBps=0, which would
+		// otherwise price this pool as fee-free instead of refusing to quote it.
+		return nil, errNotTracked
+	}
+	if !h.quoteIsSpecified(params.ZeroForOne) {
+		return &uniswapv4.BeforeSwapResult{
+			DeltaSpecified:   bignumber.ZeroBI,
+			DeltaUnspecified: bignumber.ZeroBI,
+		}, nil
+	}
+	fee := feeAmount(params.AmountSpecified, h.totalFeeBps())
+	return &uniswapv4.BeforeSwapResult{
+		DeltaSpecified:   fee,
+		DeltaUnspecified: bignumber.ZeroBI,
+	}, nil
+}
+
+// AfterSwap applies the fee post-swap (floor-rounded, on the realized output) when
+// the quote currency is the swap's output side.
+func (h *Hook) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
+	if !params.CalcOut {
+		return nil, errCalcInUnsupported
+	}
+	if h.LaunchTime == 0 {
+		return nil, errNotTracked
+	}
+	if h.quoteIsSpecified(params.ZeroForOne) {
+		return &uniswapv4.AfterSwapResult{HookFee: bignumber.ZeroBI}, nil
+	}
+	fee := feeAmount(params.AmountOut, h.totalFeeBps())
+	return &uniswapv4.AfterSwapResult{HookFee: fee}, nil
+}
+
+// feeAmount mirrors LaunchHook.sol's _feeAmount for the exact-in (non-exactOutput)
+// branch: floor(magnitude * feeBps / 10_000).
+func feeAmount(magnitude *big.Int, feeBps int64) *big.Int {
+	if feeBps == 0 || magnitude == nil || magnitude.Sign() == 0 {
+		return bignumber.ZeroBI
+	}
+	return bignumber.MulDivDown(new(big.Int), magnitude, big.NewInt(feeBps), big.NewInt(bps))
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/hook_live_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/hook_live_test.go
@@ -1,0 +1,46 @@
+package b20
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+)
+
+// TestTrack_Live decodes poolConfig against a real B20 launch on Base (found via a
+// live launch tx, see explorer.md), confirming LaunchHookABI's field order/types
+// actually match the deployed contract -- not just the ABI JSON compiling.
+func TestTrack_Live(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	rpcClient := ethrpc.New("https://mainnet.base.org").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+	hookAddr := common.HexToAddress("0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc")
+
+	h := &Hook{Hook: &uniswapv4.BaseHook{}}
+	_, err := h.Track(context.Background(), &uniswapv4.HookParam{
+		RpcClient:   rpcClient,
+		HookAddress: hookAddr,
+		Pool: &entity.Pool{
+			Address: "0x68d39022eee9e18f82fe929f70dd8d2009e442e6d80c6c1ffc170c32b7d3b671",
+		},
+	})
+	require.NoError(t, err)
+
+	// Values cross-checked by hand against `cast call ... poolConfig(bytes32)` on 2026-08-25.
+	assert.False(t, h.TokenIsCurrency0)
+	assert.Equal(t, int64(100), h.BaseFeeBps)
+	assert.Equal(t, int64(9900), h.AntiSnipeStartTotalBps)
+	assert.Equal(t, int64(16), h.AntiSnipeWindowSeconds)
+	assert.Equal(t, int64(1786986263), h.LaunchTime)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/hook_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/hook_test.go
@@ -1,0 +1,152 @@
+package b20
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+// reference values pulled from LaunchHook.sol's live poolConfig for a real B20 launch
+// on Base (poolId 0x68d39022eee9e18f82fe929f70dd8d2009e442e6d80c6c1ffc170c32b7d3b671),
+// so the decay math is checked against the actual on-chain fee schedule, not just its
+// own logic restated.
+func refExtra() Extra {
+	return Extra{
+		TokenIsCurrency0:       false,
+		BaseFeeBps:             100,
+		AntiSnipeStartTotalBps: 9900,
+		AntiSnipeWindowSeconds: 16,
+		LaunchTime:             1786986263,
+	}
+}
+
+// totalFeeBps must reproduce LaunchHook.sol's _totalFeeBps exactly: a wrong bps here
+// silently mis-prices every swap during the anti-snipe window (first 16s after
+// launch for this reference pool) without erroring, so a route built on this quote
+// would settle for less than it should on-chain.
+func TestTotalFeeBps_Decay(t *testing.T) {
+	h := &Hook{Extra: refExtra()}
+
+	cases := []struct {
+		name    string
+		elapsed int64
+		want    int64
+	}{
+		{"at launch instant, surcharge is maximal", 0, 9900},
+		{"halfway through the window, surcharge is halved", 8, 5000},
+		{"window boundary, decays to just base fee", 16, 100},
+		{"long after the window, stays at base fee", 1_000_000, 100},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			nowFn = func() int64 { return h.LaunchTime + c.elapsed }
+			assert.Equal(t, c.want, h.totalFeeBps())
+		})
+	}
+}
+
+// A misconfigured pool (antiSnipeStartTotalBps above the hard ceiling somehow making
+// it through Track) must never let the simulator quote a fee above what the contract
+// can ever charge -- MaxTotalFeeBps is the contract's own hard ceiling.
+func TestTotalFeeBps_CappedAtMax(t *testing.T) {
+	// On-chain _validateFeeConfig rejects antiSnipeStartTotalBps > MAX_TOTAL_FEE_BPS at
+	// registration time, but the Go clamp must hold defensively too -- use an
+	// out-of-policy value (10_000) so the surcharge math alone would exceed the cap and
+	// the assertion can actually fail if the `if total > MaxTotalFeeBps` clamp is removed.
+	h := &Hook{Extra: Extra{BaseFeeBps: 0, AntiSnipeStartTotalBps: 10_000, AntiSnipeWindowSeconds: 10, LaunchTime: 1}}
+	nowFn = func() int64 { return 1 } // elapsed=0 -> surcharge=10_000, would exceed the cap uncapped
+	assert.Equal(t, int64(MaxTotalFeeBps), h.totalFeeBps())
+}
+
+func TestQuoteIsSpecified(t *testing.T) {
+	cases := []struct {
+		name             string
+		tokenIsCurrency0 bool
+		zeroForOne       bool
+		want             bool
+	}{
+		{"token=c1, sell c0(quote) for c1(token): quote is specified (buying token)", false, true, true},
+		{"token=c1, sell c1(token) for c0(quote): token is specified (selling token)", false, false, false},
+		{"token=c0, sell c0(token) for c1(quote): token is specified (selling token)", true, true, false},
+		{"token=c0, sell c1(quote) for c0(token): quote is specified (buying token)", true, false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := &Hook{Extra: Extra{TokenIsCurrency0: c.tokenIsCurrency0}}
+			assert.Equal(t, c.want, h.quoteIsSpecified(c.zeroForOne))
+		})
+	}
+}
+
+// Buying the token with quote-as-input: LaunchHook.sol charges the fee pre-swap
+// (beforeSwap), floor-rounded, reducing what the AMM sees as input.
+func TestBeforeSwap_QuoteSpecified_ChargesFeeOnInput(t *testing.T) {
+	e := refExtra()
+	nowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds } // post-window: flat 100bps
+	h := &Hook{Extra: e}
+
+	// tokenIsCurrency0=false -> quote is currency0 -> zeroForOne=true sells quote in.
+	amountIn := big.NewInt(1_000_000)
+	result, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true, AmountSpecified: amountIn})
+	require.NoError(t, err)
+
+	// floor(1_000_000 * 100 / 10_000) = 10_000, matching _feeAmount's floor mulDiv.
+	assert.Equal(t, big.NewInt(10_000), result.DeltaSpecified)
+	assert.Equal(t, bignumber.ZeroBI, result.DeltaUnspecified)
+}
+
+// Selling the token for quote: the fee must NOT be charged in BeforeSwap (it's
+// deferred to AfterSwap on the realized output) -- charging it here too would
+// double-count against AfterSwap's own fee application.
+func TestBeforeSwap_TokenSpecified_NoFeeHere(t *testing.T) {
+	e := refExtra()
+	nowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds }
+	h := &Hook{Extra: e}
+
+	result, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false, AmountSpecified: big.NewInt(1_000_000)})
+	require.NoError(t, err)
+	assert.Equal(t, bignumber.ZeroBI, result.DeltaSpecified)
+	assert.Equal(t, bignumber.ZeroBI, result.DeltaUnspecified)
+}
+
+// Selling the token for quote: fee lands post-swap on the realized quote output.
+func TestAfterSwap_TokenSpecified_ChargesFeeOnOutput(t *testing.T) {
+	e := refExtra()
+	nowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds }
+	h := &Hook{Extra: e}
+
+	amountOut := big.NewInt(1_000_000)
+	result, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false},
+		AmountOut:        amountOut,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(10_000), result.HookFee)
+}
+
+func TestBeforeSwap_ExactOutUnsupported(t *testing.T) {
+	h := &Hook{Extra: refExtra()}
+	_, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: false, AmountSpecified: big.NewInt(1)})
+	assert.ErrorIs(t, err, errCalcInUnsupported)
+}
+
+// A pool whose Track() never succeeded (RPC failure, or a factory that constructs the
+// Hook before HookExtra is populated) must refuse to quote rather than default to a
+// zero-value Extra (BaseFeeBps=0), which would silently price the pool as fee-free.
+func TestBeforeAfterSwap_UntrackedPool_Errors(t *testing.T) {
+	h := &Hook{} // zero-value Extra: LaunchTime == 0
+
+	_, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true, AmountSpecified: big.NewInt(1_000_000)})
+	assert.ErrorIs(t, err, errNotTracked)
+
+	_, err = h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false},
+		AmountOut:        big.NewInt(1_000_000),
+	})
+	assert.ErrorIs(t, err, errNotTracked)
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -180,6 +180,7 @@ import (
 	pkg_liquiditysource_uniswap_v4_hooks_angstrom "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/angstrom"
 	pkg_liquiditysource_uniswap_v4_hooks_arena "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/arena"
 	pkg_liquiditysource_uniswap_v4_hooks_arrakis "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/arrakis"
+	pkg_liquiditysource_uniswap_v4_hooks_b20 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/b20"
 	pkg_liquiditysource_uniswap_v4_hooks_bunniv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/bunni-v2"
 	pkg_liquiditysource_uniswap_v4_hooks_clanker "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/clanker"
 	pkg_liquiditysource_uniswap_v4_hooks_cult "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/cult"
@@ -428,6 +429,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_angstrom.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_arena.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_arrakis.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_b20.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_bunniv2.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_clanker.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_cult.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -293,6 +293,7 @@ const (
 	ExchangeUniswapV4AngstromL2         = "uniswap-v4-angstrom-l2"
 	ExchangeUniswapV4Arena              = "uniswap-v4-arena"
 	ExchangeUniswapV4Arrakis            = "uniswap-v4-arrakis"
+	ExchangeUniswapV4B20                = "uniswap-v4-b20"
 	ExchangeUniswapV4BunniV2            = "uniswap-v4-bunni-v2"
 	ExchangeUniswapV4Clanker            = "uniswap-v4-clanker"
 	ExchangeUniswapV4Cult               = "uniswap-v4-cult"


### PR DESCRIPTION
Adds a hook plugin for LaunchHook (0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc
on Base), the shared Uniswap v4 hook behind every B20 launch: permanently
locked single-sided liquidity plus a dynamic swap fee (base + time-decaying
anti-snipe surcharge) applied on the quote currency.

Reuses the existing uniswap-v4 PoolType and hook registry (no new package);
registers ExchangeUniswapV4B20 and re-generates the msgpack pool-type table.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
