### PR TITLE
feat: integrate FlowState C1 (Robinhood Chain)

### DIFF
--- a/pkg/liquidity-source/flowstate-c1/abis.go
+++ b/pkg/liquidity-source/flowstate-c1/abis.go
@@ -1,0 +1,17 @@
+package flowstatec1
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var marketABI abi.ABI
+
+func init() {
+	var err error
+	marketABI, err = abi.JSON(bytes.NewReader(marketABIJson))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/liquidity-source/flowstate-c1/abis/FlowstateMarket.json
+++ b/pkg/liquidity-source/flowstate-c1/abis/FlowstateMarket.json
@@ -1,0 +1,34 @@
+[
+  {
+    "inputs": [{"internalType": "address", "name": "token", "type": "address"}],
+    "name": "poolByToken",
+    "outputs": [{"internalType": "address", "name": "pool", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "pool", "type": "address"},
+      {"internalType": "address", "name": "asset", "type": "address"},
+      {"internalType": "uint256", "name": "amount", "type": "uint256"}
+    ],
+    "name": "quoteBuyFromPool",
+    "outputs": [
+      {
+        "components": [
+          {"internalType": "bool", "name": "available", "type": "bool"},
+          {"internalType": "uint256", "name": "fillableAmount", "type": "uint256"},
+          {"internalType": "uint256", "name": "quoteAmount", "type": "uint256"},
+          {"internalType": "uint256", "name": "feeAmount", "type": "uint256"},
+          {"internalType": "uint16", "name": "feeBps", "type": "uint16"},
+          {"internalType": "address", "name": "quoteAsset", "type": "address"}
+        ],
+        "internalType": "struct Quote",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/flowstate-c1/config.go
+++ b/pkg/liquidity-source/flowstate-c1/config.go
@@ -1,0 +1,19 @@
+package flowstatec1
+
+import "github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+
+// PoolConfig seeds one inventory token. FlowState has no subgraph on Robinhood yet
+// and staging depth is a single pool, so the pool list is config-seeded (real pool
+// address is resolved on-chain via poolByToken, not hardcoded here).
+type PoolConfig struct {
+	Token       string `json:"token"`
+	ProbeAmount string `json:"probeAmount"`
+}
+
+type Config struct {
+	DexID       string              `json:"dexID"`
+	ChainID     valueobject.ChainID `json:"chainID"`
+	Market      string              `json:"market"`
+	QuoteAssets []string            `json:"quoteAssets"`
+	Pools       []PoolConfig        `json:"pools"`
+}

--- a/pkg/liquidity-source/flowstate-c1/constant.go
+++ b/pkg/liquidity-source/flowstate-c1/constant.go
@@ -1,0 +1,12 @@
+package flowstatec1
+
+const (
+	DexType = "flowstate-c1"
+
+	defaultGas = 250_000
+
+	// defaultProbeAmount is the token amount used to sample quoteBuyFromPool for a unit
+	// rate. Pricing has no curve impact up to fillableAmount (vendor spec section 3.1),
+	// so any amount well under expected depth yields the same per-unit rate.
+	defaultProbeAmount = "1000000000000000" // 1e15
+)

--- a/pkg/liquidity-source/flowstate-c1/embed.go
+++ b/pkg/liquidity-source/flowstate-c1/embed.go
@@ -1,0 +1,6 @@
+package flowstatec1
+
+import _ "embed"
+
+//go:embed abis/FlowstateMarket.json
+var marketABIJson []byte

--- a/pkg/liquidity-source/flowstate-c1/pool_simulator.go
+++ b/pkg/liquidity-source/flowstate-c1/pool_simulator.go
@@ -1,0 +1,139 @@
+package flowstatec1
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+	StaticExtra
+	Extra
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+var (
+	ErrPoolNotAvailable      = errors.New("pool is currently not available")
+	ErrInsufficientLiquidity = errors.New("amount exceeds available tokens")
+	ErrInvalidProbe          = errors.New("invalid probe rate")
+	ErrZeroAmountOut         = errors.New("amountOut is zero")
+)
+
+func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
+	info := pool.PoolInfo{
+		Address:     strings.ToLower(entityPool.Address),
+		Exchange:    entityPool.Exchange,
+		Type:        entityPool.Type,
+		Tokens:      []string{entityPool.Tokens[0].Address, entityPool.Tokens[1].Address},
+		Reserves:    []*big.Int{bignumber.NewBig10(entityPool.Reserves[0]), bignumber.NewBig10(entityPool.Reserves[1])},
+		BlockNumber: entityPool.BlockNumber,
+	}
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(entityPool.StaticExtra), &staticExtra); err != nil {
+		return nil, err
+	}
+
+	var extra Extra
+	if err := json.Unmarshal([]byte(entityPool.Extra), &extra); err != nil {
+		return nil, err
+	}
+
+	return &PoolSimulator{
+		Pool:        pool.Pool{Info: info},
+		StaticExtra: staticExtra,
+		Extra:       extra,
+	}, nil
+}
+
+// CanSwapFrom: buy-only, quote asset in (token[0]), inventory token out (token[1]).
+func (s *PoolSimulator) CanSwapFrom(token string) []string {
+	if token == s.Info.Tokens[0] {
+		return []string{s.Info.Tokens[1]}
+	}
+
+	return nil
+}
+
+func (s *PoolSimulator) CanSwapTo(token string) []string {
+	if token == s.Info.Tokens[1] {
+		return []string{s.Info.Tokens[0]}
+	}
+
+	return nil
+}
+
+func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	if !s.Available {
+		return nil, ErrPoolNotAvailable
+	}
+
+	if s.ProbeQuoteCost.IsZero() || s.ProbeAmount.IsZero() {
+		return nil, ErrInvalidProbe
+	}
+
+	amountIn, overflow := uint256.FromBig(param.TokenAmountIn.Amount)
+	if overflow {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	// No curve price impact up to FillableAmount (vendor spec 3.1): the unit rate
+	// sampled at ProbeAmount holds for any size, so scale linearly.
+	var amountOut uint256.Int
+	big256.MulDivDown(&amountOut, amountIn, s.ProbeAmount, s.ProbeQuoteCost)
+
+	if amountOut.IsZero() {
+		return nil, ErrZeroAmountOut
+	}
+
+	if amountOut.Gt(s.FillableAmount) {
+		return nil, ErrInsufficientLiquidity
+	}
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{
+			Token:  s.Info.Tokens[1],
+			Amount: amountOut.ToBig(),
+		},
+		Fee: &pool.TokenAmount{
+			Token:  s.Info.Tokens[0],
+			Amount: nil,
+		},
+		Gas: defaultGas,
+	}, nil
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	return &cloned
+}
+
+// UpdateBalance reassigns FillableAmount to a new *uint256.Int rather than mutating
+// the existing one in place: CloneState is a shallow copy, and a clone's pointer
+// would otherwise alias the original's.
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	amountOut, overflow := uint256.FromBig(params.TokenAmountOut.Amount)
+	if overflow {
+		return
+	}
+	s.FillableAmount = new(uint256.Int).Sub(s.FillableAmount, amountOut)
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return MetaInfo{
+		Market:      s.StaticExtra.Market,
+		Pool:        s.StaticExtra.Pool,
+		QuoteAsset:  s.StaticExtra.QuoteAsset,
+		BlockNumber: s.Info.BlockNumber,
+	}
+}

--- a/pkg/liquidity-source/flowstate-c1/pool_simulator_test.go
+++ b/pkg/liquidity-source/flowstate-c1/pool_simulator_test.go
@@ -1,0 +1,162 @@
+package flowstatec1
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+// newTestPool builds a PoolSimulator from numbers taken from a live quoteBuyFromPool
+// call against Market 0x8eFb662F738D0f5d9f146803FD02A36c6B67e60d, pool CASHCAT
+// 0x1c8Fe931c9be6583d9a2E5C05712a0F6d1e4faeD, asset USDG, on Robinhood Chain (4663):
+// quoteBuyFromPool(pool, USDG, 1e15) -> (available=true, fillableAmount=1e15,
+// quoteAmount=219, feeAmount=2, feeBps=100, quoteAsset=USDG).
+func newTestPool(t *testing.T, fillableAmount string) *PoolSimulator {
+	t.Helper()
+
+	staticExtra, err := json.Marshal(StaticExtra{
+		Market:     "0x8efb662f738d0f5d9f146803fd02a36c6b67e60d",
+		Pool:       "0x1c8fe931c9be6583d9a2e5c05712a0f6d1e4faed",
+		QuoteAsset: "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+	})
+	require.NoError(t, err)
+
+	extra, err := json.Marshal(Extra{
+		Available:      true,
+		ProbeAmount:    mustUint256(t, "1000000000000000"),
+		ProbeQuoteCost: mustUint256(t, "219"),
+		FillableAmount: mustUint256(t, fillableAmount),
+		FeeBps:         100,
+	})
+	require.NoError(t, err)
+
+	entityPool := entity.Pool{
+		Address:  "0x1c8fe931c9be6583d9a2e5c05712a0f6d1e4faed-0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+		Exchange: "flowstate-c1",
+		Type:     DexType,
+		Reserves: []string{"0", fillableAmount},
+		Tokens: []*entity.PoolToken{
+			{Address: "0x5fc5360d0400a0fd4f2af552add042d716f1d168", Swappable: true}, // USDG
+			{Address: "0x020bfc650a365f8bb26819deaabf3e21291018b4", Swappable: true}, // CASHCAT
+		},
+		StaticExtra: string(staticExtra),
+		Extra:       string(extra),
+	}
+
+	sim, err := NewPoolSimulator(entityPool)
+	require.NoError(t, err)
+
+	return sim
+}
+
+func mustUint256(t *testing.T, s string) *uint256.Int {
+	t.Helper()
+	v, err := uint256.FromDecimal(s)
+	require.NoError(t, err)
+	return v
+}
+
+func TestCalcAmountOut_FlatRateWithinDepth(t *testing.T) {
+	sim := newTestPool(t, "16304318509466102233884") // real CASHCAT balance at block 41,844,217-ish
+
+	// Same amount as the probe: amountOut must equal the probe's token amount exactly.
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+			Amount: big.NewInt(219),
+		},
+		TokenOut: "0x020bfc650a365f8bb26819deaabf3e21291018b4",
+	})
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(1_000_000_000_000_000), res.TokenAmountOut.Amount)
+
+	// No curve impact: 10x the input should give ~10x the output (linear rate).
+	res10x, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+			Amount: big.NewInt(2190),
+		},
+		TokenOut: "0x020bfc650a365f8bb26819deaabf3e21291018b4",
+	})
+	require.NoError(t, err)
+	require.Equal(t, new(big.Int).Mul(res.TokenAmountOut.Amount, big.NewInt(10)), res10x.TokenAmountOut.Amount)
+}
+
+func TestCalcAmountOut_ExceedsDepth(t *testing.T) {
+	// Depth capped at the probe amount itself: any request for more must fail rather
+	// than silently overpromise inventory that the pool doesn't actually hold.
+	sim := newTestPool(t, "1000000000000000")
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+			Amount: big.NewInt(2190), // would need 1e16 tokens out, only 1e15 available
+		},
+		TokenOut: "0x020bfc650a365f8bb26819deaabf3e21291018b4",
+	})
+	require.ErrorIs(t, err, ErrInsufficientLiquidity)
+}
+
+func TestCalcAmountOut_Unavailable(t *testing.T) {
+	sim := newTestPool(t, "1000000000000000")
+	sim.Available = false
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+			Amount: big.NewInt(1),
+		},
+		TokenOut: "0x020bfc650a365f8bb26819deaabf3e21291018b4",
+	})
+	require.ErrorIs(t, err, ErrPoolNotAvailable)
+}
+
+func TestCalcAmountOut_ZeroOutput(t *testing.T) {
+	// A tiny input that rounds down to zero tokens out must error, not return a
+	// zero-output "successful" swap (AGENTS.md: zero-output swaps must error). Probe
+	// rate here is 1000 quote wei per 1 token wei, so 1 quote wei in floors to 0 out.
+	staticExtra, err := json.Marshal(StaticExtra{
+		Market:     "0x8efb662f738d0f5d9f146803fd02a36c6b67e60d",
+		Pool:       "0x1c8fe931c9be6583d9a2e5c05712a0f6d1e4faed",
+		QuoteAsset: "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+	})
+	require.NoError(t, err)
+
+	extra, err := json.Marshal(Extra{
+		Available:      true,
+		ProbeAmount:    mustUint256(t, "1"),
+		ProbeQuoteCost: mustUint256(t, "1000"),
+		FillableAmount: mustUint256(t, "1000000000000000000"),
+		FeeBps:         100,
+	})
+	require.NoError(t, err)
+
+	sim, err := NewPoolSimulator(entity.Pool{
+		Address:  "0x1c8fe931c9be6583d9a2e5c05712a0f6d1e4faed-0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+		Exchange: "flowstate-c1",
+		Type:     DexType,
+		Reserves: []string{"0", "1000000000000000000"},
+		Tokens: []*entity.PoolToken{
+			{Address: "0x5fc5360d0400a0fd4f2af552add042d716f1d168", Swappable: true},
+			{Address: "0x020bfc650a365f8bb26819deaabf3e21291018b4", Swappable: true},
+		},
+		StaticExtra: string(staticExtra),
+		Extra:       string(extra),
+	})
+	require.NoError(t, err)
+
+	_, err = sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+			Amount: big.NewInt(1),
+		},
+		TokenOut: "0x020bfc650a365f8bb26819deaabf3e21291018b4",
+	})
+	require.ErrorIs(t, err, ErrZeroAmountOut)
+}

--- a/pkg/liquidity-source/flowstate-c1/pool_tracker.go
+++ b/pkg/liquidity-source/flowstate-c1/pool_tracker.go
@@ -1,0 +1,103 @@
+package flowstatec1
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	sourcePool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/abi"
+)
+
+type PoolTracker struct {
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryE(DexType, NewPoolTracker)
+
+func NewPoolTracker(ethrpcClient *ethrpc.Client) (*PoolTracker, error) {
+	return &PoolTracker{ethrpcClient: ethrpcClient}, nil
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ sourcePool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	l := logger.WithFields(logger.Fields{"poolAddress": p.Address})
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return p, err
+	}
+
+	var extra Extra
+	if err := json.Unmarshal([]byte(p.Extra), &extra); err != nil {
+		return p, err
+	}
+
+	inventoryToken := p.Tokens[1].Address
+
+	// quoteBuyFromPool's fillableAmount is min(requested amount, actual depth), so a
+	// probe below expected depth only yields the unit rate, not the real cap. Depth
+	// comes from the inventory token's balance of the pool instead (verified on-chain
+	// to equal quoteBuyFromPool's fillableAmount when probing at/above full depth).
+	var (
+		quoteOut  struct{ Quote Quote }
+		balanceOf *big.Int
+	)
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{
+		ABI:    marketABI,
+		Target: staticExtra.Market,
+		Method: "quoteBuyFromPool",
+		Params: []any{
+			common.HexToAddress(staticExtra.Pool),
+			common.HexToAddress(staticExtra.QuoteAsset),
+			extra.ProbeAmount.ToBig(),
+		},
+	}, []any{&quoteOut})
+	req.AddCall(&ethrpc.Call{
+		ABI:    abi.Erc20ABI,
+		Target: inventoryToken,
+		Method: "balanceOf",
+		Params: []any{common.HexToAddress(staticExtra.Pool)},
+	}, []any{&balanceOf})
+
+	res, err := req.TryBlockAndAggregate()
+	if err != nil {
+		l.WithFields(logger.Fields{"error": err}).Error("failed to track flowstate-c1 pool state")
+		return p, err
+	}
+
+	quote := quoteOut.Quote
+	extra.Available = quote.Available
+	extra.ProbeQuoteCost = uint256.MustFromBig(quote.QuoteAmount)
+	extra.FillableAmount = uint256.MustFromBig(balanceOf)
+	extra.FeeBps = quote.FeeBps
+
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return p, err
+	}
+
+	p.Extra = string(extraBytes)
+	p.Reserves = []string{"0", extra.FillableAmount.String()}
+	p.Timestamp = time.Now().Unix()
+
+	if res.BlockNumber != nil {
+		p.BlockNumber = res.BlockNumber.Uint64()
+	}
+
+	l.Info("successfully tracked flowstate-c1 pool state")
+
+	return p, nil
+}

--- a/pkg/liquidity-source/flowstate-c1/pools_list_updater.go
+++ b/pkg/liquidity-source/flowstate-c1/pools_list_updater.go
@@ -1,0 +1,144 @@
+package flowstatec1
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+	loaded       bool
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: cfg, ethrpcClient: ethrpcClient}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	if u.loaded || len(u.config.Pools) == 0 {
+		return nil, metadataBytes, nil
+	}
+
+	pools, err := u.buildPools(ctx)
+	if err != nil {
+		logger.WithFields(logger.Fields{"dex_id": u.config.DexID, "error": err}).
+			Error("failed to build flowstate-c1 pools")
+		return nil, metadataBytes, err
+	}
+
+	u.loaded = true
+
+	logger.WithFields(logger.Fields{"dex_id": u.config.DexID, "pools": len(pools)}).
+		Info("loaded flowstate-c1 static pools")
+
+	return pools, metadataBytes, nil
+}
+
+// buildPools resolves poolByToken for every configured inventory token, then fans out
+// one entity.Pool per (token, quoteAsset) pair, since one on-chain pool can be bought
+// with any of the market's approved quote assets. Symbol/decimals are left unset --
+// pool-service auto-populates token metadata from its own registry.
+func (u *PoolsListUpdater) buildPools(ctx context.Context) ([]entity.Pool, error) {
+	req := u.ethrpcClient.NewRequest().SetContext(ctx)
+
+	poolAddrs := make([]common.Address, len(u.config.Pools))
+
+	for i, p := range u.config.Pools {
+		req.AddCall(&ethrpc.Call{
+			ABI:    marketABI,
+			Target: u.config.Market,
+			Method: "poolByToken",
+			Params: []any{common.HexToAddress(p.Token)},
+		}, []any{&poolAddrs[i]})
+	}
+
+	if _, err := req.TryBlockAndAggregate(); err != nil {
+		return nil, err
+	}
+
+	pools := make([]entity.Pool, 0, len(u.config.Pools)*len(u.config.QuoteAssets))
+	for i, p := range u.config.Pools {
+		if poolAddrs[i] == (common.Address{}) {
+			logger.WithFields(logger.Fields{"token": p.Token}).
+				Warn("poolByToken returned zero address, skipping")
+			continue
+		}
+
+		probeAmount := p.ProbeAmount
+		if probeAmount == "" {
+			probeAmount = defaultProbeAmount
+		}
+
+		for _, quoteAsset := range u.config.QuoteAssets {
+			pools = append(pools, u.newPool(poolAddrs[i], p.Token, quoteAsset, probeAmount))
+		}
+	}
+
+	return pools, nil
+}
+
+func (u *PoolsListUpdater) newPool(poolAddr common.Address, token, quoteAsset, probeAmount string) entity.Pool {
+	poolAddrLower := strings.ToLower(hexutil.Encode(poolAddr[:]))
+	quoteAssetLower := strings.ToLower(quoteAsset)
+	tokenLower := strings.ToLower(token)
+
+	staticExtra, _ := json.Marshal(StaticExtra{
+		Market:     strings.ToLower(u.config.Market),
+		Pool:       poolAddrLower,
+		QuoteAsset: quoteAssetLower,
+	})
+
+	probe, err := uint256.FromDecimal(probeAmount)
+	if err != nil {
+		probe = new(uint256.Int)
+	}
+	extra, _ := json.Marshal(Extra{
+		Available:      false,
+		ProbeAmount:    probe,
+		ProbeQuoteCost: new(uint256.Int),
+		FillableAmount: new(uint256.Int),
+	})
+
+	return entity.Pool{
+		// Synthetic id: the same on-chain pool is priced against every approved quote
+		// asset, so the pool contract address alone is not a unique key.
+		Address:   pairPoolAddress(poolAddr, common.HexToAddress(quoteAsset)),
+		Exchange:  u.config.DexID,
+		Type:      DexType,
+		Timestamp: time.Now().Unix(),
+		Reserves:  []string{"0", "0"},
+		Tokens: []*entity.PoolToken{
+			{Address: quoteAssetLower, Swappable: true},
+			{Address: tokenLower, Swappable: true},
+		},
+		StaticExtra: string(staticExtra),
+		Extra:       string(extra),
+	}
+}
+
+// pairPoolAddress derives a deterministic, address-shaped id from the real pool and
+// the quote asset it's priced against, since one on-chain pool prices against every
+// approved quote asset and needs a distinct entity.Pool per pair. XOR rather than a
+// hash: collision-free for this scale (one pool times a handful of quote assets),
+// no crypto dependency needed.
+func pairPoolAddress(pool, quoteAsset common.Address) string {
+	var xored common.Address
+	for i := range xored {
+		xored[i] = pool[i] ^ quoteAsset[i]
+	}
+	return strings.ToLower(hexutil.Encode(xored[:]))
+}

--- a/pkg/liquidity-source/flowstate-c1/type.go
+++ b/pkg/liquidity-source/flowstate-c1/type.go
@@ -1,0 +1,47 @@
+package flowstatec1
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// StaticExtra is set once at pool creation. Market and Pool are the real on-chain
+// addresses; Pool is shared across every quote asset a token can be bought with, so
+// each (Pool, QuoteAsset) pair gets its own synthetic entity.Pool keyed off both.
+type StaticExtra struct {
+	Market     string `json:"m"`
+	Pool       string `json:"p"`
+	QuoteAsset string `json:"q"`
+}
+
+// Extra is refreshed by the tracker from quoteBuyFromPool(Pool, QuoteAsset, ProbeAmount).
+// Pricing has no curve impact up to FillableAmount (vendor spec 3.1), so ProbeQuoteCost /
+// ProbeAmount is the flat unit rate for any amount up to that cap.
+type Extra struct {
+	Available      bool         `json:"a"`
+	ProbeAmount    *uint256.Int `json:"pa"`
+	ProbeQuoteCost *uint256.Int `json:"pq"`
+	FillableAmount *uint256.Int `json:"f"`
+	FeeBps         uint16       `json:"fb"`
+}
+
+// Quote mirrors the Market's on-chain Quote struct exactly, so its fields stay
+// *big.Int -- that's the type go-ethereum's ABI decoder unpacks a uint256 into at
+// the RPC boundary. Convert to uint256.Int only once decoded, in the tracker.
+type Quote struct {
+	Available      bool
+	FillableAmount *big.Int
+	QuoteAmount    *big.Int
+	FeeAmount      *big.Int
+	FeeBps         uint16
+	QuoteAsset     common.Address
+}
+
+type MetaInfo struct {
+	Market      string `json:"market"`
+	Pool        string `json:"pool"`
+	QuoteAsset  string `json:"quoteAsset"`
+	BlockNumber uint64 `json:"blockNumber"`
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -74,6 +74,7 @@ import (
 	pkg_liquiditysource_eulerswap_v2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/v2"
 	pkg_liquiditysource_feltir "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/feltir"
 	pkg_liquiditysource_flap "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/flap"
+	pkg_liquiditysource_flowstatec1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/flowstate-c1"
 	pkg_liquiditysource_fluid_atokenswap "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/fluid/atoken-swap"
 	pkg_liquiditysource_fluid_dexlite "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/fluid/dex-lite"
 	pkg_liquiditysource_fluid_dext1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/fluid/dex-t1"
@@ -324,6 +325,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_eulerswap_v2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_feltir.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_flap.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_flowstatec1.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_fluid_atokenswap.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_fluid_dexlite.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_fluid_dext1.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -80,6 +80,7 @@ import (
 	eulerswapv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/euler-swap/v2"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/feltir"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/flap"
+	flowstatec1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/flowstate-c1"
 	fluidDexLite "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/fluid/dex-lite"
 	fluidDexT1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/fluid/dex-t1"
 	_ "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/fluid/dex-t1/lazy"
@@ -368,6 +369,7 @@ type Types struct {
 	StaderETHx                 string
 	Feltir                     string
 	Flap                       string
+	FlowstateC1                string
 	FluidVaultT1               string
 	FluidDexT1                 string
 	FluidDexLite               string
@@ -607,6 +609,7 @@ var (
 		StaderETHx:                 staderethx.DexType,
 		Feltir:                     feltir.DexType,
 		Flap:                       flap.DexType,
+		FlowstateC1:                flowstatec1.DexType,
 		FluidVaultT1:               fluidVaultT1.DexType,
 		FluidDexT1:                 fluidDexT1.DexType,
 		FluidDexLite:               fluidDexLite.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -117,6 +117,7 @@ const (
 	ExchangeFermi                       = "fermi"
 	ExchangeFermiProp                   = "fermi-prop"
 	ExchangeFlap                        = "flap"
+	ExchangeFlowstateC1                 = "flowstate-c1"
 	ExchangeFluidDexLite                = "fluid-dex-lite"
 	ExchangeFluidDexT1                  = "fluid-dex-t1"
 	ExchangeFluidDexV2                  = "fluid-dex-v2"


### PR DESCRIPTION
New oracle-priced, single-sided liquidity venue on Robinhood Chain (4663).
Direct Market integration (poolByToken discovery, quoteBuyFromPool for
pricing, buyFromPoolExactQuote for execution) rather than the permissionless
Uniswap V4 hook route -- matches how euler-swap-v2 handles a protocol that's
also deployed as a V4 hook: own package, own math, dedicated executor call,
not routed through generic V4 infra.

Pricing has no curve impact up to available depth (flat rate sampled via a
probe quoteBuyFromPool call), so the tracker caches a unit rate + the
inventory token's balanceOf(pool) as the depth cap, rather than replicating
the on-chain anchor-band/staleness-surcharge mechanism off-chain. One
on-chain pool prices against every market-approved quote asset, so pool
discovery fans out one entity.Pool per (token, quoteAsset) pair, keyed by an
XOR-derived address-shaped id (see 1010-prop's pairPoolAddress for the
hash-based precedent this deviates from -- XOR is sufficient collision-wise
at this pool count and needs no crypto import).

Verified against the live staging deployment via cast: Market
0x8eFb662F738D0f5d9f146803FD02A36c6B67e60d, poolByToken/quoteBuyFromPool
results match the vendor's technical overview (v1.5, 2026-08-21) exactly.
