### PR TITLE
fix/prism prop stale check

### DIFF
--- a/pkg/liquidity-source/prism-prop/pool_list_updater.go
+++ b/pkg/liquidity-source/prism-prop/pool_list_updater.go
@@ -47,7 +47,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, _ []byte) ([]entity.
 	pools := make([]entity.Pool, 0, len(pairs))
 	for _, pair := range pairs {
 		pools = append(pools, entity.Pool{
-			Address:  poolAddress(u.config.RouterAddress, pair.Token0.Hex(), pair.Token1.Hex()),
+			Address:  poolAddress(pair.Token0.Hex(), pair.Token1.Hex()),
 			Exchange: u.config.DexID,
 			Type:     DexType,
 			Tokens: []*entity.PoolToken{
@@ -63,9 +63,9 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, _ []byte) ([]entity.
 	return pools, nil, nil
 }
 
-// poolAddress is synthetic: prism-prop has one router contract quoting every
-// pair, so the "pool address" is derived from (router, pair), same as
-// titan-prop's IPropAMM venues.
-func poolAddress(router, token0, token1 string) string {
-	return strings.ToLower(router + "_" + token0 + "_" + token1)
+// poolAddress is synthetic: prism-prop has one router per chain (from
+// config, carried separately via StaticExtra.RouterAddress) quoting every
+// pair, so the pool ID only needs to disambiguate the pair, not the router.
+func poolAddress(token0, token1 string) string {
+	return strings.ToLower(token0 + "_" + token1)
 }

--- a/pkg/liquidity-source/prism-prop/pool_list_updater.go
+++ b/pkg/liquidity-source/prism-prop/pool_list_updater.go
@@ -2,11 +2,11 @@ package prismprop
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/KyberNetwork/ethrpc"
-
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/goccy/go-json"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
@@ -39,20 +39,22 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, _ []byte) ([]entity.
 		return nil, nil, err
 	}
 
-	staticExtraBytes, err := json.Marshal(StaticExtra{RouterAddress: strings.ToLower(u.config.RouterAddress)})
+	router := common.HexToAddress(u.config.RouterAddress)
+	staticExtraBytes, err := json.Marshal(StaticExtra{RouterAddress: hexutil.Encode(router[:])})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	pools := make([]entity.Pool, 0, len(pairs))
 	for _, pair := range pairs {
+		token0, token1 := hexutil.Encode(pair.Token0[:]), hexutil.Encode(pair.Token1[:])
 		pools = append(pools, entity.Pool{
-			Address:  poolAddress(u.config.RouterAddress, pair.Token0.Hex(), pair.Token1.Hex()),
+			Address:  poolAddress(token0, token1),
 			Exchange: u.config.DexID,
 			Type:     DexType,
 			Tokens: []*entity.PoolToken{
-				{Address: strings.ToLower(pair.Token0.Hex()), Swappable: true},
-				{Address: strings.ToLower(pair.Token1.Hex()), Swappable: true},
+				{Address: token0, Swappable: true},
+				{Address: token1, Swappable: true},
 			},
 			Reserves:    entity.PoolReserves{"0", "0"},
 			Extra:       "{}",
@@ -63,9 +65,11 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, _ []byte) ([]entity.
 	return pools, nil, nil
 }
 
-// poolAddress is synthetic: prism-prop has one router contract quoting every
-// pair, so the "pool address" is derived from (router, pair), same as
-// titan-prop's IPropAMM venues.
-func poolAddress(router, token0, token1 string) string {
-	return strings.ToLower(router + "_" + token0 + "_" + token1)
+// poolAddress is synthetic: prism-prop has one router per chain quoting
+// every pair, so a fixed "prism" namespace plus the pair already
+// disambiguates every pool -- prefixing with the full router address isn't
+// needed for uniqueness within this exchange, only across exchanges, which
+// the "prism" literal already covers.
+func poolAddress(token0, token1 string) string {
+	return "prismprop_" + token0 + "_" + token1
 }

--- a/pkg/liquidity-source/prism-prop/pool_list_updater.go
+++ b/pkg/liquidity-source/prism-prop/pool_list_updater.go
@@ -47,7 +47,7 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, _ []byte) ([]entity.
 	pools := make([]entity.Pool, 0, len(pairs))
 	for _, pair := range pairs {
 		pools = append(pools, entity.Pool{
-			Address:  poolAddress(pair.Token0.Hex(), pair.Token1.Hex()),
+			Address:  poolAddress(u.config.RouterAddress, pair.Token0.Hex(), pair.Token1.Hex()),
 			Exchange: u.config.DexID,
 			Type:     DexType,
 			Tokens: []*entity.PoolToken{
@@ -63,9 +63,9 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, _ []byte) ([]entity.
 	return pools, nil, nil
 }
 
-// poolAddress is synthetic: prism-prop has one router per chain (from
-// config, carried separately via StaticExtra.RouterAddress) quoting every
-// pair, so the pool ID only needs to disambiguate the pair, not the router.
-func poolAddress(token0, token1 string) string {
-	return strings.ToLower(token0 + "_" + token1)
+// poolAddress is synthetic: prism-prop has one router contract quoting every
+// pair, so the "pool address" is derived from (router, pair), same as
+// titan-prop's IPropAMM venues.
+func poolAddress(router, token0, token1 string) string {
+	return strings.ToLower(router + "_" + token0 + "_" + token1)
 }

--- a/pkg/liquidity-source/prism-prop/pool_simulator.go
+++ b/pkg/liquidity-source/prism-prop/pool_simulator.go
@@ -2,10 +2,11 @@ package prismprop
 
 import (
 	"math"
+	"time"
 
 	"github.com/goccy/go-json"
+	"github.com/samber/lo"
 
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	orderbook "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/order-book"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
@@ -23,17 +24,22 @@ type PoolSimulator struct {
 	routerAddress string
 }
 
-var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+var _ = pool.RegisterFactory(DexType, NewPoolSimulator)
 
-func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
-	poolSim, err := orderbook.NewPoolSimulatorWith(entityPool, math.MaxInt64)
+// NewPoolSimulator honors params.Opts.StaleCheck against orderbook.MaxAge,
+// same as order-book's own NewPoolSimulator -- the book updates almost every
+// block (confirmed live), so a stale/stuck tracker must not keep serving
+// quotes indefinitely.
+func NewPoolSimulator(params pool.FactoryParams) (*PoolSimulator, error) {
+	maxAge := lo.Ternary[time.Duration](params.Opts.StaleCheck, orderbook.MaxAge, math.MaxInt64)
+	poolSim, err := orderbook.NewPoolSimulatorWith(params.EntityPool, maxAge)
 	if err != nil {
 		return nil, err
 	}
 	poolSim.Gas = defaultGas
 
 	var staticExtra StaticExtra
-	if err := json.Unmarshal([]byte(entityPool.StaticExtra), &staticExtra); err != nil {
+	if err := json.Unmarshal([]byte(params.EntityPool.StaticExtra), &staticExtra); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- **fix: honor StaleCheck for prism-prop instead of disabling it**
- **refactor: drop router prefix from pool address**
- **Revert "refactor: drop router prefix from pool address"**
- **refactor: shorten pool address to prismprop_token0_token1, use hexutil**
