### PR TITLE
fix(uniswap-v4): register base RehypeDopplerHook v2 and split fee denominators by generation

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/doppler/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/doppler/constant.go
@@ -33,10 +33,11 @@ var (
 	}
 
 	DHooks = map[common.Address]func(json.RawMessage) IDHook{ // Doppler Hooks i.e. DopplerHookInitializer's internal hooks
-		h("0x97cAD5684FB7Cc2bEd9a9b5eBfba67138F4f2503"): NewRehypeDHook, // monad RehypeDopplerHook
-		h("0x3Ec4798A9B11e8243A8Db99687f7A23597B96623"): NewRehypeDHook, // ethereum/base RehypeDopplerHook
-		h("0xBF4195ab0B03e1eB3345dd1e83BeD7650b1ed123"): NewRehypeDHook, // ethereum/base RehypeDopplerHookInitializer
-		h("0x6f02324d20cc679d0e585290caa6b16bacbc0f77"): NewRehypeDHook, // robinhood RehypeDopplerHookInitializer
+		h("0x97cAD5684FB7Cc2bEd9a9b5eBfba67138F4f2503"): NewRehypeDHook,   // monad RehypeDopplerHook (MAX_SWAP_FEE = 0.8e6)
+		h("0x3Ec4798A9B11e8243A8Db99687f7A23597B96623"): NewRehypeDHook,   // ethereum/base RehypeDopplerHook (MAX_SWAP_FEE = 0.8e6)
+		h("0xBF4195ab0B03e1eB3345dd1e83BeD7650b1ed123"): NewRehypeDHook,   // ethereum/base RehypeDopplerHookInitializer (MAX_SWAP_FEE = 0.8e6)
+		h("0x6f02324d20cc679d0e585290caa6b16bacbc0f77"): NewRehypeDHook,   // robinhood RehypeDopplerHookInitializer (MAX_SWAP_FEE = 0.8e6)
+		h("0x9982538F41f2ae29ddb9d3D9307010052984FDbB"): NewRehypeDHookV2, // ethereum/base RehypeDopplerHook v2 (MAX_SWAP_FEE = 1e6)
 	}
 
 	ErrCannotSwapBeforeStartingTime = errors.New("cannot swap before starting time")

--- a/pkg/liquidity-source/uniswap/v4/hooks/doppler/doppler.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/doppler/doppler.go
@@ -110,8 +110,16 @@ type IDHook interface {
 	AfterSwap(params *uniswapv4.AfterSwapParams, dExtra *DHook) (*uniswapv4.AfterSwapResult, error)
 }
 
-// maxSwapFee matches the on-chain MAX_SWAP_FEE = 0.8e6 constant in RehypeTypes.sol.
-var maxSwapFee = big.NewInt(800_000)
+// Fee denominators (MAX_SWAP_FEE) differ across deployed RehypeTypes.sol generations:
+// the first generation used 0.8e6, the 2026-03 refactor changed it to 1e6
+// ("Maximum swap fee denominator (1e6 = 100%)"). Verified on-chain against
+// 0x9982538F41f2ae29ddb9d3D9307010052984FDbB (base): a swap with core output
+// 806621420570090 wei and currentFee 10500 transferred exactly
+// floor(806621420570090*10500/1e6) = 8469524915985 wei of hook fees.
+const (
+	maxSwapFeeV1 int64 = 800_000   // pre-refactor deployments
+	maxSwapFeeV2 int64 = 1_000_000 // post-refactor deployments
+)
 
 // RehypeDHook holds the fee schedule for a RehypeDopplerHook pool.
 // All fields nil means no fee (fee = 0).
@@ -122,11 +130,24 @@ type RehypeDHook struct {
 	EndFee          int64 `json:"e,omitempty"`
 	StartingTime    int64 `json:"t,omitempty"`
 	DurationSeconds int64 `json:"d,omitempty"`
+
+	// feeDenominator is the MAX_SWAP_FEE constant of the deployed hook generation this
+	// instance models. Derived from DHooks at construction; never persisted.
+	feeDenominator int64
 }
 
 func NewRehypeDHook(dExtra json.RawMessage) IDHook {
+	return newRehypeDHook(dExtra, maxSwapFeeV1)
+}
+
+func NewRehypeDHookV2(dExtra json.RawMessage) IDHook {
+	return newRehypeDHook(dExtra, maxSwapFeeV2)
+}
+
+func newRehypeDHook(dExtra json.RawMessage, feeDenominator int64) IDHook {
 	var hook RehypeDHook
 	_ = json.Unmarshal(dExtra, &hook)
+	hook.feeDenominator = feeDenominator
 	return &hook
 }
 
@@ -224,9 +245,12 @@ func (h *RehypeDHook) AfterSwap(params *uniswapv4.AfterSwapParams, _ *DHook) (*u
 		return &uniswapv4.AfterSwapResult{HookFee: bignumber.ZeroBI, Gas: 198835}, nil
 	}
 	feeBase := lo.Ternary(params.CalcOut, params.AmountOut, params.AmountIn)
-	hookFee := big.NewInt(currentFee)
+	denominator := h.feeDenominator
+	if denominator == 0 { // zero-value instances keep the legacy shared denominator
+		denominator = maxSwapFeeV1
+	}
 	return &uniswapv4.AfterSwapResult{
-		HookFee: bignumber.MulDivDown(hookFee, feeBase, hookFee, maxSwapFee),
+		HookFee: bignumber.MulDivDown(new(big.Int), big.NewInt(currentFee), feeBase, big.NewInt(denominator)),
 		Gas:     198835,
 	}, nil
 }


### PR DESCRIPTION
Pools created through the ethereum/base DopplerHookInitializer (0xBDF938...) now resolve to a new internal RehypeDopplerHook at 0x9982538F41f2ae29ddb9d3D9307010052984FDbB, which was missing from the DHooks registry: hX.e stayed null, AfterSwap fell back to BaseHook and quotes silently omitted the hook fee (~105bps of output), overquoting against on-chain proceeds.

The 2026-03 doppler refactor also changed RehypeTypes.MAX_SWAP_FEE from 0.8e6 to 1e6. Verified on-chain against 0x9982538F... on base: swap 0xe69dda90 with core output 806621420570090 transferred exactly floor(out * 10500 / 1e6) = 8469524915985 wei of hook fees.

Legacy deployments keep the previous shared 800_000 denominator via NewRehypeDHook; zero-value instances fall back to it as well.


<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
