### PR TITLE
feat: integrate StonkBrokers Smart Launch V2 launchpad (stonkbrokers-fun-v2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,22 @@ pkg/liquidity-source/<dex>/
 - Check native token support.
 - Decide whether to reuse an existing integration or create a new one.
 
+### Naming Convention
+
+Name a new source `<protocol>-<family>`. Use that same string for the directory under
+`pkg/liquidity-source/`, for `DexType`, and for the `pkg/valueobject` exchange constant.
+
+- For protocols with multiple generations, prefer nested packages (brownfi/v2, brownfi/v3).
+- Sources outside these families keep a plain name: `carbon`, `pendle`. Existing names stay.
+
+Suffixes:
+- -v2: Uniswap V2 / Solidly / Velodrome forks — e.g. aeon-v2, velodrome-v2
+- -v3: Uniswap V3 forks — e.g. katana-v3
+- -v4: Uniswap V4 / Algebra Integral / hooks — e.g. uniswap-v4-b20
+- -lb: Liquidity Book
+- -prop: Proprietary AMM — e.g. 1010-prop, wasabi-prop
+- -fun: Launchpad bonding curve — e.g. alt-fun, virtual-fun
+
 ### Pool Discovery - IPoolsListUpdater
 
 - Prefer discovering pools on-chain over off-chain indexes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,23 @@ pkg/liquidity-source/<dex>/
 - Check native token support.
 - Decide whether to reuse an existing integration or create a new one.
 
+### Naming Convention
+
+Name a new source `<protocol>-<family>`. Use that same string for the directory under
+`pkg/liquidity-source/`, for `DexType`, and for the `pkg/valueobject` exchange constant.
+
+- For protocols with multiple generations, prefer nested packages (brownfi/v2, brownfi/v3).
+- Sources outside these families keep a plain name: `carbon`, `pendle`. Existing names stay.
+
+
+Suffixes:
+- -v2: Uniswap V2 / Solidly / Velodrome forks — e.g. aeon-v2, velodrome-v2
+- -v3: Uniswap V3 forks — e.g. katana-v3
+- -v4: Uniswap V4 / Algebra Integral / hooks — e.g. uniswap-v4-b20
+- -lb: Liquidity Book
+- -prop: Proprietary AMM — e.g. 1010-prop, wasabi-prop
+- -fun: Launchpad bonding curve — e.g. alt-fun, virtual-fun
+
 ### Pool Discovery - IPoolsListUpdater
 
 - Prefer discovering pools on-chain over off-chain indexes.

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi.go
@@ -9,9 +9,9 @@ import (
 // PadABI / lensABI are parsed directly from Blockscout's verified-source ABI
 // for the reference pad (0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f) and the
 // shared lens (0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3) -- ground truth
-// pulled during dex-explorer, not the PDF's advertised
+// pulled from the explorer, not the PDF's advertised
 // stonkbrokers.io/integration/ download. All 8 V2 pads share this ABI (same
-// verified contract name + compiler settings; see output/explorer.md).
+// verified contract name + compiler settings).
 //
 // aggregatorV3ABI / twapPoolABI back the buy-side oracle reads (see
 // embed.go).

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi.go
@@ -1,43 +1,12 @@
 package stonkbrokersfunv2
 
 import (
-	"bytes"
-
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	abiutil "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/abi"
 )
 
-// PadABI / lensABI are parsed directly from Blockscout's verified-source ABI
-// for the reference pad (0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f) and the
-// shared lens (0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3) -- ground truth
-// pulled from the explorer, not the PDF's advertised
-// stonkbrokers.io/integration/ download. All 8 V2 pads share this ABI (same
-// verified contract name + compiler settings).
-//
-// aggregatorV3ABI / twapPoolABI back the buy-side oracle reads (see
-// embed.go).
 var (
-	PadABI          abi.ABI
-	lensABI         abi.ABI
-	aggregatorV3ABI abi.ABI
-	twapPoolABI     abi.ABI
+	PadABI          = abiutil.MustParseABI(padBytes)
+	lensABI         = abiutil.MustParseABI(lensBytes)
+	aggregatorV3ABI = abiutil.MustParseABI(aggregatorV3Bytes)
+	twapPoolABI     = abiutil.MustParseABI(twapPoolBytes)
 )
-
-func init() {
-	builder := []struct {
-		ABI  *abi.ABI
-		data []byte
-	}{
-		{&PadABI, padBytes},
-		{&lensABI, lensBytes},
-		{&aggregatorV3ABI, aggregatorV3Bytes},
-		{&twapPoolABI, twapPoolBytes},
-	}
-
-	for _, b := range builder {
-		var err error
-		*b.ABI, err = abi.JSON(bytes.NewReader(b.data))
-		if err != nil {
-			panic(err)
-		}
-	}
-}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi.go
@@ -1,0 +1,43 @@
+package stonkbrokersfunv2
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// PadABI / lensABI are parsed directly from Blockscout's verified-source ABI
+// for the reference pad (0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f) and the
+// shared lens (0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3) -- ground truth
+// pulled during dex-explorer, not the PDF's advertised
+// stonkbrokers.io/integration/ download. All 8 V2 pads share this ABI (same
+// verified contract name + compiler settings; see output/explorer.md).
+//
+// aggregatorV3ABI / twapPoolABI back the buy-side oracle reads (see
+// embed.go).
+var (
+	PadABI          abi.ABI
+	lensABI         abi.ABI
+	aggregatorV3ABI abi.ABI
+	twapPoolABI     abi.ABI
+)
+
+func init() {
+	builder := []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{&PadABI, padBytes},
+		{&lensABI, lensBytes},
+		{&aggregatorV3ABI, aggregatorV3Bytes},
+		{&twapPoolABI, twapPoolBytes},
+	}
+
+	for _, b := range builder {
+		var err error
+		*b.ABI, err = abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi/AggregatorV3.json
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi/AggregatorV3.json
@@ -1,0 +1,22 @@
+[
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestRoundData",
+    "outputs": [
+      {"internalType": "uint80", "name": "roundId", "type": "uint80"},
+      {"internalType": "int256", "name": "answer", "type": "int256"},
+      {"internalType": "uint256", "name": "startedAt", "type": "uint256"},
+      {"internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+      {"internalType": "uint80", "name": "answeredInRound", "type": "uint80"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi/Lens.json
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi/Lens.json
@@ -1,0 +1,628 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      }
+    ],
+    "name": "ethUsdView",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "usd8",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "fresh",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "priceWei",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quoteIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "quoteBuy",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokensOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "taxBps",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokensIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "quoteSell",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "quoteOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "taxBps",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      }
+    ],
+    "name": "quoteUsdView",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "usd8",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "fresh",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "viewLaunch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "creator",
+                "type": "address"
+              },
+              {
+                "internalType": "uint64",
+                "name": "startMcapUsd8",
+                "type": "uint64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "gradMcapUsd8",
+                "type": "uint64"
+              },
+              {
+                "internalType": "uint16",
+                "name": "startTaxBps",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint16",
+                "name": "decayPerMinuteBps",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint16",
+                "name": "creatorFeeBpsSnap",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint16",
+                "name": "protocolFeeBpsSnap",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint32",
+                "name": "windowSecs",
+                "type": "uint32"
+              },
+              {
+                "internalType": "uint64",
+                "name": "startTime",
+                "type": "uint64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "deadline",
+                "type": "uint64"
+              },
+              {
+                "internalType": "bool",
+                "name": "externalToken",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "sellsEnabled",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "armed",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "graduated",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "bonded",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "aborted",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "loadedSupply",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "vQuote",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "vToken",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "realQuote",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "buyCount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct StonkSafeLaunchpadV2.Launch",
+            "name": "core",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "taxBps",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "mcapUsd8Now",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensSold",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "oracleFresh",
+            "type": "bool"
+          },
+          {
+            "internalType": "address[]",
+            "name": "legs",
+            "type": "address[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "pools",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lockIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpQuote",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint16",
+            "name": "lpFeeBpsSnap",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint64",
+            "name": "closedAtTs",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint32",
+            "name": "bufferSecs",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint8",
+            "name": "unsoldMode",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "eoaOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "openEnded",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint16",
+            "name": "postTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint8",
+            "name": "bondVenue",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxBuyPpm",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "icoBoost",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct SafeLaunchLensV2.LaunchView",
+        "name": "v",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract StonkSafeLaunchpadV2",
+        "name": "pad",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "count",
+        "type": "uint256"
+      }
+    ],
+    "name": "viewLaunches",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "creator",
+                "type": "address"
+              },
+              {
+                "internalType": "uint64",
+                "name": "startMcapUsd8",
+                "type": "uint64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "gradMcapUsd8",
+                "type": "uint64"
+              },
+              {
+                "internalType": "uint16",
+                "name": "startTaxBps",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint16",
+                "name": "decayPerMinuteBps",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint16",
+                "name": "creatorFeeBpsSnap",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint16",
+                "name": "protocolFeeBpsSnap",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint32",
+                "name": "windowSecs",
+                "type": "uint32"
+              },
+              {
+                "internalType": "uint64",
+                "name": "startTime",
+                "type": "uint64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "deadline",
+                "type": "uint64"
+              },
+              {
+                "internalType": "bool",
+                "name": "externalToken",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "sellsEnabled",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "armed",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "graduated",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "bonded",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "aborted",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "loadedSupply",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "vQuote",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "vToken",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "realQuote",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "buyCount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct StonkSafeLaunchpadV2.Launch",
+            "name": "core",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "taxBps",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "mcapUsd8Now",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensSold",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "oracleFresh",
+            "type": "bool"
+          },
+          {
+            "internalType": "address[]",
+            "name": "legs",
+            "type": "address[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "pools",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lockIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lpQuote",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint16",
+            "name": "lpFeeBpsSnap",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint64",
+            "name": "closedAtTs",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint32",
+            "name": "bufferSecs",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint8",
+            "name": "unsoldMode",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "eoaOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "openEnded",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint16",
+            "name": "postTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint8",
+            "name": "bondVenue",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxBuyPpm",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "icoBoost",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct SafeLaunchLensV2.LaunchView[]",
+        "name": "out",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi/Pad.json
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi/Pad.json
@@ -1,0 +1,2413 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "stockBooster_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "treasury_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ethUsdFeed_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "nfpm_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "boxLocker_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "quote_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "twapPool_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "quoteUsdFeed_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "weth_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "launchFeeWei_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "v3Nfpm_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "boxLockerV3_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AbortedLaunch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyArmed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyBonded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyGraduated",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BadEconomics",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BadParam",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BuyCapExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BuysPresent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeeOnTransferToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeePushFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientLaunchFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotArmed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotClosed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotCreator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEoa",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotGraduatable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotOperator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotWethLane",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NothingOwed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SaltNotYours",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SellExceedsCurve",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SellsDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SlippageExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokenInUse",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokenIsQuoteAsset",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnknownLaunch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VanitySuffix",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WindowClosed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroTrade",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "minStartMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "maxStartMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "minGradMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "maxGradMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "maxStartTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minWindowSecs",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxWindowSecs",
+            "type": "uint32"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct StonkSafeLaunchpadV2.Bounds",
+        "name": "bounds",
+        "type": "tuple"
+      }
+    ],
+    "name": "BoundsSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "card",
+        "type": "address"
+      }
+    ],
+    "name": "ClockInCardSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "CreatorQuoteAccrued",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "CreatorQuoteFlushed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "raisedQuote",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "finalPriceQuoteWei",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mcapUsd8",
+        "type": "uint256"
+      }
+    ],
+    "name": "CurveClosed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "creatorBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "protocolBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "lpBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "FeeSplitSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "kick",
+        "type": "address"
+      }
+    ],
+    "name": "IcoKickstarterSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensSwept",
+        "type": "uint256"
+      }
+    ],
+    "name": "LaunchAborted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "supply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "vQuote0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "quoteUsd8",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "deadline",
+        "type": "uint64"
+      }
+    ],
+    "name": "LaunchArmed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "raisedQuote",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnedTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "LaunchBonded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "externalToken",
+        "type": "bool"
+      }
+    ],
+    "name": "LaunchCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeWei",
+        "type": "uint256"
+      }
+    ],
+    "name": "LaunchFeeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lockTokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "legQuote",
+        "type": "uint256"
+      }
+    ],
+    "name": "LegBonded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "bondedQuoteWei",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "excessQuoteWei",
+        "type": "uint256"
+      }
+    ],
+    "name": "LpFeeBonded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "launchId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "OperatorSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "buyer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "quoteIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "taxPaid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "taxBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mcapUsd8",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeBuy",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "taxPaid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "taxBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "quoteOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mcapUsd8",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeSell",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "spacing",
+        "type": "int24"
+      }
+    ],
+    "name": "TickSpacingSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "secs",
+        "type": "uint32"
+      }
+    ],
+    "name": "TwapWindowSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lockTokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensPlaced",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnsoldLpBonded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint160",
+        "name": "mask",
+        "type": "uint160"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint160",
+        "name": "value",
+        "type": "uint160"
+      }
+    ],
+    "name": "VanitySuffixSet",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BUFFER_TAX_BPS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_BUFFER_SECS",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_BUY_CAP_PPM",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_POST_TAX_BPS",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_POST_TAX_BPS",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "V3_FEE",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "abort",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "supplyWei",
+        "type": "uint256"
+      }
+    ],
+    "name": "arm",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "bond",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "boughtOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bounds",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "minStartMcapUsd8",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxStartMcapUsd8",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minGradMcapUsd8",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxGradMcapUsd8",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint16",
+        "name": "maxStartTaxBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint32",
+        "name": "minWindowSecs",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "maxWindowSecs",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "boxLocker",
+    "outputs": [
+      {
+        "internalType": "contract ISafeLaunchClLocker",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "boxLockerV3",
+    "outputs": [
+      {
+        "internalType": "contract ISafeLaunchClLocker",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "bufferSecsOf",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quoteIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minTokensOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "ref",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "buy",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokensOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minTokensOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "ref",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "buyEth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokensOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clFactory",
+    "outputs": [
+      {
+        "internalType": "contract IUpClFactoryMinimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clTickSpacing",
+    "outputs": [
+      {
+        "internalType": "int24",
+        "name": "",
+        "type": "int24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clockInCard",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "closedAt",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supply",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "vanitySalt",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "startMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "gradMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "startTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "taxDecayPerMinuteBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "bool",
+            "name": "sellsEnabled",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32",
+            "name": "bufferSecs",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint8",
+            "name": "unsoldMode",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "eoaOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "openEnded",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint16",
+            "name": "postTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint8",
+            "name": "bondVenue",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxBuyPpm",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct StonkSafeLaunchpadV2.CreateParams",
+        "name": "p",
+        "type": "tuple"
+      }
+    ],
+    "name": "createLaunch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "creatorFeeBps",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "creatorQuoteOwed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "currentTaxBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ethUsdFeed",
+    "outputs": [
+      {
+        "internalType": "contract IAggregatorV3",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "flushCreatorQuote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLaunch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "creator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "startMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "gradMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "startTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "decayPerMinuteBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "creatorFeeBpsSnap",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "protocolFeeBpsSnap",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint32",
+            "name": "windowSecs",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "startTime",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "deadline",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "externalToken",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "sellsEnabled",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "armed",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "graduated",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "bonded",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "aborted",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "loadedSupply",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "vQuote",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "vToken",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "realQuote",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "buyCount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct StonkSafeLaunchpadV2.Launch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "graduate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "icoKickstarter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isWethLane",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "launchCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "launchFeeWei",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "launchIdOfToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "legsOf",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "legs",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lpFeeBps",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "lpFeeBpsSnapOf",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "lpQuoteOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "mcapUsd8",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "modesOf",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "unsoldMode",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "eoaOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "openEnded",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint16",
+            "name": "postTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint8",
+            "name": "bondVenue",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxBuyPpm",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "icoBoost",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct StonkSafeLaunchpadV2.LaunchModes",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nfpm",
+    "outputs": [
+      {
+        "internalType": "contract IUpNfpmMinimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nfpmV3",
+    "outputs": [
+      {
+        "internalType": "contract IUniV3NfpmMinimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "operatorOf",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolsOf",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "pools",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "lockIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFeeBps",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "quote",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "quoteDecimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "quoteIsToken0",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "quoteUsdFeed",
+    "outputs": [
+      {
+        "internalType": "contract IAggregatorV3",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rescueEth",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rescueExcessQuote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      }
+    ],
+    "name": "rescueToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokensIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minQuoteOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "ref",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "ethOut",
+        "type": "bool"
+      }
+    ],
+    "name": "sell",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "quoteOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "minStartMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "maxStartMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "minGradMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "maxGradMcapUsd8",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "maxStartTaxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minWindowSecs",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxWindowSecs",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct StonkSafeLaunchpadV2.Bounds",
+        "name": "b",
+        "type": "tuple"
+      }
+    ],
+    "name": "setBounds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "card",
+        "type": "address"
+      }
+    ],
+    "name": "setClockInCard",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "creatorBps_",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "protocolBps_",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "lpBps_",
+        "type": "uint16"
+      }
+    ],
+    "name": "setFeeSplit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "kick",
+        "type": "address"
+      }
+    ],
+    "name": "setIcoKickstarter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "feeWei",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLaunchFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int24",
+        "name": "spacing",
+        "type": "int24"
+      }
+    ],
+    "name": "setTickSpacing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "secs",
+        "type": "uint32"
+      }
+    ],
+    "name": "setTwapWindow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint160",
+        "name": "mask",
+        "type": "uint160"
+      },
+      {
+        "internalType": "uint160",
+        "name": "value",
+        "type": "uint160"
+      }
+    ],
+    "name": "setVanitySuffix",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stockBooster",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "strictQuoteUsd8",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol_",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "supply_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "tokenInitCodeHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalEscrowed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalOwed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasury",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "twapPool",
+    "outputs": [
+      {
+        "internalType": "contract ITwapPoolMinimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "twapWindowSecs",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "v3Factory",
+    "outputs": [
+      {
+        "internalType": "contract IUniV3FactoryMinimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vanityMask",
+    "outputs": [
+      {
+        "internalType": "uint160",
+        "name": "",
+        "type": "uint160"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vanityValue",
+    "outputs": [
+      {
+        "internalType": "uint160",
+        "name": "",
+        "type": "uint160"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/abi/TwapPool.json
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/abi/TwapPool.json
@@ -1,0 +1,26 @@
+[
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint32[]", "name": "secondsAgos", "type": "uint32[]"}],
+    "name": "observe",
+    "outputs": [
+      {"internalType": "int56[]", "name": "tickCumulatives", "type": "int56[]"},
+      {"internalType": "uint160[]", "name": "secondsPerLiquidityCumulativeX128s", "type": "uint160[]"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/config.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/config.go
@@ -6,8 +6,7 @@ import (
 
 // Config lists the fixed Smart Launch V2 pads for this chain. Pads are
 // statically deployed per quote lane -- there is no factory to discover them
-// from (see output/explorer.md's `findings.explorer.pool_discovery:
-// view_enum`). dex-implement-tracker's pool list updater enumerates
+// from and no creation event to follow, so the pool list updater enumerates
 // launchCount() and getLaunch(id) directly on each configured pad.
 type Config struct {
 	DexID   string              `json:"dexID"`
@@ -15,7 +14,7 @@ type Config struct {
 
 	// Pads is the fixed set of StonkSafeLaunchpadV2 addresses to scan, one
 	// per quote lane (WETH/STONK/USDG/GME/NVDA/AAPL/SPCX/USO on Robinhood
-	// Chain -- see output/explorer.md's findings.contracts.other).
+	// Chain).
 	Pads []string `json:"pads"`
 
 	// Lens is the shared SafeLaunchLensV2 address used for quoting.

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/config.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/config.go
@@ -1,0 +1,23 @@
+package stonkbrokersfunv2
+
+import (
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+// Config lists the fixed Smart Launch V2 pads for this chain. Pads are
+// statically deployed per quote lane -- there is no factory to discover them
+// from (see output/explorer.md's `findings.explorer.pool_discovery:
+// view_enum`). dex-implement-tracker's pool list updater enumerates
+// launchCount() and getLaunch(id) directly on each configured pad.
+type Config struct {
+	DexID   string              `json:"dexID"`
+	ChainID valueobject.ChainID `json:"chainId"`
+
+	// Pads is the fixed set of StonkSafeLaunchpadV2 addresses to scan, one
+	// per quote lane (WETH/STONK/USDG/GME/NVDA/AAPL/SPCX/USO on Robinhood
+	// Chain -- see output/explorer.md's findings.contracts.other).
+	Pads []string `json:"pads"`
+
+	// Lens is the shared SafeLaunchLensV2 address used for quoting.
+	Lens string `json:"lens"`
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
@@ -89,6 +89,7 @@ var (
 	ErrZeroTrade        = errors.New("zero trade amount")
 	ErrSlippageExceeded = errors.New("slippage exceeded")
 	ErrBuyCapExceeded   = errors.New("per-recipient buy cap exceeded (StonkSafeLaunchpadV2 BuyCapExceeded)")
+	ErrNoSnapshotBlock  = errors.New("multicall returned no block number to pin the refresh to")
 	ErrEoaOnly          = errors.New("launch is eoaOnly: buy() reverts NotEoa when msg.sender != tx.origin, so it is unreachable from an aggregator executor")
 
 	// ErrStalePrice mirrors the on-chain revert: buy() calls mcapUsd8(id)

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
@@ -55,8 +55,14 @@ const (
 	methodEthUsdFeed      = "ethUsdFeed"
 	methodBufferTaxBps    = "BUFFER_TAX_BPS"
 
-	methodBuy    = "buy"
-	methodBuyEth = "buyEth"
+	// MethodBuy is exported because the swap is BUILT elsewhere: this package
+	// only ever quotes, while the aggregator's encoder packs the calldata off
+	// PadABI. Sharing the name keeps the two in step.
+	//
+	// buyEth() (payable, WETH lane only) is deliberately not used: the executor
+	// already holds wrapped WETH by the time it reaches this pool, so buy()
+	// avoids an unwrap-then-rewrap round trip inside the pad.
+	MethodBuy = "buy"
 
 	methodViewLaunch   = "viewLaunch"
 	methodViewLaunches = "viewLaunches"

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
@@ -64,9 +64,9 @@ const (
 	// avoids an unwrap-then-rewrap round trip inside the pad.
 	MethodBuy = "buy"
 
-	methodViewLaunch   = "viewLaunch"
-	methodViewLaunches = "viewLaunches"
-	methodQuoteBuy     = "quoteBuy"
+	// The lens exposes viewLaunch/viewLaunches too; we read launch state off the
+	// pad directly and only use the lens as an independent quote oracle in tests.
+	methodQuoteBuy = "quoteBuy"
 
 	bps = 10_000
 

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
@@ -1,0 +1,106 @@
+package stonkbrokersfunv2
+
+import (
+	"errors"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+// DexType covers only the Smart Launch V2 pads (mint & standard launches) on
+// Robinhood Chain (chainId 4663) -- StonkSafeLaunchpadV2 + SafeLaunchLensV2.
+// Out of scope, deliberately: V3 pads (external-token/BYO launches), the
+// post-bond DEX leg, and the separate Stonk Launcher factory (unverified on
+// Blockscout, never called here). See context/stonkbrokers/output/explorer.md.
+const (
+	DexType = valueobject.ExchangeStonkbrokersFunV2
+
+	// Scope decision -- BUY ONLY (quote -> token). Investigated during
+	// dex-scaffold (see context/stonkbrokers/output/scaffold.md "Scope
+	// decision: buy-only" for full evidence):
+	//
+	//   sell(id, tokensIn, minQuoteOut, ref, account, ethOut) requires
+	//   EITHER account == msg.sender, OR operatorOf[account][id][msg.sender]
+	//   == true. operatorOf is set exclusively by
+	//   setOperator(id, operator, approved) which hardcodes
+	//   `operatorOf[msg.sender][id][operator] = approved` -- only the
+	//   position holder can grant it, for themselves, per launch, with no
+	//   permit/signature variant to bundle into a router's swap calldata.
+	//   A stateless aggregator route never becomes the position holder
+	//   (boughtOf[id][executor] is 0 unless the executor itself bought on
+	//   this exact launch earlier), so it can neither satisfy
+	//   account == msg.sender with real credit, nor obtain a same-tx
+	//   operator grant. Per the integration doc's own terminal note,
+	//   "Transferred bags cannot be sold through the pad" -- boughtOf
+	//   credit is non-transferable, so this holds even for tokens the
+	//   end user already holds from elsewhere. Sell is not implemented.
+	//
+	// buy(id, quoteIn, minTokensOut, ref, recipient) has none of this
+	// friction: quoteIn is pulled from msg.sender (the router), tokens and
+	// boughtOf credit land on `recipient` (the end user) -- exactly
+	// KyberSwap's standard executor shape.
+
+	methodLaunchCount     = "launchCount"
+	methodGetLaunch       = "getLaunch"
+	methodModesOf         = "modesOf"
+	methodBufferSecsOf    = "bufferSecsOf"
+	methodCurrentTaxBps   = "currentTaxBps"
+	methodLaunchIdOfToken = "launchIdOfToken"
+	methodQuote           = "quote"
+	methodQuoteDecimals   = "quoteDecimals"
+	methodIsWethLane      = "isWethLane"
+	methodQuoteIsToken0   = "quoteIsToken0"
+	methodQuoteUsdFeed    = "quoteUsdFeed"
+	methodTwapPool        = "twapPool"
+	methodTwapWindowSecs  = "twapWindowSecs"
+	methodEthUsdFeed      = "ethUsdFeed"
+	methodBufferTaxBps    = "BUFFER_TAX_BPS"
+
+	methodBuy    = "buy"
+	methodBuyEth = "buyEth"
+
+	methodViewLaunch   = "viewLaunch"
+	methodViewLaunches = "viewLaunches"
+	methodQuoteBuy     = "quoteBuy"
+
+	bps = 10_000
+
+	// defaultGas is the measured cost of a real buyEth() on the WETH pad: a
+	// Tenderly fork of Robinhood Chain at block 46382449 executed
+	// buyEth(176, 0, 0x0, recipient) with 0.01 ETH for 265,009 gas
+	// (docs/simulations/tenderly-buyeth-launch176.md). That trade took the
+	// ordinary path -- no graduation close, launch already had a prior buy --
+	// so a first buy into a launch, or one that trips the graduation branch,
+	// costs more than this.
+	defaultGas = 265_000
+)
+
+var (
+	ErrPoolNotArmed     = errors.New("launch not armed")
+	ErrPoolGraduated    = errors.New("launch graduated, trade on pad closed")
+	ErrPoolBonded       = errors.New("launch bonded, trade via the locked DEX pool instead")
+	ErrPoolAborted      = errors.New("launch aborted")
+	ErrWindowClosed     = errors.New("curve window closed")
+	ErrZeroTrade        = errors.New("zero trade amount")
+	ErrSlippageExceeded = errors.New("slippage exceeded")
+	ErrBuyCapExceeded   = errors.New("per-recipient buy cap exceeded (StonkSafeLaunchpadV2 BuyCapExceeded)")
+	ErrEoaOnly          = errors.New("launch is eoaOnly: buy() reverts NotEoa when msg.sender != tx.origin, so it is unreachable from an aggregator executor")
+
+	// ErrStalePrice mirrors the on-chain revert: buy() calls mcapUsd8(id)
+	// unconditionally (no try/catch) to check the graduation gate, and
+	// mcapUsd8 reverts if the pad's oracle (direct Chainlink feed or TWAP
+	// pool, per-pad -- see StaticExtra) is stale. Stock lanes
+	// (GME/NVDA/AAPL/SPCX/USO) go stale over weekends (documented worst
+	// case 79.7h gap). dex-implement-math MUST port SafeLaunchTwapLib's
+	// staleness window and return this error rather than a quote whenever
+	// the tracked oracle snapshot is stale -- ported from AGENTS.md's "track
+	// every flag/check on the swap path so the simulator can reject swaps
+	// that would revert on-chain."
+	ErrStalePrice        = errors.New("quote-asset oracle stale, buy blocked (graduation mcap unreadable on-chain)")
+	ErrBadOracleAnswer   = errors.New("oracle answer invalid (<= 0, unscalable, or overflow)")
+	ErrInvalidToken      = errors.New("invalid tokenIn/tokenOut for this pool")
+	ErrInvalidPoolTokens = errors.New("pool must have exactly 2 tokens")
+
+	// ErrSellNotSupported documents the buy-only scope decision above for
+	// any future caller that tries CalcAmountIn or a token->quote direction.
+	ErrSellNotSupported = errors.New("sell not supported by this integration: requires a caller-owned boughtOf credit or a pre-granted per-launch operator approval, unreachable from a generic aggregator swap")
+)

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
@@ -10,12 +10,12 @@ import (
 // Robinhood Chain (chainId 4663) -- StonkSafeLaunchpadV2 + SafeLaunchLensV2.
 // Out of scope, deliberately: V3 pads (external-token/BYO launches), the
 // post-bond DEX leg, and the separate Stonk Launcher factory (unverified on
-// Blockscout, never called here). See context/stonkbrokers/output/explorer.md.
+// Blockscout, never called here).
 const (
 	DexType = valueobject.ExchangeStonkbrokersFunV2
 
 	// Scope decision -- BUY ONLY (quote -> token). Investigated during
-	// dex-scaffold (see context/stonkbrokers/output/scaffold.md "Scope
+	// the scope decision recorded below ("Scope
 	// decision: buy-only" for full evidence):
 	//
 	//   sell(id, tokensIn, minQuoteOut, ref, account, ethOut) requires
@@ -67,7 +67,7 @@ const (
 	// defaultGas is the measured cost of a real buyEth() on the WETH pad: a
 	// Tenderly fork of Robinhood Chain at block 46382449 executed
 	// buyEth(176, 0, 0x0, recipient) with 0.01 ETH for 265,009 gas
-	// (docs/simulations/tenderly-buyeth-launch176.md). That trade took the
+	// That trade took the
 	// ordinary path -- no graduation close, launch already had a prior buy --
 	// so a first buy into a launch, or one that trips the graduation branch,
 	// costs more than this.
@@ -90,7 +90,7 @@ var (
 	// mcapUsd8 reverts if the pad's oracle (direct Chainlink feed or TWAP
 	// pool, per-pad -- see StaticExtra) is stale. Stock lanes
 	// (GME/NVDA/AAPL/SPCX/USO) go stale over weekends (documented worst
-	// case 79.7h gap). dex-implement-math MUST port SafeLaunchTwapLib's
+	// case 79.7h gap). The simulator ports SafeLaunchTwapLib's
 	// staleness window and return this error rather than a quote whenever
 	// the tracked oracle snapshot is stale -- ported from AGENTS.md's "track
 	// every flag/check on the swap path so the simulator can reject swaps

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/constant.go
@@ -92,16 +92,6 @@ var (
 	ErrNoSnapshotBlock  = errors.New("multicall returned no block number to pin the refresh to")
 	ErrEoaOnly          = errors.New("launch is eoaOnly: buy() reverts NotEoa when msg.sender != tx.origin, so it is unreachable from an aggregator executor")
 
-	// ErrStalePrice mirrors the on-chain revert: buy() calls mcapUsd8(id)
-	// unconditionally (no try/catch) to check the graduation gate, and
-	// mcapUsd8 reverts if the pad's oracle (direct Chainlink feed or TWAP
-	// pool, per-pad -- see StaticExtra) is stale. Stock lanes
-	// (GME/NVDA/AAPL/SPCX/USO) go stale over weekends (documented worst
-	// case 79.7h gap). The simulator ports SafeLaunchTwapLib's
-	// staleness window and return this error rather than a quote whenever
-	// the tracked oracle snapshot is stale -- ported from AGENTS.md's "track
-	// every flag/check on the swap path so the simulator can reject swaps
-	// that would revert on-chain."
 	ErrStalePrice        = errors.New("quote-asset oracle stale, buy blocked (graduation mcap unreadable on-chain)")
 	ErrBadOracleAnswer   = errors.New("oracle answer invalid (<= 0, unscalable, or overflow)")
 	ErrInvalidToken      = errors.New("invalid tokenIn/tokenOut for this pool")

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/embed.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/embed.go
@@ -13,7 +13,6 @@ var lensBytes []byte
 // Chainlink AggregatorV3Interface (decimals, latestRoundData) and a minimal
 // Uniswap-v3-style pool (token0, token1, observe). Selectors verified via
 // `cast sig` against the well-known canonical signatures -- see
-// context/stonkbrokers/output/math.md.
 //
 //go:embed abi/AggregatorV3.json
 var aggregatorV3Bytes []byte

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/embed.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/embed.go
@@ -8,12 +8,6 @@ var padBytes []byte
 //go:embed abi/Lens.json
 var lensBytes []byte
 
-// aggregatorV3Bytes / twapPoolBytes are minimal, hand-written ABIs for the
-// two third-party contracts read for the buy-side oracle gate: a standard
-// Chainlink AggregatorV3Interface (decimals, latestRoundData) and a minimal
-// Uniswap-v3-style pool (token0, token1, observe). Selectors verified via
-// `cast sig` against the well-known canonical signatures -- see
-//
 //go:embed abi/AggregatorV3.json
 var aggregatorV3Bytes []byte
 

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/embed.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/embed.go
@@ -1,0 +1,22 @@
+package stonkbrokersfunv2
+
+import _ "embed"
+
+//go:embed abi/Pad.json
+var padBytes []byte
+
+//go:embed abi/Lens.json
+var lensBytes []byte
+
+// aggregatorV3Bytes / twapPoolBytes are minimal, hand-written ABIs for the
+// two third-party contracts read for the buy-side oracle gate: a standard
+// Chainlink AggregatorV3Interface (decimals, latestRoundData) and a minimal
+// Uniswap-v3-style pool (token0, token1, observe). Selectors verified via
+// `cast sig` against the well-known canonical signatures -- see
+// context/stonkbrokers/output/math.md.
+//
+//go:embed abi/AggregatorV3.json
+var aggregatorV3Bytes []byte
+
+//go:embed abi/TwapPool.json
+var twapPoolBytes []byte

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/event_parser.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/event_parser.go
@@ -1,0 +1,67 @@
+package stonkbrokersfunv2
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/poolfactory"
+	abiutil "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/abi"
+)
+
+// A launch has no address of its own: it trades through its lane's pad, and the
+// pool key is "<pad>_<launchId>". Routing a pad log therefore means decoding
+// that id out of it.
+var padEventIDs = map[common.Hash]struct{}{
+	// Trades: move vQuote/vToken.
+	abiutil.MustABIEvent(PadABI, "SafeBuy").ID:     {},
+	abiutil.MustABIEvent(PadABI, "SafeSell").ID:    {},
+	abiutil.MustABIEvent(PadABI, "LaunchArmed").ID: {},
+	// The three terminal transitions isTerminal parks the pool on.
+	abiutil.MustABIEvent(PadABI, "CurveClosed").ID:   {},
+	abiutil.MustABIEvent(PadABI, "LaunchBonded").ID:  {},
+	abiutil.MustABIEvent(PadABI, "LaunchAborted").ID: {},
+}
+
+type EventParserConfig struct {
+	DexID string `json:"dexID,omitempty"`
+}
+
+type EventParser struct {
+	config *EventParserConfig
+}
+
+var _ = poolfactory.RegisterFactoryC(DexType, NewEventParser)
+
+func NewEventParser(config *EventParserConfig) *EventParser {
+	return &EventParser{config: config}
+}
+
+func (p *EventParser) DecodePoolAddressesFromFactoryLog(_ context.Context, log types.Log) ([]string, error) {
+	if len(log.Topics) < 2 {
+		return nil, nil
+	}
+	if _, ok := padEventIDs[log.Topics[0]]; !ok {
+		return nil, nil
+	}
+
+	// All six events index the launch id first.
+	launchID := new(big.Int).SetBytes(log.Topics[1][:])
+	if !launchID.IsUint64() {
+		return nil, nil
+	}
+
+	return []string{PoolAddress(hexutil.Encode(log.Address[:]), launchID.Uint64())}, nil
+}
+
+func (p *EventParser) DecodePoolCreated(_ types.Log) (*entity.Pool, error) {
+	return nil, nil
+}
+
+func (p *EventParser) IsEventSupported(_ common.Hash) bool {
+	return false
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/event_parser_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/event_parser_test.go
@@ -1,0 +1,102 @@
+package stonkbrokersfunv2
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	abiutil "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/abi"
+)
+
+// topic0 values pinned against the deployed StonkSafeLaunchpadV2 ABI. Hard-coded
+// rather than derived so a silent ABI swap under the package fails here instead
+// of quietly matching nothing on chain.
+func TestPadEventIDs_MatchDeployedSignatures(t *testing.T) {
+	t.Parallel()
+
+	for name, want := range map[string]string{
+		"SafeBuy":       "0xba22b06917da96d20a8f4f80d45cbdaaf3294856de78268558edcce22e4298df",
+		"SafeSell":      "0x2de6d6d1573ee69658d3daae2e752379e6eb0676622a5ade2812088d7cb56581",
+		"LaunchArmed":   "0x617dff9af409b81e92edd8d62fb192f25509657b96d203585e3e6b605d4dea26",
+		"CurveClosed":   "0x35438c0a652764ec4e53a7c6ea24f69d38de411205cb46565a621d1ecec1b4f0",
+		"LaunchBonded":  "0x93a0dc53b22eaff6d32706900ad4faf8945af529c8178e4556a9cba1b688cc87",
+		"LaunchAborted": "0x580dfdb1b506406bf92732277b3b526bdf395c999ba181ddd0c576be4b95dc8d",
+	} {
+		id := abiutil.MustABIEvent(PadABI, name).ID
+		require.Equal(t, want, id.Hex(), name)
+		require.Contains(t, padEventIDs, id, name)
+	}
+}
+
+func TestDecodePoolAddressesFromFactoryLog(t *testing.T) {
+	t.Parallel()
+
+	const padHex = "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f"
+	pad := common.HexToAddress(padHex)
+	parser := NewEventParser(&EventParserConfig{DexID: string(DexType)})
+
+	idTopic := func(n int64) common.Hash { return common.BigToHash(big.NewInt(n)) }
+	padLog := func(event string, rest ...common.Hash) types.Log {
+		return types.Log{
+			Address: pad,
+			Topics:  append([]common.Hash{abiutil.MustABIEvent(PadABI, event).ID}, rest...),
+		}
+	}
+
+	tests := []struct {
+		name string
+		log  types.Log
+		want []string
+	}{
+		{"buy", padLog("SafeBuy", idTopic(176), common.Hash{}), []string{padHex + "_176"}},
+		{"sell", padLog("SafeSell", idTopic(176), common.Hash{}), []string{padHex + "_176"}},
+		{"arm", padLog("LaunchArmed", idTopic(1)), []string{padHex + "_1"}},
+		{"close", padLog("CurveClosed", idTopic(291)), []string{padHex + "_291"}},
+		{"bond", padLog("LaunchBonded", idTopic(291)), []string{padHex + "_291"}},
+		{"abort", padLog("LaunchAborted", idTopic(42)), []string{padHex + "_42"}},
+
+		// Each log names exactly one launch, which is the whole point: routing a
+		// pad's trades by dependency instead would wake every launch on the lane.
+		{"a sibling's trade routes to the sibling only",
+			padLog("SafeBuy", idTopic(177), common.Hash{}), []string{padHex + "_177"}},
+
+		// OperatorSet indexes `account` first, so treating topics[1] as a launch
+		// id would point at a wholly unrelated pool.
+		{"operator grant", padLog("OperatorSet", idTopic(176), idTopic(176), common.Hash{}), nil},
+		{"launch creation", padLog("LaunchCreated", idTopic(176), common.Hash{}, common.Hash{}), nil},
+		{"unindexed pad event", padLog("LaunchFeeSet"), nil},
+		{"log with no topics", types.Log{Address: pad}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.DecodePoolAddressesFromFactoryLog(context.Background(), tt.log)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// The key has to match what discovery stored, byte for byte, or the decoded
+// address resolves to nothing.
+func TestDecodePoolAddressesFromFactoryLog_MatchesDiscoveryKey(t *testing.T) {
+	t.Parallel()
+
+	const padHex = "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f"
+	parser := NewEventParser(&EventParserConfig{})
+
+	got, err := parser.DecodePoolAddressesFromFactoryLog(context.Background(), types.Log{
+		// Checksummed on the wire; the key is lowercase.
+		Address: common.HexToAddress("0xFCD61B25BBF3ABD6CF0070D6328E351CC30EEC9F"),
+		Topics: []common.Hash{
+			abiutil.MustABIEvent(PadABI, "SafeBuy").ID,
+			common.BigToHash(big.NewInt(176)),
+			{},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{PoolAddress(padHex, 176)}, got)
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/math.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/math.go
@@ -1,0 +1,190 @@
+package stonkbrokersfunv2
+
+import (
+	"github.com/holiman/uint256"
+
+	uniswapv3 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v3"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
+)
+
+// maxPriceAgeSecs ports SafeLaunchTwapLib.MAX_PRICE_AGE (48 hours) -- the
+// fail-closed staleness window shared by every oracle read on the buy path
+// (direct feed AND the ETH/USD leg of TWAP mode).
+const maxPriceAgeSecs = 48 * 60 * 60
+
+var (
+	tenE8     = uint256.NewInt(1e8)
+	tenE18    = uint256.NewInt(1e18)
+	oneLsh128 = new(uint256.Int).Lsh(uint256.NewInt(1), 128)
+	// denomToken0Branch = (1 << 128) * 1e18, the fused denominator used by
+	// SafeLaunchTwapLib.quoteUsd8's quoteIsToken0==true branch.
+	denomToken0Branch = new(uint256.Int).Mul(new(uint256.Int).Lsh(uint256.NewInt(1), 128), tenE18)
+)
+
+// CurrentTaxBps ports StonkSafeLaunchpadV2.currentTaxBps exactly (see
+// docs/source/stonksafelaunchpadv2-.../StonkSafeLaunchpadV2.sol lines
+// ~1008-1021). Callers must already have gated on armed/!graduated (matches
+// on-chain's early return of 0 in that case -- CalcAmountOut never reaches
+// here for a non-tradeable pool since it returns a sentinel error first).
+func CurrentTaxBps(now uint64, se StaticExtra) uint16 {
+	if now <= se.StartTime {
+		return se.BufferTaxBps
+	}
+	elapsed := now - se.StartTime
+	if elapsed < uint64(se.BufferSecs) {
+		return se.BufferTaxBps
+	}
+	minutesElapsed := (elapsed - uint64(se.BufferSecs)) / 60
+	decayed := minutesElapsed * uint64(se.DecayPerMinuteBps)
+	if decayed >= uint64(se.StartTaxBps) {
+		if se.OpenEnded {
+			return se.PostTaxBps
+		}
+		return 0
+	}
+	return se.StartTaxBps - uint16(decayed)
+}
+
+// CalcBuyAmountOut ports StonkSafeLaunchpadV2._buy's core constant-product
+// math over virtual reserves (lines ~728-776): tax is taken on the input
+// (fee-on-input), then the AMM swap runs on the net amount.
+//
+//	tax   = quoteIn * taxBps / BPS
+//	net   = quoteIn - tax
+//	tokensOut = net * vToken / (vQuote + net)     // Math.mulDiv, floor
+//
+// Returns the post-trade virtual reserves too (newVQuote, newVToken) so the
+// caller can feed them into the graduation/mcap check without recomputing.
+func CalcBuyAmountOut(quoteIn, vQuote, vToken *uint256.Int, taxBps uint16) (
+	tokensOut, tax, newVQuote, newVToken *uint256.Int, err error,
+) {
+	if quoteIn == nil || quoteIn.IsZero() {
+		return nil, nil, nil, nil, ErrZeroTrade
+	}
+
+	tax = big256.MulDivDown(new(uint256.Int), quoteIn, uint256.NewInt(uint64(taxBps)), bpsU256)
+	net := new(uint256.Int).Sub(quoteIn, tax)
+	if net.IsZero() {
+		return nil, nil, nil, nil, ErrZeroTrade
+	}
+
+	denom := new(uint256.Int).Add(vQuote, net)
+	tokensOut = big256.MulDivDown(new(uint256.Int), net, vToken, denom)
+	if tokensOut.IsZero() {
+		return nil, nil, nil, nil, ErrZeroTrade
+	}
+	if tokensOut.Cmp(vToken) >= 0 {
+		// Unreachable for a well-formed constant-product curve (net/(vQuote+net) < 1
+		// strictly), guarded defensively against corrupt/stale tracker state.
+		return nil, nil, nil, nil, ErrSlippageExceeded
+	}
+
+	newVQuote = new(uint256.Int).Add(vQuote, net)
+	newVToken = new(uint256.Int).Sub(vToken, tokensOut)
+	return tokensOut, tax, newVQuote, newVToken, nil
+}
+
+var bpsU256 = uint256.NewInt(bps)
+
+// ppmU256 is the 1e6 denominator LaunchModes.maxBuyPpm is expressed against
+// (StonkSafeLaunchpadV2._buy divides loadedSupply*capPpm by 1_000_000).
+var ppmU256 = uint256.NewInt(1_000_000)
+
+// McapUsd8FromReserves ports StonkSafeLaunchpadV2.mcapUsd8 (lines
+// ~1023-1028), evaluated against the given (post-trade) virtual reserves.
+//
+//	mcapQuoteWei = vQuote * loadedSupply / vToken   // Math.mulDiv, floor
+//	usd8         = mcapQuoteWei * quoteUsd8 / 10**quoteDecimals
+func McapUsd8FromReserves(vQuote, vToken, loadedSupply *uint256.Int, quoteUsd8 uint64, quoteDecimals uint8) *uint256.Int {
+	if vToken == nil || vToken.IsZero() {
+		return uint256.NewInt(0)
+	}
+	mcapQuoteWei := big256.MulDivDown(new(uint256.Int), vQuote, loadedSupply, vToken)
+	return big256.MulDivDown(new(uint256.Int), mcapQuoteWei, uint256.NewInt(quoteUsd8), big256.TenPow(quoteDecimals))
+}
+
+// feedUsd8 ports SafeLaunchTwapLib._feedUsd8 exactly: fail-closed on a
+// non-positive answer, on staleness (> 48h old), and on unscalable/zero/
+// overflowing results after rescaling to 1e8.
+func feedUsd8(r OracleReading, now uint64) (uint64, error) {
+	if !r.Ok || r.Answer == nil || r.Answer.IsZero() {
+		return 0, ErrBadOracleAnswer
+	}
+	updatedAt := r.UpdatedAt
+	if now < updatedAt {
+		updatedAt = now // clock-skew guard; never treat a future timestamp as making the reading stale
+	}
+	if now-updatedAt > maxPriceAgeSecs {
+		return 0, ErrStalePrice
+	}
+
+	var usd8 *uint256.Int
+	if r.Decimals == 8 {
+		usd8 = r.Answer
+	} else {
+		usd8 = big256.MulDivDown(new(uint256.Int), r.Answer, tenE8, big256.TenPow(r.Decimals))
+	}
+	if usd8.IsZero() || !usd8.IsUint64() {
+		return 0, ErrBadOracleAnswer
+	}
+	return usd8.Uint64(), nil
+}
+
+// DirectFeedUsd8 ports SafeLaunchTwapLib.directFeedUsd8 -- the oracle path
+// used by feed-mode lanes (WETH and the tokenized-stock lanes GME/NVDA/
+// AAPL/SPCX/USO; StaticExtra.QuoteUsdFeed != "").
+func DirectFeedUsd8(r OracleReading, now uint64) (uint64, error) {
+	return feedUsd8(r, now)
+}
+
+// TwapQuoteUsd8 ports SafeLaunchTwapLib.quoteUsd8 -- the oracle path used by
+// TWAP-mode lanes (STONK, USDG; StaticExtra.TwapPool != ""). Live-verified
+// against the USDG pad (see output/math.md): reproduces the on-chain
+// mcapUsd8() USD mark bit-for-bit from a raw observe()+latestRoundData()
+// snapshot.
+func TwapQuoteUsd8(t TwapReading, window uint32, quoteIsToken0 bool, quoteDecimals uint8, now uint64) (uint64, error) {
+	if !t.Ok {
+		return 0, ErrBadOracleAnswer
+	}
+	eth8, err := feedUsd8(t.EthUsd, now)
+	if err != nil {
+		return 0, err
+	}
+
+	delta := t.TickCumulativeNow - t.TickCumulativeOld
+	w := int64(window)
+	if w == 0 {
+		return 0, ErrBadOracleAnswer
+	}
+	avgTick := delta / w // Go truncates toward zero, same as Solidity's int division
+	if delta < 0 && delta%w != 0 {
+		avgTick-- // floor correction, matching SafeLaunchTwapLib.quoteUsd8
+	}
+	if avgTick < -887272 || avgTick > 887272 {
+		return 0, ErrBadOracleAnswer
+	}
+
+	var sqrtP uint256.Int
+	if err := uniswapv3.GetSqrtRatioAtTick(int(avgTick), &sqrtP); err != nil {
+		return 0, ErrBadOracleAnswer
+	}
+
+	// token1-per-token0 raw price, X128 fixed point: mulDiv(sqrtP, sqrtP, 1<<64).
+	ratioX128 := big256.MulDivDown(new(uint256.Int), &sqrtP, &sqrtP, oneLsh64)
+
+	quoteScaled := new(uint256.Int).Mul(uint256.NewInt(eth8), big256.TenPow(quoteDecimals))
+
+	var usd8 *uint256.Int
+	if quoteIsToken0 {
+		usd8 = big256.MulDivDown(new(uint256.Int), ratioX128, quoteScaled, denomToken0Branch)
+	} else {
+		tmp := big256.MulDivDown(new(uint256.Int), quoteScaled, oneLsh128, ratioX128)
+		usd8 = new(uint256.Int).Div(tmp, tenE18)
+	}
+	if usd8.IsZero() || !usd8.IsUint64() {
+		return 0, ErrBadOracleAnswer
+	}
+	return usd8.Uint64(), nil
+}
+
+var oneLsh64 = new(uint256.Int).Lsh(uint256.NewInt(1), 64)

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/math.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/math.go
@@ -139,7 +139,7 @@ func DirectFeedUsd8(r OracleReading, now uint64) (uint64, error) {
 
 // TwapQuoteUsd8 ports SafeLaunchTwapLib.quoteUsd8 -- the oracle path used by
 // TWAP-mode lanes (STONK, USDG; StaticExtra.TwapPool != ""). Live-verified
-// against the USDG pad (see output/math.md): reproduces the on-chain
+// against the USDG pad: reproduces the on-chain
 // mcapUsd8() USD mark bit-for-bit from a raw observe()+latestRoundData()
 // snapshot.
 func TwapQuoteUsd8(t TwapReading, window uint32, quoteIsToken0 bool, quoteDecimals uint8, now uint64) (uint64, error) {

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/math_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/math_test.go
@@ -1,0 +1,184 @@
+package stonkbrokersfunv2
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func uDec(t *testing.T, s string) *uint256.Int {
+	t.Helper()
+	v, err := uint256.FromDecimal(s)
+	require.NoError(t, err)
+	return v
+}
+
+// TestCalcBuyAmountOut_LiveVerifiedWethLaunch176 ports the reference fixture
+// captured live in output/explorer.md: WETH V2 pad
+// (0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f), on-chain launch id 176,
+// buying 0.01 ETH at block 46325622. Both getLaunch(176) and
+// quoteBuy(pad,176,0.01 ETH) were called directly against the chain's
+// canonical RPC; this test asserts the ported formula reproduces the lens's
+// own quoteBuy output bit-for-bit.
+func TestCalcBuyAmountOut_LiveVerifiedWethLaunch176(t *testing.T) {
+	vQuote := uDec(t, "410349618506110198")
+	vToken := uDec(t, "999010726104174939447103989")
+	quoteIn := uDec(t, "10000000000000000") // 0.01 ETH
+	const taxBps = 100                      // openEnded, past window -> flat postTaxBps
+
+	tokensOut, tax, newVQuote, newVToken, err := CalcBuyAmountOut(quoteIn, vQuote, vToken, taxBps)
+	require.NoError(t, err)
+
+	require.Equal(t, "23534122942428164868379888", tokensOut.Dec())
+	require.Equal(t, "100000000000000", tax.Dec()) // 0.0001 ETH == 1% of 0.01 ETH
+
+	wantNewVQuote := uDec(t, "420249618506110198") // vQuote + (quoteIn - tax)
+	wantNewVToken := new(uint256.Int).Sub(vToken, tokensOut)
+	require.True(t, newVQuote.Eq(wantNewVQuote))
+	require.True(t, newVToken.Eq(wantNewVToken))
+}
+
+func TestCalcBuyAmountOut_ZeroTradeRejected(t *testing.T) {
+	vQuote := uDec(t, "1000000000000000000")
+	vToken := uDec(t, "1000000000000000000000")
+
+	_, _, _, _, err := CalcBuyAmountOut(uint256.NewInt(0), vQuote, vToken, 100)
+	require.ErrorIs(t, err, ErrZeroTrade)
+
+	// A quoteIn small enough that the tax rounds it to zero net is also a
+	// zero-trade, not a zero-output-but-otherwise-fine quote.
+	_, _, _, _, err = CalcBuyAmountOut(uint256.NewInt(1), vQuote, vToken, 10_000)
+	require.ErrorIs(t, err, ErrZeroTrade)
+}
+
+// TestCurrentTaxBps ports StonkSafeLaunchpadV2.currentTaxBps's four branches:
+// buffer (flat snipe-shield), linear decay, floor at 0, and the openEnded
+// flat post-tax floor. BufferTaxBps=9999 and MaxBuyPpm-adjacent constants
+// are the live values read from the WETH pad (BUFFER_TAX_BPS()).
+func TestCurrentTaxBps(t *testing.T) {
+	base := StaticExtra{
+		BufferTaxBps:      9999,
+		StartTaxBps:       5000,
+		DecayPerMinuteBps: 500,
+		BufferSecs:        600,
+		StartTime:         1_000_000,
+	}
+
+	tests := []struct {
+		name string
+		se   StaticExtra
+		now  uint64
+		want uint16
+	}{
+		{"inside buffer", base, 1_000_000 + 300, 9999},
+		{"exactly at buffer boundary", base, 1_000_000 + 600, 5000},
+		{"partway through decay", base, 1_000_000 + 600 + 3*60, 5000 - 3*500}, // 3500
+		{"decay reaches zero, not open-ended", base, 1_000_000 + 600 + 10*60, 0},
+		{
+			name: "decay reaches zero, open-ended falls to postTaxBps",
+			se: StaticExtra{
+				BufferTaxBps: 9999, StartTaxBps: 5000, DecayPerMinuteBps: 500,
+				BufferSecs: 600, StartTime: 1_000_000, OpenEnded: true, PostTaxBps: 100,
+			},
+			now:  1_000_000 + 600 + 10*60,
+			want: 100,
+		},
+		{
+			name: "zero window+buffer, openEnded -> immediately flat post-tax (matches live launch 176)",
+			se: StaticExtra{
+				BufferTaxBps: 9999, StartTaxBps: 0, DecayPerMinuteBps: 0,
+				BufferSecs: 0, StartTime: 1_787_691_927, OpenEnded: true, PostTaxBps: 100,
+			},
+			now:  1_787_691_927 + 28_572,
+			want: 100,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, CurrentTaxBps(tc.now, tc.se))
+		})
+	}
+}
+
+// TestMcapUsd8FromReserves_GraduationBoundary exercises the mcap comparison
+// that decides whether a buy closes the curve.
+func TestMcapUsd8FromReserves_GraduationBoundary(t *testing.T) {
+	loadedSupply := uDec(t, "1000000000000000000000000000") // 1e9 tokens, 18 decimals
+	vToken := uDec(t, "999010726104174939447103989")
+	vQuote := uDec(t, "420249618506110198")
+	const quoteDecimals = 18
+	const ethUsd8 = 245_794_157_469 // $2457.94157469, live ETH/USD feed value
+
+	mcap := McapUsd8FromReserves(vQuote, vToken, loadedSupply, ethUsd8, quoteDecimals)
+	require.False(t, mcap.IsZero())
+
+	zeroVToken := uint256.NewInt(0)
+	require.True(t, McapUsd8FromReserves(vQuote, zeroVToken, loadedSupply, ethUsd8, quoteDecimals).IsZero())
+}
+
+// TestDirectFeedUsd8_StalePriceRejected mirrors SafeLaunchTwapLib._feedUsd8's
+// fail-closed staleness gate (48h) -- this is the ErrStalePrice enforcement
+// path the coordinator asked to be made real, not just declared.
+func TestDirectFeedUsd8_StalePriceRejected(t *testing.T) {
+	fresh := OracleReading{Answer: uint256.NewInt(245_794_157_469), Decimals: 8, UpdatedAt: 1_787_719_697, Ok: true}
+
+	got, err := DirectFeedUsd8(fresh, 1_787_719_697+3600) // 1h later, fresh
+	require.NoError(t, err)
+	require.Equal(t, uint64(245_794_157_469), got)
+
+	_, err = DirectFeedUsd8(fresh, 1_787_719_697+48*3600+1) // 48h+1s later, stale
+	require.ErrorIs(t, err, ErrStalePrice)
+
+	notOk := OracleReading{Ok: false}
+	_, err = DirectFeedUsd8(notOk, 1_787_719_697)
+	require.ErrorIs(t, err, ErrBadOracleAnswer)
+
+	badAnswer := OracleReading{Answer: uint256.NewInt(0), Decimals: 8, UpdatedAt: 1_787_719_697, Ok: true}
+	_, err = DirectFeedUsd8(badAnswer, 1_787_719_697)
+	require.ErrorIs(t, err, ErrBadOracleAnswer)
+}
+
+// TestDirectFeedUsd8_RescalesNonE8Decimals exercises the decimals != 8
+// rescale branch (feed-mode lanes are not guaranteed to publish at 1e8).
+func TestDirectFeedUsd8_RescalesNonE8Decimals(t *testing.T) {
+	// A realistic 1e18-scaled feed answer worth $2457.94157469 (same mark as
+	// the live 1e8 ETH/USD feed used elsewhere in this file) must rescale to
+	// the identical 1e8 usd8 value: mulDiv(x, 1e8, 1e18) == x / 1e10.
+	r := OracleReading{Answer: uDec(t, "2457941574690000000000"), Decimals: 18, UpdatedAt: 1000, Ok: true}
+	got, err := DirectFeedUsd8(r, 1000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(245_794_157_469), got)
+}
+
+// TestTwapQuoteUsd8_LiveVerifiedUsdgLaunch8 ports the second reference
+// fixture captured live in output/math.md: USDG V2 pad
+// (0xd4F20033586977A2511f4A2DB4aF7C79a340D70a), TWAP pool
+// 0x52e65b17fb6e5ba00ed806f37afcd2daa50271ca (token0=WETH, token1=USDG,
+// so quoteIsToken0=false), observe([1800,0]) and the shared ETH/USD feed
+// were both called directly against the chain's canonical RPC. The result
+// is cross-checked against the pad's own mcapUsd8(8) getter in
+// output/math.md (implied quoteUsd8 ~= 99786960, matching this test's exact
+// integer result).
+func TestTwapQuoteUsd8_LiveVerifiedUsdgLaunch8(t *testing.T) {
+	reading := TwapReading{
+		TickCumulativeOld: -942871677686,
+		TickCumulativeNow: -943228487508,
+		EthUsd: OracleReading{
+			Answer:    uint256.NewInt(245_794_157_469),
+			Decimals:  8,
+			UpdatedAt: 1_787_719_697,
+			Ok:        true,
+		},
+		Ok: true,
+	}
+
+	got, err := TwapQuoteUsd8(reading, 1800, false, 6, 1_787_720_500)
+	require.NoError(t, err)
+	require.Equal(t, uint64(99_786_960), got)
+}
+
+func TestTwapQuoteUsd8_ObserveFailurePropagates(t *testing.T) {
+	_, err := TwapQuoteUsd8(TwapReading{Ok: false}, 1800, false, 6, 1000)
+	require.ErrorIs(t, err, ErrBadOracleAnswer)
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/math_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/math_test.go
@@ -15,7 +15,7 @@ func uDec(t *testing.T, s string) *uint256.Int {
 }
 
 // TestCalcBuyAmountOut_LiveVerifiedWethLaunch176 ports the reference fixture
-// captured live in output/explorer.md: WETH V2 pad
+// captured live: WETH V2 pad
 // (0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f), on-chain launch id 176,
 // buying 0.01 ETH at block 46325622. Both getLaunch(176) and
 // quoteBuy(pad,176,0.01 ETH) were called directly against the chain's
@@ -152,13 +152,13 @@ func TestDirectFeedUsd8_RescalesNonE8Decimals(t *testing.T) {
 }
 
 // TestTwapQuoteUsd8_LiveVerifiedUsdgLaunch8 ports the second reference
-// fixture captured live in output/math.md: USDG V2 pad
+// fixture captured live: USDG V2 pad
 // (0xd4F20033586977A2511f4A2DB4aF7C79a340D70a), TWAP pool
 // 0x52e65b17fb6e5ba00ed806f37afcd2daa50271ca (token0=WETH, token1=USDG,
 // so quoteIsToken0=false), observe([1800,0]) and the shared ETH/USD feed
 // were both called directly against the chain's canonical RPC. The result
 // is cross-checked against the pad's own mcapUsd8(8) getter in
-// output/math.md (implied quoteUsd8 ~= 99786960, matching this test's exact
+// the live reading (implied quoteUsd8 ~= 99786960, matching this test's exact
 // integer result).
 func TestTwapQuoteUsd8_LiveVerifiedUsdgLaunch8(t *testing.T) {
 	reading := TwapReading{

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
@@ -97,6 +97,18 @@ type padStatic struct {
 	launchCount    *big.Int
 }
 
+// PoolAddress is the synthetic key for one launch. Launch ids are per-pad, so
+// neither the pad address nor the id identifies a pool on its own.
+//
+// The separator is "_" and deliberately NOT "#": entity.Pool.Address travels
+// through URL query strings (router-service's poolIds parameter, among others),
+// and "#" starts a fragment there, so a caller passing the key verbatim silently
+// loses the id and matches nothing. "_" is unreserved in RFC 3986. Same shape as
+// fluid/dex-v2's encodeFluidDexV2PoolAddress.
+func PoolAddress(pad string, launchID uint64) string {
+	return pad + "_" + strconv.FormatUint(launchID, 10)
+}
+
 // GetNewPools implements the on-chain, cursor-based discovery: for each of the
 // 8 fixed Smart Launch V2 pads, page forward from the last known
 // launchId to the pad's current launchCount(), emitting one entity.Pool per
@@ -244,7 +256,7 @@ func (l *PoolsListUpdater) fetchLaunches(
 		}
 
 		pools = append(pools, entity.Pool{
-			Address:   pad + "#" + strconv.FormatUint(id, 10),
+			Address:   PoolAddress(pad, id),
 			Exchange:  l.config.DexID,
 			Type:      DexType,
 			Timestamp: ts,

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
@@ -30,7 +30,7 @@ func NewPoolsListUpdater(cfg *Config, client *ethrpc.Client) *PoolsListUpdater {
 // launchRaw mirrors StonkSafeLaunchpadV2.Launch's field names/types exactly
 // -- go-ethereum's abi package unpacks a tuple return into a struct by
 // matching PascalCase field names to the ABI's tuple component names.
-// Verified against a live getLaunch(176) call (see output/math.md).
+// Verified against a live getLaunch(176) call.
 type launchRaw struct {
 	Token              common.Address
 	Creator            common.Address
@@ -97,15 +97,14 @@ type padStatic struct {
 	launchCount    *big.Int
 }
 
-// GetNewPools implements the on-chain, cursor-based discovery
-// (findings.explorer.pool_discovery: view_enum in output/explorer.md): for
-// each of the 8 fixed Smart Launch V2 pads, page forward from the last known
+// GetNewPools implements the on-chain, cursor-based discovery: for each of the
+// 8 fixed Smart Launch V2 pads, page forward from the last known
 // launchId to the pad's current launchCount(), emitting one entity.Pool per
 // newly discovered (pad, launchId).
 //
 // Per AGENTS.md: reserves are NOT set here (left "0","0"; the tracker fills
 // them on the next refresh) and token decimals are NOT fetched here (the
-// pool-service token-metadata pipeline populates them after listing) --
+// token-metadata pipeline populates them after listing) --
 // QuoteDecimals in StaticExtra comes from the PAD's own quoteDecimals()
 // view, not an ERC20 introspection call, so it is available immediately for
 // the math package without violating that rule.

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
@@ -1,0 +1,261 @@
+package stonkbrokersfunv2
+
+import (
+	"context"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, client *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{config: cfg, ethrpcClient: client}
+}
+
+// launchRaw mirrors StonkSafeLaunchpadV2.Launch's field names/types exactly
+// -- go-ethereum's abi package unpacks a tuple return into a struct by
+// matching PascalCase field names to the ABI's tuple component names.
+// Verified against a live getLaunch(176) call (see output/math.md).
+type launchRaw struct {
+	Token              common.Address
+	Creator            common.Address
+	StartMcapUsd8      uint64
+	GradMcapUsd8       uint64
+	StartTaxBps        uint16
+	DecayPerMinuteBps  uint16
+	CreatorFeeBpsSnap  uint16
+	ProtocolFeeBpsSnap uint16
+	WindowSecs         uint32
+	StartTime          uint64
+	Deadline           uint64
+	ExternalToken      bool
+	SellsEnabled       bool
+	Armed              bool
+	Graduated          bool
+	Bonded             bool
+	Aborted            bool
+	LoadedSupply       *big.Int
+	VQuote             *big.Int
+	VToken             *big.Int
+	RealQuote          *big.Int
+	BuyCount           *big.Int
+}
+
+// modesRaw mirrors StonkSafeLaunchpadV2.LaunchModes.
+type modesRaw struct {
+	UnsoldMode uint8
+	EoaOnly    bool
+	OpenEnded  bool
+	PostTaxBps uint16
+	BondVenue  uint8
+	MaxBuyPpm  uint32
+	IcoBoost   bool
+}
+
+// getLaunchResult / modesOfResult wrap the single-tuple returns of
+// getLaunch(uint256) and modesOf(uint256). go-ethereum's Arguments.isTuple()
+// is len(outputs) > 1, so a method returning exactly one `tuple` takes the
+// copyAtomic path, which assigns into *field 0* of a struct destination rather
+// than the struct itself. Unpacking straight into launchRaw would therefore try
+// to write the whole tuple into launchRaw.Token ([20]byte) and panic in
+// abi.setArray. The extra level of nesting puts the tuple at field 0.
+type getLaunchResult struct {
+	Launch launchRaw
+}
+
+type modesOfResult struct {
+	Modes modesRaw
+}
+
+// padStatic is the pad-wide (immutable, same for every launch on this pad)
+// info fetched once per updater pass.
+type padStatic struct {
+	quote          common.Address
+	quoteDecimals  uint8
+	isWethLane     bool
+	quoteIsToken0  bool
+	quoteUsdFeed   common.Address
+	twapPool       common.Address
+	twapWindowSecs uint32
+	ethUsdFeed     common.Address
+	bufferTaxBps   *big.Int
+	launchCount    *big.Int
+}
+
+// GetNewPools implements the on-chain, cursor-based discovery
+// (findings.explorer.pool_discovery: view_enum in output/explorer.md): for
+// each of the 8 fixed Smart Launch V2 pads, page forward from the last known
+// launchId to the pad's current launchCount(), emitting one entity.Pool per
+// newly discovered (pad, launchId).
+//
+// Per AGENTS.md: reserves are NOT set here (left "0","0"; the tracker fills
+// them on the next refresh) and token decimals are NOT fetched here (the
+// pool-service token-metadata pipeline populates them after listing) --
+// QuoteDecimals in StaticExtra comes from the PAD's own quoteDecimals()
+// view, not an ERC20 introspection call, so it is available immediately for
+// the math package without violating that rule.
+func (l *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	cursor := map[string]uint64{}
+	if len(metadataBytes) > 0 {
+		if err := json.Unmarshal(metadataBytes, &cursor); err != nil {
+			return nil, metadataBytes, err
+		}
+	}
+
+	var pools []entity.Pool
+	now := time.Now().Unix()
+
+	for _, rawPad := range l.config.Pads {
+		pad := strings.ToLower(strings.TrimSpace(rawPad))
+		next := cursor[pad]
+		if next == 0 {
+			next = 1
+		}
+
+		ps, err := l.fetchPadStatic(ctx, pad)
+		if err != nil {
+			logger.WithFields(logger.Fields{"err": err, "pad": pad, "dex": DexType}).
+				Errorf("stonkbrokers-fun-v2: fetch pad static info")
+			return pools, metadataBytes, err
+		}
+
+		count := ps.launchCount.Uint64()
+		if count < next {
+			continue
+		}
+
+		newPools, err := l.fetchLaunches(ctx, pad, ps, next, count, now)
+		if err != nil {
+			logger.WithFields(logger.Fields{"err": err, "pad": pad, "dex": DexType}).
+				Errorf("stonkbrokers-fun-v2: fetch launches")
+			return pools, metadataBytes, err
+		}
+		pools = append(pools, newPools...)
+		cursor[pad] = count + 1
+	}
+
+	newMetadata, err := json.Marshal(cursor)
+	if err != nil {
+		return pools, metadataBytes, err
+	}
+	return pools, newMetadata, nil
+}
+
+func (l *PoolsListUpdater) fetchPadStatic(ctx context.Context, pad string) (*padStatic, error) {
+	var ps padStatic
+	req := l.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodLaunchCount}, []any{&ps.launchCount})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodQuote}, []any{&ps.quote})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodQuoteDecimals}, []any{&ps.quoteDecimals})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodIsWethLane}, []any{&ps.isWethLane})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodQuoteIsToken0}, []any{&ps.quoteIsToken0})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodQuoteUsdFeed}, []any{&ps.quoteUsdFeed})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodTwapPool}, []any{&ps.twapPool})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodTwapWindowSecs}, []any{&ps.twapWindowSecs})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodEthUsdFeed}, []any{&ps.ethUsdFeed})
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodBufferTaxBps}, []any{&ps.bufferTaxBps})
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+	return &ps, nil
+}
+
+func (l *PoolsListUpdater) fetchLaunches(
+	ctx context.Context, pad string, ps *padStatic, fromID, toID uint64, ts int64,
+) ([]entity.Pool, error) {
+	n := int(toID-fromID) + 1
+	launches := make([]getLaunchResult, n)
+	modes := make([]modesOfResult, n)
+	bufferSecs := make([]uint32, n)
+
+	req := l.ethrpcClient.NewRequest().SetContext(ctx)
+	for i := 0; i < n; i++ {
+		id := new(big.Int).SetUint64(fromID + uint64(i))
+		req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodGetLaunch, Params: []any{id}}, []any{&launches[i]})
+		req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodModesOf, Params: []any{id}}, []any{&modes[i]})
+		req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodBufferSecsOf, Params: []any{id}}, []any{&bufferSecs[i]})
+	}
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+
+	pools := make([]entity.Pool, 0, n)
+	for i := 0; i < n; i++ {
+		base := i * 3
+		if base+2 >= len(resp.Result) || !resp.Result[base] || !resp.Result[base+1] || !resp.Result[base+2] {
+			// getLaunch/modesOf/bufferSecsOf reverted for this id -- skip it,
+			// a later refresh will pick it up once/if it becomes readable.
+			continue
+		}
+		id := fromID + uint64(i)
+		lr := launches[i].Launch
+		mr := modes[i].Modes
+
+		staticExtra := StaticExtra{
+			Pad:               pad,
+			Lens:              strings.ToLower(l.config.Lens),
+			LaunchID:          strconv.FormatUint(id, 10),
+			IsWethLane:        ps.isWethLane,
+			QuoteDecimals:     ps.quoteDecimals,
+			BufferTaxBps:      uint16(ps.bufferTaxBps.Uint64()),
+			StartTaxBps:       lr.StartTaxBps,
+			DecayPerMinuteBps: lr.DecayPerMinuteBps,
+			BufferSecs:        bufferSecs[i],
+			WindowSecs:        lr.WindowSecs,
+			StartTime:         lr.StartTime,
+			Deadline:          lr.Deadline,
+			OpenEnded:         mr.OpenEnded,
+			EoaOnly:           mr.EoaOnly,
+			PostTaxBps:        mr.PostTaxBps,
+			MaxBuyPpm:         mr.MaxBuyPpm,
+			GradMcapUsd8:      lr.GradMcapUsd8,
+			LoadedSupply:      lr.LoadedSupply.String(),
+			QuoteIsToken0:     ps.quoteIsToken0,
+		}
+		if (ps.quoteUsdFeed != common.Address{}) {
+			staticExtra.QuoteUsdFeed = strings.ToLower(ps.quoteUsdFeed.Hex())
+		}
+		if (ps.twapPool != common.Address{}) {
+			staticExtra.TwapPool = strings.ToLower(ps.twapPool.Hex())
+			staticExtra.TwapWindowSecs = ps.twapWindowSecs
+		}
+		if (ps.ethUsdFeed != common.Address{}) {
+			staticExtra.EthUsdFeed = strings.ToLower(ps.ethUsdFeed.Hex())
+		}
+
+		seBytes, err := json.Marshal(staticExtra)
+		if err != nil {
+			return nil, err
+		}
+
+		pools = append(pools, entity.Pool{
+			Address:   pad + "#" + strconv.FormatUint(id, 10),
+			Exchange:  l.config.DexID,
+			Type:      DexType,
+			Timestamp: ts,
+			Reserves:  entity.PoolReserves{"0", "0"}, // tracker fills real reserves next refresh
+			Tokens: []*entity.PoolToken{
+				{Address: strings.ToLower(lr.Token.Hex()), Swappable: true},
+				{Address: strings.ToLower(ps.quote.Hex()), Swappable: true},
+			},
+			StaticExtra: string(seBytes),
+		})
+	}
+	return pools, nil
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
@@ -97,29 +97,10 @@ type padStatic struct {
 	launchCount    *big.Int
 }
 
-// PoolAddress is the synthetic key for one launch. Launch ids are per-pad, so
-// neither the pad address nor the id identifies a pool on its own.
-//
-// The separator is "_" and deliberately NOT "#": entity.Pool.Address travels
-// through URL query strings (router-service's poolIds parameter, among others),
-// and "#" starts a fragment there, so a caller passing the key verbatim silently
-// loses the id and matches nothing. "_" is unreserved in RFC 3986. Same shape as
-// fluid/dex-v2's encodeFluidDexV2PoolAddress.
 func PoolAddress(pad string, launchID uint64) string {
 	return pad + "_" + strconv.FormatUint(launchID, 10)
 }
 
-// GetNewPools implements the on-chain, cursor-based discovery: for each of the
-// 8 fixed Smart Launch V2 pads, page forward from the last known
-// launchId to the pad's current launchCount(), emitting one entity.Pool per
-// newly discovered (pad, launchId).
-//
-// Per AGENTS.md: reserves are NOT set here (left "0","0"; the tracker fills
-// them on the next refresh) and token decimals are NOT fetched here (the
-// token-metadata pipeline populates them after listing) --
-// QuoteDecimals in StaticExtra comes from the PAD's own quoteDecimals()
-// view, not an ERC20 introspection call, so it is available immediately for
-// the math package without violating that rule.
 func (l *PoolsListUpdater) GetNewPools(ctx context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
 	cursor := map[string]uint64{}
 	if len(metadataBytes) > 0 {
@@ -195,7 +176,7 @@ func (l *PoolsListUpdater) fetchLaunches(
 	bufferSecs := make([]uint32, n)
 
 	req := l.ethrpcClient.NewRequest().SetContext(ctx)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		id := new(big.Int).SetUint64(fromID + uint64(i))
 		req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodGetLaunch, Params: []any{id}}, []any{&launches[i]})
 		req.AddCall(&ethrpc.Call{ABI: PadABI, Target: pad, Method: methodModesOf, Params: []any{id}}, []any{&modes[i]})
@@ -207,7 +188,7 @@ func (l *PoolsListUpdater) fetchLaunches(
 	}
 
 	pools := make([]entity.Pool, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		base := i * 3
 		if base+2 >= len(resp.Result) || !resp.Result[base] || !resp.Result[base+1] || !resp.Result[base+2] {
 			// getLaunch/modesOf/bufferSecsOf reverted for this id -- skip it,

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater.go
@@ -218,6 +218,15 @@ func (l *PoolsListUpdater) fetchLaunches(
 		lr := launches[i].Launch
 		mr := modes[i].Modes
 
+		// eoaOnly launches revert NotEoa() for any contract caller, and an
+		// aggregator always reaches buy() from the executor, so they can never
+		// be routed. Drop them here rather than indexing pools that only exist
+		// to be refused: 60 of 362 live launches set the flag. The cursor pages
+		// by launch id, not by pools emitted, so skipping does not lose ground.
+		if mr.EoaOnly {
+			continue
+		}
+
 		staticExtra := StaticExtra{
 			Pad:               pad,
 			Lens:              strings.ToLower(l.config.Lens),

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
@@ -62,15 +62,17 @@ func (ts *PoolsListUpdaterTestSuite) TestGetNewPools_DiscoversFixedPadOnChain() 
 	// and it can only do that if discovery persisted them. eoaOnly in
 	// particular is set on 74 of the 283 launches live at the time of
 	// writing, so a full pad scan must observe at least one.
-	var sawEoaOnly, sawCap bool
+	// eoaOnly launches are dropped at discovery: they revert NotEoa() for any
+	// contract caller, so an aggregator can never route them. maxBuyPpm, by
+	// contrast, must survive into StaticExtra for CalcAmountOut to bound it.
+	var sawCap bool
 	for _, p := range pools {
 		var se StaticExtra
 		ts.Require().NoError(json.Unmarshal([]byte(p.StaticExtra), &se))
-		sawEoaOnly = sawEoaOnly || se.EoaOnly
+		ts.Require().False(se.EoaOnly, "discovery must not emit eoaOnly launches: %s", p.Address)
 		sawCap = sawCap || se.MaxBuyPpm != 0
 	}
-	t.Logf("eoaOnly seen: %v, maxBuyPpm seen: %v", sawEoaOnly, sawCap)
-	ts.Require().True(sawEoaOnly, "WETH pad has eoaOnly launches; StaticExtra must carry the flag")
+	t.Logf("discovered %d routable pools; maxBuyPpm seen: %v", len(pools), sawCap)
 
 	// Re-running with the returned cursor must not re-discover anything
 	// already seen (idempotent forward-only paging).

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
@@ -3,10 +3,12 @@ package stonkbrokersfunv2
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 	"testing"
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/test"
@@ -81,4 +83,19 @@ func TestPoolsListUpdaterTestSuite(t *testing.T) {
 	t.Parallel()
 	test.SkipCI(t)
 	suite.Run(t, new(PoolsListUpdaterTestSuite))
+}
+
+// TestPoolAddress_IsURLSafe pins the synthetic key's shape. entity.Pool.Address
+// is passed through URL query strings (router-service's poolIds parameter), so
+// the separator must survive that trip: "#" would start a fragment and silently
+// truncate the id, leaving a key that matches no pool.
+func TestPoolAddress_IsURLSafe(t *testing.T) {
+	t.Parallel()
+
+	const pad = "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f"
+	addr := PoolAddress(pad, 176)
+
+	require.Equal(t, pad+"_176", addr)
+	require.NotContains(t, addr, "#", "'#' starts a URL fragment and truncates the id")
+	require.Equal(t, addr, url.QueryEscape(addr), "the key must survive a query string unescaped")
 }

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
@@ -14,7 +14,7 @@ import (
 
 // wethV2Pad is used as a single-pad config for the list-updater test so the
 // live call stays small -- production Config.Pads carries all 8 lanes (see
-// output/explorer.md's findings.contracts.other).
+// the eight quote lanes).
 const wethV2Pad = "0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f"
 
 type PoolsListUpdaterTestSuite struct {

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_list_updater_test.go
@@ -1,0 +1,84 @@
+package stonkbrokersfunv2
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/test"
+)
+
+// wethV2Pad is used as a single-pad config for the list-updater test so the
+// live call stays small -- production Config.Pads carries all 8 lanes (see
+// output/explorer.md's findings.contracts.other).
+const wethV2Pad = "0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f"
+
+type PoolsListUpdaterTestSuite struct {
+	suite.Suite
+	updater *PoolsListUpdater
+}
+
+func (ts *PoolsListUpdaterTestSuite) SetupSuite() {
+	cfg := &Config{
+		DexID:   DexType,
+		ChainID: 4663,
+		Pads:    []string{wethV2Pad},
+		Lens:    "0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3",
+	}
+	client := ethrpc.New(robinhoodRPCURL()).
+		SetMulticallContract(common.HexToAddress(multicallAddress))
+	ts.updater = NewPoolsListUpdater(cfg, client)
+}
+
+// TestGetNewPools_DiscoversFixedPadOnChain proves the on-chain, cursor-based
+// discovery (findings.explorer.pool_discovery: view_enum) actually decodes
+// launchCount()/getLaunch()/modesOf()/bufferSecsOf() against the live WETH
+// pad, and that reserves are deliberately left "0","0" at discovery time
+// (AGENTS.md) for the tracker to fill.
+func (ts *PoolsListUpdaterTestSuite) TestGetNewPools_DiscoversFixedPadOnChain() {
+	t := ts.T()
+
+	pools, metadata, err := ts.updater.GetNewPools(context.Background(), nil)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(pools, "WETH pad has at least launch id 176 (and likely far more) discoverable")
+	t.Logf("discovered %d pools, first address %s", len(pools), pools[0].Address)
+	t.Logf("cursor metadata: %s", string(metadata))
+
+	for _, p := range pools {
+		ts.Require().Equal("0", p.Reserves[0])
+		ts.Require().Equal("0", p.Reserves[1])
+		ts.Require().Len(p.Tokens, 2)
+		ts.Require().NotEmpty(p.StaticExtra)
+	}
+
+	// The two LaunchModes flags that decide whether a route can execute at
+	// all must survive into StaticExtra -- CalcAmountOut refuses on either,
+	// and it can only do that if discovery persisted them. eoaOnly in
+	// particular is set on 74 of the 283 launches live at the time of
+	// writing, so a full pad scan must observe at least one.
+	var sawEoaOnly, sawCap bool
+	for _, p := range pools {
+		var se StaticExtra
+		ts.Require().NoError(json.Unmarshal([]byte(p.StaticExtra), &se))
+		sawEoaOnly = sawEoaOnly || se.EoaOnly
+		sawCap = sawCap || se.MaxBuyPpm != 0
+	}
+	t.Logf("eoaOnly seen: %v, maxBuyPpm seen: %v", sawEoaOnly, sawCap)
+	ts.Require().True(sawEoaOnly, "WETH pad has eoaOnly launches; StaticExtra must carry the flag")
+
+	// Re-running with the returned cursor must not re-discover anything
+	// already seen (idempotent forward-only paging).
+	pools2, _, err := ts.updater.GetNewPools(context.Background(), metadata)
+	ts.Require().NoError(err)
+	ts.Require().Empty(pools2, "cursor must prevent re-discovering already-seen launches")
+}
+
+func TestPoolsListUpdaterTestSuite(t *testing.T) {
+	t.Parallel()
+	test.SkipCI(t)
+	suite.Run(t, new(PoolsListUpdaterTestSuite))
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator.go
@@ -15,7 +15,7 @@ import (
 
 // PoolSimulator prices ONE (pad, launchId) Smart Launch V2 launch. Buy only
 // (quote -> project token) -- see constant.go's scope-decision comment and
-// context/stonkbrokers/output/scaffold.md for why sell is not implemented.
+// ErrSellNotSupported for why sell is not implemented.
 type PoolSimulator struct {
 	pool.Pool
 
@@ -129,7 +129,7 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	// mcapUsd8(id) UNCONDITIONALLY (no try/catch) on every successful buy to
 	// decide whether to close the curve -- if the pad's oracle is stale, the
 	// on-chain call reverts entirely, so this must reject the quote too, not
-	// just the graduation decision. See output/math.md's StalePrice section.
+	// just the graduation decision.
 	quoteUsd8, err := s.currentQuoteUsd8(now)
 	if err != nil {
 		return nil, err

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator.go
@@ -1,0 +1,208 @@
+package stonkbrokersfunv2
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/samber/lo"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+// PoolSimulator prices ONE (pad, launchId) Smart Launch V2 launch. Buy only
+// (quote -> project token) -- see constant.go's scope-decision comment and
+// context/stonkbrokers/output/scaffold.md for why sell is not implemented.
+type PoolSimulator struct {
+	pool.Pool
+
+	staticExtra StaticExtra
+	extra       Extra
+
+	loadedSupply *uint256.Int
+}
+
+var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+
+func NewPoolSimulator(ep entity.Pool) (*PoolSimulator, error) {
+	if len(ep.Tokens) != 2 || len(ep.Reserves) != 2 {
+		return nil, ErrInvalidPoolTokens
+	}
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(ep.StaticExtra), &staticExtra); err != nil {
+		return nil, err
+	}
+	var extra Extra
+	if err := json.Unmarshal([]byte(ep.Extra), &extra); err != nil {
+		return nil, err
+	}
+	loadedSupply, err := uint256.FromDecimal(staticExtra.LoadedSupply)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PoolSimulator{
+		Pool: pool.Pool{Info: pool.PoolInfo{
+			Address:     ep.Address,
+			Exchange:    ep.Exchange,
+			Type:        ep.Type,
+			Tokens:      lo.Map(ep.Tokens, func(t *entity.PoolToken, _ int) string { return t.Address }),
+			Reserves:    lo.Map(ep.Reserves, func(s string, _ int) *big.Int { return bignum.NewBig(s) }),
+			BlockNumber: ep.BlockNumber,
+		}},
+		staticExtra:  staticExtra,
+		extra:        extra,
+		loadedSupply: loadedSupply,
+	}, nil
+}
+
+// CalcAmountOut supports exactly one direction: token1 (quote) -> token0
+// (project token). Every gate StonkSafeLaunchpadV2.buy()/_buy() would revert
+// on is checked here first, per AGENTS.md ("track every flag/check on the
+// swap path so the simulator can reject swaps that would revert on-chain").
+func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	indexIn := s.GetTokenIndex(params.TokenAmountIn.Token)
+	indexOut := s.GetTokenIndex(params.TokenOut)
+	if indexIn != 1 || indexOut != 0 {
+		// Either an unknown token, or the token0->token1 (sell) direction,
+		// which this integration deliberately does not implement.
+		if indexIn == 0 && indexOut == 1 {
+			return nil, ErrSellNotSupported
+		}
+		return nil, ErrInvalidToken
+	}
+
+	if s.extra.Aborted {
+		return nil, ErrPoolAborted
+	}
+	if s.extra.Bonded {
+		return nil, ErrPoolBonded
+	}
+	if s.extra.Graduated {
+		return nil, ErrPoolGraduated
+	}
+	if !s.extra.Armed {
+		return nil, ErrPoolNotArmed
+	}
+	now := uint64(time.Now().Unix())
+	if !s.staticExtra.OpenEnded && now >= s.staticExtra.Deadline {
+		return nil, ErrWindowClosed
+	}
+	// _tradeGates' last check. An aggregator route reaches buy() from the
+	// executor contract, so msg.sender != tx.origin always holds and an
+	// eoaOnly launch reverts NotEoa() unconditionally -- refuse rather than
+	// quote a guaranteed revert.
+	if s.staticExtra.EoaOnly {
+		return nil, ErrEoaOnly
+	}
+
+	amountIn, overflow := uint256.FromBig(params.TokenAmountIn.Amount)
+	if overflow || amountIn == nil {
+		return nil, ErrZeroTrade
+	}
+
+	taxBps := CurrentTaxBps(now, s.staticExtra)
+	tokensOut, tax, newVQuote, newVToken, err := CalcBuyAmountOut(amountIn, s.extra.VQuote, s.extra.VToken, taxBps)
+	if err != nil {
+		return nil, err
+	}
+
+	// _buy credits boughtOf[id][recipient] += tokensOut and then reverts
+	// BuyCapExceeded() if the running total passes the cap. We cannot see the
+	// recipient's existing position, so enforce the single-trade upper bound:
+	// a tokensOut already past the cap can never execute for any recipient.
+	if s.staticExtra.MaxBuyPpm != 0 {
+		var ppm, capTokens uint256.Int
+		ppm.SetUint64(uint64(s.staticExtra.MaxBuyPpm))
+		capTokens.Mul(s.loadedSupply, &ppm)
+		capTokens.Div(&capTokens, ppmU256)
+		if tokensOut.Gt(&capTokens) {
+			return nil, ErrBuyCapExceeded
+		}
+	}
+
+	// Buy-side graduation/StalePrice gate: StonkSafeLaunchpadV2._buy calls
+	// mcapUsd8(id) UNCONDITIONALLY (no try/catch) on every successful buy to
+	// decide whether to close the curve -- if the pad's oracle is stale, the
+	// on-chain call reverts entirely, so this must reject the quote too, not
+	// just the graduation decision. See output/math.md's StalePrice section.
+	quoteUsd8, err := s.currentQuoteUsd8(now)
+	if err != nil {
+		return nil, err
+	}
+	mcap := McapUsd8FromReserves(newVQuote, newVToken, s.loadedSupply, quoteUsd8, s.staticExtra.QuoteDecimals)
+	graduates := mcap.Cmp(uint256.NewInt(s.staticExtra.GradMcapUsd8)) >= 0
+
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: params.TokenOut, Amount: tokensOut.ToBig()},
+		Fee:            &pool.TokenAmount{Token: params.TokenAmountIn.Token, Amount: tax.ToBig()},
+		Gas:            defaultGas,
+		SwapInfo: SwapInfo{
+			NewVQuote: newVQuote,
+			NewVToken: newVToken,
+			Graduates: graduates,
+		},
+	}, nil
+}
+
+// currentQuoteUsd8 resolves the pad's USD mark via whichever oracle path is
+// wired (StaticExtra.QuoteUsdFeed direct feed, or StaticExtra.TwapPool),
+// mutually exclusive per the pad's own constructor invariant.
+func (s *PoolSimulator) currentQuoteUsd8(now uint64) (uint64, error) {
+	if s.staticExtra.QuoteUsdFeed != "" {
+		if s.extra.DirectFeed == nil {
+			return 0, ErrBadOracleAnswer
+		}
+		return DirectFeedUsd8(*s.extra.DirectFeed, now)
+	}
+	if s.staticExtra.TwapPool != "" {
+		if s.extra.Twap == nil {
+			return 0, ErrBadOracleAnswer
+		}
+		return TwapQuoteUsd8(*s.extra.Twap, s.staticExtra.TwapWindowSecs, s.staticExtra.QuoteIsToken0, s.staticExtra.QuoteDecimals, now)
+	}
+	return 0, ErrBadOracleAnswer
+}
+
+// UpdateBalance consumes the SwapInfo CalcAmountOut already computed --
+// never recomputes the swap (AGENTS.md).
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	swapInfo, ok := params.SwapInfo.(SwapInfo)
+	if !ok || swapInfo.NewVQuote == nil || swapInfo.NewVToken == nil {
+		return
+	}
+	s.extra.VQuote = swapInfo.NewVQuote
+	s.extra.VToken = swapInfo.NewVToken
+	if swapInfo.Graduates {
+		s.extra.Graduated = true
+	}
+}
+
+// CloneState deep-copies every slice/pointer UpdateBalance writes in place
+// (AGENTS.md). VQuote/VToken are replaced wholesale by UpdateBalance
+// (pointer reassignment, not in-place mutation), but clone them anyway so a
+// clone and its source never alias the same *uint256.Int across a
+// subsequent UpdateBalance on either one.
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	if s.extra.VQuote != nil {
+		cloned.extra.VQuote = new(uint256.Int).Set(s.extra.VQuote)
+	}
+	if s.extra.VToken != nil {
+		cloned.extra.VToken = new(uint256.Int).Set(s.extra.VToken)
+	}
+	return &cloned
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return PoolMeta{
+		Pad:             s.staticExtra.Pad,
+		LaunchID:        s.staticExtra.LaunchID,
+		ApprovalAddress: s.staticExtra.Pad,
+		BlockNumber:     s.Info.BlockNumber,
+	}
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
@@ -350,3 +350,42 @@ func TestCalcAmountOut_BuyCapBoundary(t *testing.T) {
 	_, err = quoteBuy176(t, buildPoolWithModes(t, false, atCap-1), big.NewInt(amount))
 	require.ErrorIs(t, err, ErrBuyCapExceeded)
 }
+
+// TestIsTerminal covers which launch states are permanently unswappable, and
+// which only look that way. Every "true" case below is one-way on-chain: the
+// four state flags are each assigned exactly once and never cleared, and
+// deadline/eoaOnly are written once and never rewritten.
+func TestIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	const day = 86400
+	now := uint64(time.Now().Unix())
+	armed := Extra{Armed: true}
+
+	tests := []struct {
+		name string
+		ex   Extra
+		se   StaticExtra
+		want bool
+	}{
+		{"aborted", Extra{Aborted: true}, StaticExtra{OpenEnded: true}, true},
+		{"bonded", Extra{Bonded: true}, StaticExtra{OpenEnded: true}, true},
+		{"graduated", Extra{Graduated: true}, StaticExtra{OpenEnded: true}, true},
+		{"eoaOnly", armed, StaticExtra{OpenEnded: true, EoaOnly: true}, true},
+		{"window closed", armed, StaticExtra{Deadline: now - day}, true},
+
+		{"tradeable open-ended", armed, StaticExtra{OpenEnded: true}, false},
+		{"window still open", armed, StaticExtra{Deadline: now + day}, false},
+		// An unarmed launch is NOT terminal: the creator can still call arm(),
+		// and its deadline is zero only because arm() has not set it yet.
+		{"not armed", Extra{}, StaticExtra{Deadline: 0}, false},
+		// Open-ended launches have no timer close at all, so a past deadline
+		// value must not park them.
+		{"open-ended ignores deadline", armed, StaticExtra{OpenEnded: true, Deadline: now - day}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isTerminal(tt.ex, tt.se))
+		})
+	}
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
@@ -67,7 +67,7 @@ func buildLiveLaunch176Pool(t *testing.T) *PoolSimulator {
 	require.NoError(t, err)
 
 	ep := entity.Pool{
-		Address:  wethPad + "#176",
+		Address:  wethPad + "_176",
 		Exchange: string(DexType),
 		Type:     DexType,
 		Tokens: []*entity.PoolToken{

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
@@ -20,7 +20,7 @@ const (
 	ethUsdFeed = "0x78f3556b67e17df817d51ef5a990cdaf09e8d3a9"
 )
 
-// buildLiveLaunch176Pool reproduces context/stonkbrokers/output/explorer.md's
+// buildLiveLaunch176Pool reproduces this package's
 // reference fixture as an entity.Pool: WETH V2 pad, on-chain launch id 176,
 // getLaunch(176) + the WETH pad's quoteUsdFeed()/ethUsdFeed() wiring, all
 // live-verified against the chain's canonical RPC at block 46325622.

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_simulator_test.go
@@ -1,0 +1,352 @@
+package stonkbrokersfunv2
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+const (
+	wethPad    = "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f"
+	moonToken  = "0x391d8735013cc60f7cca0f2ee611a14dc2e66666"
+	wethToken  = "0x0bd7d308f8e1639fab988df18a8011f41eacad73"
+	ethUsdFeed = "0x78f3556b67e17df817d51ef5a990cdaf09e8d3a9"
+)
+
+// buildLiveLaunch176Pool reproduces context/stonkbrokers/output/explorer.md's
+// reference fixture as an entity.Pool: WETH V2 pad, on-chain launch id 176,
+// getLaunch(176) + the WETH pad's quoteUsdFeed()/ethUsdFeed() wiring, all
+// live-verified against the chain's canonical RPC at block 46325622.
+func buildLiveLaunch176Pool(t *testing.T) *PoolSimulator {
+	t.Helper()
+
+	staticExtra := StaticExtra{
+		Pad:               wethPad,
+		Lens:              "0x25b5df581f4b2ed450203f375ad8a28b17f115b3",
+		LaunchID:          "176",
+		IsWethLane:        true,
+		QuoteDecimals:     18,
+		BufferTaxBps:      9999,
+		StartTaxBps:       0,
+		DecayPerMinuteBps: 0,
+		BufferSecs:        0,
+		WindowSecs:        0,
+		StartTime:         1_787_691_927,
+		Deadline:          1_787_691_927,
+		OpenEnded:         true,
+		PostTaxBps:        100,
+		MaxBuyPpm:         0,
+		GradMcapUsd8:      5_000_000_000_000, // $50,000
+		LoadedSupply:      "1000000000000000000000000000",
+		QuoteUsdFeed:      ethUsdFeed,
+		EthUsdFeed:        ethUsdFeed,
+	}
+	extra := Extra{
+		VQuote:       uDec(t, "410349618506110198"),
+		VToken:       uDec(t, "999010726104174939447103989"),
+		SellsEnabled: true,
+		Armed:        true,
+		DirectFeed: &OracleReading{
+			Answer:    uint256.NewInt(245_794_157_469),
+			Decimals:  8,
+			UpdatedAt: uint64(time.Now().Unix()), // fresh, so staleness never trips in these tests
+			Ok:        true,
+		},
+	}
+
+	seBytes, err := json.Marshal(staticExtra)
+	require.NoError(t, err)
+	exBytes, err := json.Marshal(extra)
+	require.NoError(t, err)
+
+	ep := entity.Pool{
+		Address:  wethPad + "#176",
+		Exchange: string(DexType),
+		Type:     DexType,
+		Tokens: []*entity.PoolToken{
+			{Address: moonToken, Decimals: 18, Swappable: true},
+			{Address: wethToken, Decimals: 18, Swappable: true},
+		},
+		Reserves:    entity.PoolReserves{extra.VToken.Dec(), extra.VQuote.Dec()},
+		StaticExtra: string(seBytes),
+		Extra:       string(exBytes),
+		BlockNumber: 46_325_622,
+	}
+
+	sim, err := NewPoolSimulator(ep)
+	require.NoError(t, err)
+	return sim
+}
+
+func TestCalcAmountOut_LiveVerifiedWethLaunch176(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: big.NewInt(0).SetUint64(10_000_000_000_000_000)},
+		TokenOut:      moonToken,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "23534122942428164868379888", res.TokenAmountOut.Amount.String())
+	require.Equal(t, "100000000000000", res.Fee.Amount.String())
+	require.Equal(t, int64(defaultGas), res.Gas)
+
+	swapInfo, ok := res.SwapInfo.(SwapInfo)
+	require.True(t, ok)
+	require.False(t, swapInfo.Graduates) // $50k grad mcap, this trade doesn't get close
+}
+
+func TestCalcAmountOut_SellDirectionRejected(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: moonToken, Amount: big.NewInt(1_000_000)},
+		TokenOut:      wethToken,
+	})
+	require.ErrorIs(t, err, ErrSellNotSupported)
+}
+
+func TestCalcAmountOut_GatesRejectUntradeableStates(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*PoolSimulator)
+		wantErr error
+	}{
+		{"aborted", func(s *PoolSimulator) { s.extra.Aborted = true }, ErrPoolAborted},
+		{"bonded", func(s *PoolSimulator) { s.extra.Bonded = true }, ErrPoolBonded},
+		{"graduated", func(s *PoolSimulator) { s.extra.Graduated = true }, ErrPoolGraduated},
+		{"not armed", func(s *PoolSimulator) { s.extra.Armed = false }, ErrPoolNotArmed},
+		{
+			"window closed (not open-ended, deadline passed)",
+			func(s *PoolSimulator) { s.staticExtra.OpenEnded = false; s.staticExtra.Deadline = 1 },
+			ErrWindowClosed,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sim := buildLiveLaunch176Pool(t)
+			tc.mutate(sim)
+			_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+				TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: big.NewInt(1_000_000_000_000_000)},
+				TokenOut:      moonToken,
+			})
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestCalcAmountOut_StalePriceRejected is the concrete enforcement test for
+// the coordinator's requirement: a stale oracle must reject the BUY quote,
+// not silently price it. 49 hours old exceeds SafeLaunchTwapLib's 48h window.
+func TestCalcAmountOut_StalePriceRejected(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+	sim.extra.DirectFeed.UpdatedAt = uint64(time.Now().Add(-49 * time.Hour).Unix())
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: big.NewInt(1_000_000_000_000_000)},
+		TokenOut:      moonToken,
+	})
+	require.ErrorIs(t, err, ErrStalePrice)
+}
+
+func TestCalcAmountOut_TwapModeMissingReadingRejected(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+	// Simulate a TWAP-mode lane (StaticExtra.TwapPool set) whose tracker read
+	// failed -- must reject rather than quote with a nil Twap snapshot.
+	sim.staticExtra.QuoteUsdFeed = ""
+	sim.staticExtra.TwapPool = "0x52e65b17fb6e5ba00ed806f37afcd2daa50271ca"
+	sim.extra.DirectFeed = nil
+	sim.extra.Twap = nil
+
+	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: big.NewInt(1_000_000_000_000_000)},
+		TokenOut:      moonToken,
+	})
+	require.ErrorIs(t, err, ErrBadOracleAnswer)
+}
+
+func TestUpdateBalance_ConsumesSwapInfo(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+	origVQuote := new(uint256.Int).Set(sim.extra.VQuote)
+	origVToken := new(uint256.Int).Set(sim.extra.VToken)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: big.NewInt(0).SetUint64(10_000_000_000_000_000)},
+		TokenOut:      moonToken,
+	})
+	require.NoError(t, err)
+
+	// CalcAmountOut must not have mutated state.
+	require.True(t, sim.extra.VQuote.Eq(origVQuote))
+	require.True(t, sim.extra.VToken.Eq(origVToken))
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: wethToken, Amount: big.NewInt(0).SetUint64(10_000_000_000_000_000)},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+
+	swapInfo := res.SwapInfo.(SwapInfo)
+	require.True(t, sim.extra.VQuote.Eq(swapInfo.NewVQuote))
+	require.True(t, sim.extra.VToken.Eq(swapInfo.NewVToken))
+	require.False(t, sim.extra.VQuote.Eq(origVQuote))
+}
+
+func TestCloneState_IsIndependent(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+	clone := sim.CloneState().(*PoolSimulator)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: big.NewInt(0).SetUint64(10_000_000_000_000_000)},
+		TokenOut:      moonToken,
+	})
+	require.NoError(t, err)
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: wethToken, Amount: big.NewInt(0).SetUint64(10_000_000_000_000_000)},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+
+	require.False(t, clone.extra.VQuote.Eq(sim.extra.VQuote), "clone must not observe the source's post-swap state")
+	require.Equal(t, "410349618506110198", clone.extra.VQuote.Dec())
+}
+
+func TestGetMetaInfo_ReturnsPinnedBlockNumberAndCallTarget(t *testing.T) {
+	sim := buildLiveLaunch176Pool(t)
+	meta, ok := sim.GetMetaInfo("", "").(PoolMeta)
+	require.True(t, ok)
+	require.Equal(t, uint64(46_325_622), meta.BlockNumber)
+	require.Equal(t, wethPad, meta.Pad)
+	require.Equal(t, "176", meta.LaunchID)
+	require.Equal(t, wethPad, meta.ApprovalAddress)
+}
+
+// TestUpdateBalance_MatchesRealStateTransition pins UpdateBalance against a real
+// buyEth(176, ...) executed on a Tenderly fork of Robinhood Chain at block
+// 46382449 (tx 0x4beb3795102578346ab5a5f688434e75cba2101a36382377e500b95764af6235).
+//
+// The fork's pre-state is buildLiveLaunch176Pool's fixture. After sending
+// 0.01 ETH the contract emitted a Transfer of exactly tokensOut and getLaunch(176)
+// reported the vQuote/vToken below, so these are the chain's own numbers rather
+// than a restatement of what the simulator computed. Together with
+// TestCalcAmountOut_LiveVerifiedWethLaunch176 (which pins the quote itself) this
+// closes the loop: quote, emitted transfer, and post-trade reserves all agree.
+func TestUpdateBalance_MatchesRealStateTransition(t *testing.T) {
+	const (
+		realTokensOut = "23534122942428164868379888"
+		realVQuote    = "420249618506110198"
+		realVToken    = "975476603161746774578724101"
+	)
+
+	sim := buildLiveLaunch176Pool(t)
+	amountIn := big.NewInt(0).SetUint64(10_000_000_000_000_000) // 0.01 ETH
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: amountIn},
+		TokenOut:      moonToken,
+	})
+	require.NoError(t, err)
+	require.Equal(t, realTokensOut, res.TokenAmountOut.Amount.String(),
+		"quote must match the ERC20 Transfer the pad actually emitted")
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: wethToken, Amount: amountIn},
+		TokenAmountOut: *res.TokenAmountOut,
+		SwapInfo:       res.SwapInfo,
+	})
+
+	require.Equal(t, realVQuote, sim.extra.VQuote.Dec(),
+		"post-swap vQuote must match getLaunch(176) after the real buy")
+	require.Equal(t, realVToken, sim.extra.VToken.Dec(),
+		"post-swap vToken must match getLaunch(176) after the real buy")
+}
+
+// buildPoolWithModes clones the launch-176 fixture and overrides the two
+// LaunchModes flags that decide whether an aggregator route can execute at all.
+func buildPoolWithModes(t *testing.T, eoaOnly bool, maxBuyPpm uint32) *PoolSimulator {
+	t.Helper()
+	sim := buildLiveLaunch176Pool(t)
+	sim.staticExtra.EoaOnly = eoaOnly
+	sim.staticExtra.MaxBuyPpm = maxBuyPpm
+	return sim
+}
+
+func quoteBuy176(t *testing.T, sim *PoolSimulator, amountIn *big.Int) (*pool.CalcAmountOutResult, error) {
+	t.Helper()
+	return sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: wethToken, Amount: amountIn},
+		TokenOut:      moonToken,
+	})
+}
+
+// TestCalcAmountOut_EoaOnlyRejected: _tradeGates reverts NotEoa() whenever
+// eoaOnly is set and msg.sender != tx.origin. A route always calls buy() from
+// the executor contract, so such a launch can never execute and must not be
+// quoted. 74 of 283 live launches set this flag.
+func TestCalcAmountOut_EoaOnlyRejected(t *testing.T) {
+	_, err := quoteBuy176(t, buildPoolWithModes(t, true, 0), big.NewInt(10_000_000_000_000_000))
+	require.ErrorIs(t, err, ErrEoaOnly)
+
+	// The same launch without the flag still quotes.
+	res, err := quoteBuy176(t, buildPoolWithModes(t, false, 0), big.NewInt(10_000_000_000_000_000))
+	require.NoError(t, err)
+	require.Equal(t, "23534122942428164868379888", res.TokenAmountOut.Amount.String())
+}
+
+// TestCalcAmountOut_BuyCapRejected pins the single-trade upper bound of
+// _buy's BuyCapExceeded() check against the numbers measured on-chain: launch
+// #174 (loadedSupply 1e27, maxBuyPpm 20000 -> cap 2e25) reverts for a 0.01
+// quote-asset buy, while #120's larger 4.2069% cap does not.
+func TestCalcAmountOut_BuyCapRejected(t *testing.T) {
+	const amount = 10_000_000_000_000_000 // 0.01, quotes ~2.3534e25 tokens
+
+	// cap 2e25 < tokensOut -> refused, matching the on-chain BuyCapExceeded().
+	_, err := quoteBuy176(t, buildPoolWithModes(t, false, 20_000), big.NewInt(amount))
+	require.ErrorIs(t, err, ErrBuyCapExceeded)
+
+	// cap 4.2069e25 > tokensOut -> allowed, matching the on-chain success.
+	res, err := quoteBuy176(t, buildPoolWithModes(t, false, 42_069), big.NewInt(amount))
+	require.NoError(t, err)
+	require.Equal(t, "23534122942428164868379888", res.TokenAmountOut.Amount.String())
+
+	// A cap of zero means "no cap" on-chain, never "cap of nothing".
+	res, err = quoteBuy176(t, buildPoolWithModes(t, false, 0), big.NewInt(amount))
+	require.NoError(t, err)
+	require.Equal(t, "23534122942428164868379888", res.TokenAmountOut.Amount.String())
+}
+
+// TestCalcAmountOut_BuyCapBoundary walks the cap boundary exactly. _buy uses
+// `boughtOf > cap` (strictly greater reverts), so a tokensOut equal to the cap
+// must be allowed and one wei more must not. The cap itself is computed the way
+// the contract computes it -- floor(loadedSupply*ppm/1e6) -- rather than assumed.
+func TestCalcAmountOut_BuyCapBoundary(t *testing.T) {
+	const amount = 10_000_000_000_000_000
+
+	res, err := quoteBuy176(t, buildPoolWithModes(t, false, 0), big.NewInt(amount))
+	require.NoError(t, err)
+	out := res.TokenAmountOut.Amount
+	supply := buildLiveLaunch176Pool(t).loadedSupply.ToBig()
+
+	capFor := func(ppm uint32) *big.Int {
+		c := new(big.Int).Mul(supply, big.NewInt(int64(ppm)))
+		return c.Div(c, big.NewInt(1_000_000))
+	}
+
+	// Smallest ppm whose cap reaches tokensOut (ceil division).
+	ppm := new(big.Int).Add(new(big.Int).Mul(out, big.NewInt(1_000_000)), new(big.Int).Sub(supply, big.NewInt(1)))
+	ppm.Div(ppm, supply)
+	atCap := uint32(ppm.Uint64())
+
+	require.GreaterOrEqual(t, capFor(atCap).Cmp(out), 0, "test setup: cap must reach tokensOut")
+	_, err = quoteBuy176(t, buildPoolWithModes(t, false, atCap), big.NewInt(amount))
+	require.NoError(t, err, "tokensOut <= cap must be allowed; _buy only reverts on >")
+
+	require.Less(t, capFor(atCap-1).Cmp(out), 0, "test setup: one ppm lower must fall under tokensOut")
+	_, err = quoteBuy176(t, buildPoolWithModes(t, false, atCap-1), big.NewInt(amount))
+	require.ErrorIs(t, err, ErrBuyCapExceeded)
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
@@ -129,7 +129,7 @@ func (t *PoolTracker) GetNewPoolState(
 		lg.Errorf("stonkbrokers-fun-v2: neither QuoteUsdFeed nor TwapPool set in StaticExtra")
 	}
 
-	return t.persist(p, extra, blockNumber), nil
+	return t.persist(p, extra, staticExtra, blockNumber), nil
 }
 
 func (t *PoolTracker) fetchDirectFeed(ctx context.Context, feed string, blockNumber *big.Int) (*OracleReading, error) {
@@ -208,7 +208,7 @@ func (t *PoolTracker) fetchTwap(ctx context.Context, twapPool, ethUsdFeed string
 	}, nil
 }
 
-func (t *PoolTracker) persist(p entity.Pool, extra Extra, blockNumber *big.Int) entity.Pool {
+func (t *PoolTracker) persist(p entity.Pool, extra Extra, staticExtra StaticExtra, blockNumber *big.Int) entity.Pool {
 	extraBytes, _ := json.Marshal(extra)
 	p.Extra = string(extraBytes)
 	if extra.VToken != nil && extra.VQuote != nil {
@@ -217,6 +217,44 @@ func (t *PoolTracker) persist(p entity.Pool, extra Extra, blockNumber *big.Int) 
 	if blockNumber != nil {
 		p.BlockNumber = blockNumber.Uint64()
 	}
+
+	if isTerminal(extra, staticExtra) {
+		// This launch can never be swapped through again, so stop feeding it to
+		// path-finding permanently. Timestamp is 1 rather than time.Now() -- and
+		// not 0, which pool-service's IsPoolActive special-cases as
+		// always-active -- so the pool looks maximally stale and is archived
+		// immediately instead of waiting out the inactive-duration window. Same
+		// convention as flap and pons-v2.
+		p.Reserves = entity.PoolReserves{"0", "0"}
+		p.Timestamp = 1
+		return p
+	}
+
 	p.Timestamp = time.Now().Unix()
 	return p
+}
+
+// isTerminal reports whether a launch is permanently unswappable. Every flag it
+// reads is one-way in StonkSafeLaunchpadV2: armed/aborted/graduated/bonded are
+// each assigned exactly once and never cleared, deadline is written once in
+// arm(), and eoaOnly lives in _modesOf, written once in createLaunch on a
+// non-upgradeable pad.
+//
+// Deliberately NOT terminal: an unarmed launch (the creator can still arm it)
+// and a stale oracle (the feed recovers).
+func isTerminal(extra Extra, staticExtra StaticExtra) bool {
+	switch {
+	case extra.Aborted, extra.Bonded, extra.Graduated:
+		return true
+	case staticExtra.EoaOnly:
+		// Unroutable for an aggregator. Discovery skips these now, but pools
+		// indexed before that change still need parking.
+		return true
+	case !staticExtra.OpenEnded && extra.Armed &&
+		uint64(time.Now().Unix()) >= staticExtra.Deadline:
+		// Timer close: the window is past and time only moves forward. Only
+		// meaningful once armed, since deadline is set by arm().
+		return true
+	}
+	return false
 }

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
@@ -49,7 +49,7 @@ func NewPoolTracker(cfg *Config, client *ethrpc.Client) (*PoolTracker, error) {
 // eth_blockNumber call (ethrpc.Client.GetBlockNumber -- NOT the multicall
 // aggregate's returned block), then pin EVERY call in this refresh
 // (getLaunch + the oracle read) to that same value. This is also the
-// domain pool-service's own chain-head resolution and event logs use
+// domain the chain-head resolution and event logs downstream use
 // (pkg/repository/block/block.go's IEVMClient.BlockNumber -- standard
 // eth_blockNumber), so entity.Pool.BlockNumber stays comparable with the
 // rest of the stack (AGENTS.md: use the block from Aggregate/

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
@@ -26,36 +26,15 @@ func NewPoolTracker(cfg *Config, client *ethrpc.Client) (*PoolTracker, error) {
 	return &PoolTracker{config: cfg, ethrpcClient: client}, nil
 }
 
-// GetNewPoolState re-reads the mutable launch state (vQuote/vToken/flags)
-// and the buy-side oracle snapshot (direct feed or TWAP, per StaticExtra).
+// GetNewPoolState re-reads the launch state and the buy-side oracle snapshot.
 //
-// Robinhood Chain quirk (chain 4663, confirmed live against
-// https://rpc.mainnet.chain.robinhood.com): eth_blockNumber and the
-// block.number OPCODE are two independent, non-comparable counters.
-// Multicall3's own aggregate()/tryBlockAndAggregate() reads block.number
-// INSIDE the contract, so `resp.BlockNumber` from an ethrpc Aggregate/
-// TryAggregate call is in the OPCODE domain -- pinning a later eth_call's
-// block tag to that value always fails with "-32000 metadata is not found",
-// because eth_call's block tag is resolved in the eth_blockNumber domain
-// only. (Confirmed: eth_call pinned to a fresh eth_blockNumber succeeds;
-// pinned to the numerically-current block.number value fails.) This bit a
-// previous version of this tracker silently: the failed pin degraded to a
-// logged warning and a nil oracle reading, which is SAFE (the simulator
-// correctly refuses to quote without a reading, see CalcAmountOut's
-// ErrBadOracleAnswer) but made every buy on every pad permanently
-// unquotable in production, defeating the integration.
-//
-// Fix: fetch the eth_blockNumber domain value ONCE via a plain
-// eth_blockNumber call (ethrpc.Client.GetBlockNumber -- NOT the multicall
-// aggregate's returned block), then pin EVERY call in this refresh
-// (getLaunch + the oracle read) to that same value. This is also the
-// domain the chain-head resolution and event logs downstream use
-// (pkg/repository/block/block.go's IEVMClient.BlockNumber -- standard
-// eth_blockNumber), so entity.Pool.BlockNumber stays comparable with the
-// rest of the stack (AGENTS.md: use the block from Aggregate/
-// TryBlockAndAggregate/an existing GetBlockNumber/established event-log
-// state; pin dependent reads to it -- GetBlockNumber is exactly the
-// documented alternative when Aggregate's own block is unusable).
+// The snapshot block comes from the first Aggregate, and every dependent read is
+// pinned to it. Robinhood Chain runs two block counters -- eth_blockNumber and
+// the block.number opcode, ~2x lower -- and eth_call only accepts a tag in the
+// first. ethrpc reports whatever the configured multicall returns, so this only
+// works on ArbMulticall2 (arbBlockNumber), which is what pool-service sets for
+// robinhood; on Multicall3 every pinned read here would fail.
+// TestSnapshotBlockDomain asserts that.
 func (t *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
@@ -72,18 +51,19 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, ErrInvalidPoolTokens
 	}
 
-	ethBlockNumber, err := t.ethrpcClient.GetBlockNumber(ctx)
+	// Unpinned: this first call defines the snapshot block, which every
+	// dependent read below is then pinned to.
+	var res getLaunchResult
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: staticExtra.Pad, Method: methodGetLaunch, Params: []any{launchID}}, []any{&res})
+	resp, err := req.Aggregate()
 	if err != nil {
 		return p, err
 	}
-	blockNumber := new(big.Int).SetUint64(ethBlockNumber)
-
-	var res getLaunchResult
-	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
-	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: staticExtra.Pad, Method: methodGetLaunch, Params: []any{launchID}}, []any{&res})
-	if _, err := req.Aggregate(); err != nil {
-		return p, err
+	if resp.BlockNumber == nil {
+		return p, ErrNoSnapshotBlock
 	}
+	blockNumber := resp.BlockNumber
 	lr := res.Launch
 
 	extra := Extra{
@@ -96,18 +76,10 @@ func (t *PoolTracker) GetNewPoolState(
 		Aborted:      lr.Aborted,
 	}
 
-	// A failed oracle read at this point (after pinning to the verified-
-	// correct eth_blockNumber domain) is NOT the expected case -- it means a
-	// genuine RPC hiccup or an actually-broken feed, not routine staleness
-	// (staleness is a timestamp comparison inside feedUsd8/DirectFeedUsd8/
-	// TwapQuoteUsd8 at quote time, not a call failure here). We still don't
-	// fail the whole refresh: vQuote/vToken/armed/etc. above are valid and
-	// worth persisting even if the oracle leg is temporarily down, and
-	// persisting an explicit Ok:false reading already makes the pool
-	// untradeable end-to-end (CalcAmountOut's currentQuoteUsd8 returns
-	// ErrBadOracleAnswer for Ok:false / nil) -- so this IS "mark the pool
-	// untradeable" (not silent), just logged louder than before since it is
-	// now an unexpected condition rather than an expected one.
+	// An oracle failure here is an RPC hiccup or a broken feed, not routine
+	// staleness (that is a timestamp check at quote time). Persist the launch
+	// state anyway with Ok:false: CalcAmountOut then refuses the pool, which is
+	// the intended "untradeable" outcome.
 	switch {
 	case staticExtra.QuoteUsdFeed != "":
 		reading, err := t.fetchDirectFeed(ctx, staticExtra.QuoteUsdFeed, blockNumber)

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
@@ -1,0 +1,216 @@
+package stonkbrokersfunv2
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type PoolTracker struct {
+	config       *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE(DexType, NewPoolTracker)
+
+func NewPoolTracker(cfg *Config, client *ethrpc.Client) (*PoolTracker, error) {
+	return &PoolTracker{config: cfg, ethrpcClient: client}, nil
+}
+
+// GetNewPoolState re-reads the mutable launch state (vQuote/vToken/flags)
+// and the buy-side oracle snapshot (direct feed or TWAP, per StaticExtra).
+//
+// Robinhood Chain quirk (chain 4663, confirmed live against
+// https://rpc.mainnet.chain.robinhood.com): eth_blockNumber and the
+// block.number OPCODE are two independent, non-comparable counters.
+// Multicall3's own aggregate()/tryBlockAndAggregate() reads block.number
+// INSIDE the contract, so `resp.BlockNumber` from an ethrpc Aggregate/
+// TryAggregate call is in the OPCODE domain -- pinning a later eth_call's
+// block tag to that value always fails with "-32000 metadata is not found",
+// because eth_call's block tag is resolved in the eth_blockNumber domain
+// only. (Confirmed: eth_call pinned to a fresh eth_blockNumber succeeds;
+// pinned to the numerically-current block.number value fails.) This bit a
+// previous version of this tracker silently: the failed pin degraded to a
+// logged warning and a nil oracle reading, which is SAFE (the simulator
+// correctly refuses to quote without a reading, see CalcAmountOut's
+// ErrBadOracleAnswer) but made every buy on every pad permanently
+// unquotable in production, defeating the integration.
+//
+// Fix: fetch the eth_blockNumber domain value ONCE via a plain
+// eth_blockNumber call (ethrpc.Client.GetBlockNumber -- NOT the multicall
+// aggregate's returned block), then pin EVERY call in this refresh
+// (getLaunch + the oracle read) to that same value. This is also the
+// domain pool-service's own chain-head resolution and event logs use
+// (pkg/repository/block/block.go's IEVMClient.BlockNumber -- standard
+// eth_blockNumber), so entity.Pool.BlockNumber stays comparable with the
+// rest of the stack (AGENTS.md: use the block from Aggregate/
+// TryBlockAndAggregate/an existing GetBlockNumber/established event-log
+// state; pin dependent reads to it -- GetBlockNumber is exactly the
+// documented alternative when Aggregate's own block is unusable).
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	lg := logger.WithFields(logger.Fields{"poolAddress": p.Address, "dexID": t.config.DexID})
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return p, err
+	}
+	launchID, ok := new(big.Int).SetString(staticExtra.LaunchID, 10)
+	if !ok {
+		return p, ErrInvalidPoolTokens
+	}
+
+	ethBlockNumber, err := t.ethrpcClient.GetBlockNumber(ctx)
+	if err != nil {
+		return p, err
+	}
+	blockNumber := new(big.Int).SetUint64(ethBlockNumber)
+
+	var res getLaunchResult
+	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: staticExtra.Pad, Method: methodGetLaunch, Params: []any{launchID}}, []any{&res})
+	if _, err := req.Aggregate(); err != nil {
+		return p, err
+	}
+	lr := res.Launch
+
+	extra := Extra{
+		VQuote:       uint256.MustFromBig(lr.VQuote),
+		VToken:       uint256.MustFromBig(lr.VToken),
+		SellsEnabled: lr.SellsEnabled,
+		Armed:        lr.Armed,
+		Graduated:    lr.Graduated,
+		Bonded:       lr.Bonded,
+		Aborted:      lr.Aborted,
+	}
+
+	// A failed oracle read at this point (after pinning to the verified-
+	// correct eth_blockNumber domain) is NOT the expected case -- it means a
+	// genuine RPC hiccup or an actually-broken feed, not routine staleness
+	// (staleness is a timestamp comparison inside feedUsd8/DirectFeedUsd8/
+	// TwapQuoteUsd8 at quote time, not a call failure here). We still don't
+	// fail the whole refresh: vQuote/vToken/armed/etc. above are valid and
+	// worth persisting even if the oracle leg is temporarily down, and
+	// persisting an explicit Ok:false reading already makes the pool
+	// untradeable end-to-end (CalcAmountOut's currentQuoteUsd8 returns
+	// ErrBadOracleAnswer for Ok:false / nil) -- so this IS "mark the pool
+	// untradeable" (not silent), just logged louder than before since it is
+	// now an unexpected condition rather than an expected one.
+	switch {
+	case staticExtra.QuoteUsdFeed != "":
+		reading, err := t.fetchDirectFeed(ctx, staticExtra.QuoteUsdFeed, blockNumber)
+		if err != nil {
+			lg.Errorf("stonkbrokers-fun-v2: direct feed read failed at block %s (pool marked untradeable): %v", blockNumber, err)
+		} else if reading != nil && !reading.Ok {
+			lg.Errorf("stonkbrokers-fun-v2: direct feed call reverted at block %s (pool marked untradeable)", blockNumber)
+		}
+		extra.DirectFeed = reading
+	case staticExtra.TwapPool != "":
+		reading, err := t.fetchTwap(ctx, staticExtra.TwapPool, staticExtra.EthUsdFeed, staticExtra.TwapWindowSecs, blockNumber)
+		if err != nil {
+			lg.Errorf("stonkbrokers-fun-v2: twap read failed at block %s (pool marked untradeable): %v", blockNumber, err)
+		} else if reading != nil && !reading.Ok {
+			lg.Errorf("stonkbrokers-fun-v2: twap call reverted at block %s (pool marked untradeable)", blockNumber)
+		}
+		extra.Twap = reading
+	default:
+		lg.Errorf("stonkbrokers-fun-v2: neither QuoteUsdFeed nor TwapPool set in StaticExtra")
+	}
+
+	return t.persist(p, extra, blockNumber), nil
+}
+
+func (t *PoolTracker) fetchDirectFeed(ctx context.Context, feed string, blockNumber *big.Int) (*OracleReading, error) {
+	var (
+		roundData struct {
+			RoundId         *big.Int
+			Answer          *big.Int
+			StartedAt       *big.Int
+			UpdatedAt       *big.Int
+			AnsweredInRound *big.Int
+		}
+		decimals uint8
+	)
+	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
+	req.AddCall(&ethrpc.Call{ABI: aggregatorV3ABI, Target: feed, Method: "latestRoundData"}, []any{&roundData})
+	req.AddCall(&ethrpc.Call{ABI: aggregatorV3ABI, Target: feed, Method: "decimals"}, []any{&decimals})
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Result) < 2 || !resp.Result[0] || !resp.Result[1] {
+		return &OracleReading{Ok: false}, nil
+	}
+	if roundData.Answer == nil || roundData.Answer.Sign() <= 0 {
+		return &OracleReading{Ok: false}, nil
+	}
+	return &OracleReading{
+		Answer:    uint256.MustFromBig(roundData.Answer),
+		Decimals:  decimals,
+		UpdatedAt: roundData.UpdatedAt.Uint64(),
+		Ok:        true,
+	}, nil
+}
+
+func (t *PoolTracker) fetchTwap(ctx context.Context, twapPool, ethUsdFeed string, window uint32, blockNumber *big.Int) (*TwapReading, error) {
+	var (
+		tickCumulatives     []*big.Int
+		secondsPerLiquidity []*big.Int
+	)
+	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
+	req.AddCall(&ethrpc.Call{
+		ABI: twapPoolABI, Target: twapPool, Method: "observe",
+		Params: []any{[]uint32{window, 0}},
+	}, []any{&tickCumulatives, &secondsPerLiquidity})
+	resp, err := req.TryAggregate()
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Result) < 1 || !resp.Result[0] || len(tickCumulatives) != 2 {
+		ethReading, _ := t.fetchDirectFeed(ctx, ethUsdFeed, blockNumber)
+		if ethReading == nil {
+			ethReading = &OracleReading{Ok: false}
+		}
+		return &TwapReading{Ok: false, EthUsd: *ethReading}, nil
+	}
+
+	ethReading, err := t.fetchDirectFeed(ctx, ethUsdFeed, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	if ethReading == nil {
+		ethReading = &OracleReading{Ok: false}
+	}
+
+	return &TwapReading{
+		TickCumulativeOld: tickCumulatives[0].Int64(),
+		TickCumulativeNow: tickCumulatives[1].Int64(),
+		EthUsd:            *ethReading,
+		Ok:                true,
+	}, nil
+}
+
+func (t *PoolTracker) persist(p entity.Pool, extra Extra, blockNumber *big.Int) entity.Pool {
+	extraBytes, _ := json.Marshal(extra)
+	p.Extra = string(extraBytes)
+	if extra.VToken != nil && extra.VQuote != nil {
+		p.Reserves = entity.PoolReserves{extra.VToken.Dec(), extra.VQuote.Dec()}
+	}
+	if blockNumber != nil {
+		p.BlockNumber = blockNumber.Uint64()
+	}
+	p.Timestamp = time.Now().Unix()
+	return p
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
@@ -165,19 +165,25 @@ func (t *PoolTracker) fetchDirectFeed(ctx context.Context, feed string, blockNum
 }
 
 func (t *PoolTracker) fetchTwap(ctx context.Context, twapPool, ethUsdFeed string, window uint32, blockNumber *big.Int) (*TwapReading, error) {
-	var (
-		tickCumulatives     []*big.Int
-		secondsPerLiquidity []*big.Int
-	)
+	// observe returns TWO outputs, so go-ethereum takes the copyTuple path and
+	// needs ONE struct destination whose field names match the ABI's output
+	// names. Passing two separate pointers looks reasonable but unpacks into
+	// nothing: the multicall reports success, the destinations stay empty, and
+	// the len check below then mislabels a perfectly good pool as untradeable.
+	var observed struct {
+		TickCumulatives                    []*big.Int
+		SecondsPerLiquidityCumulativeX128s []*big.Int
+	}
 	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
 	req.AddCall(&ethrpc.Call{
 		ABI: twapPoolABI, Target: twapPool, Method: "observe",
 		Params: []any{[]uint32{window, 0}},
-	}, []any{&tickCumulatives, &secondsPerLiquidity})
+	}, []any{&observed})
 	resp, err := req.TryAggregate()
 	if err != nil {
 		return nil, err
 	}
+	tickCumulatives := observed.TickCumulatives
 	if len(resp.Result) < 1 || !resp.Result[0] || len(tickCumulatives) != 2 {
 		ethReading, _ := t.fetchDirectFeed(ctx, ethUsdFeed, blockNumber)
 		if ethReading == nil {

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker.go
@@ -26,15 +26,6 @@ func NewPoolTracker(cfg *Config, client *ethrpc.Client) (*PoolTracker, error) {
 	return &PoolTracker{config: cfg, ethrpcClient: client}, nil
 }
 
-// GetNewPoolState re-reads the launch state and the buy-side oracle snapshot.
-//
-// The snapshot block comes from the first Aggregate, and every dependent read is
-// pinned to it. Robinhood Chain runs two block counters -- eth_blockNumber and
-// the block.number opcode, ~2x lower -- and eth_call only accepts a tag in the
-// first. ethrpc reports whatever the configured multicall returns, so this only
-// works on ArbMulticall2 (arbBlockNumber), which is what pool-service sets for
-// robinhood; on Multicall3 every pinned read here would fail.
-// TestSnapshotBlockDomain asserts that.
 func (t *PoolTracker) GetNewPoolState(
 	ctx context.Context,
 	p entity.Pool,
@@ -51,8 +42,6 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, ErrInvalidPoolTokens
 	}
 
-	// Unpinned: this first call defines the snapshot block, which every
-	// dependent read below is then pinned to.
 	var res getLaunchResult
 	req := t.ethrpcClient.NewRequest().SetContext(ctx)
 	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: staticExtra.Pad, Method: methodGetLaunch, Params: []any{launchID}}, []any{&res})
@@ -66,6 +55,11 @@ func (t *PoolTracker) GetNewPoolState(
 	blockNumber := resp.BlockNumber
 	lr := res.Launch
 
+	var buyCount uint64
+	if lr.BuyCount != nil {
+		buyCount = lr.BuyCount.Uint64()
+	}
+
 	extra := Extra{
 		VQuote:       uint256.MustFromBig(lr.VQuote),
 		VToken:       uint256.MustFromBig(lr.VToken),
@@ -74,31 +68,29 @@ func (t *PoolTracker) GetNewPoolState(
 		Graduated:    lr.Graduated,
 		Bonded:       lr.Bonded,
 		Aborted:      lr.Aborted,
+		BuyCount:     buyCount,
+		FetchedAt:    time.Now().Unix(),
 	}
 
-	// An oracle failure here is an RPC hiccup or a broken feed, not routine
-	// staleness (that is a timestamp check at quote time). Persist the launch
-	// state anyway with Ok:false: CalcAmountOut then refuses the pool, which is
-	// the intended "untradeable" outcome.
 	switch {
 	case staticExtra.QuoteUsdFeed != "":
 		reading, err := t.fetchDirectFeed(ctx, staticExtra.QuoteUsdFeed, blockNumber)
 		if err != nil {
-			lg.Errorf("stonkbrokers-fun-v2: direct feed read failed at block %s (pool marked untradeable): %v", blockNumber, err)
+			lg.Errorf("direct feed read failed at block %s (pool marked untradeable): %v", blockNumber, err)
 		} else if reading != nil && !reading.Ok {
-			lg.Errorf("stonkbrokers-fun-v2: direct feed call reverted at block %s (pool marked untradeable)", blockNumber)
+			lg.Errorf("direct feed call reverted at block %s (pool marked untradeable)", blockNumber)
 		}
 		extra.DirectFeed = reading
 	case staticExtra.TwapPool != "":
 		reading, err := t.fetchTwap(ctx, staticExtra.TwapPool, staticExtra.EthUsdFeed, staticExtra.TwapWindowSecs, blockNumber)
 		if err != nil {
-			lg.Errorf("stonkbrokers-fun-v2: twap read failed at block %s (pool marked untradeable): %v", blockNumber, err)
+			lg.Errorf("twap read failed at block %s (pool marked untradeable): %v", blockNumber, err)
 		} else if reading != nil && !reading.Ok {
-			lg.Errorf("stonkbrokers-fun-v2: twap call reverted at block %s (pool marked untradeable)", blockNumber)
+			lg.Errorf("twap call reverted at block %s (pool marked untradeable)", blockNumber)
 		}
 		extra.Twap = reading
 	default:
-		lg.Errorf("stonkbrokers-fun-v2: neither QuoteUsdFeed nor TwapPool set in StaticExtra")
+		lg.Errorf("neither QuoteUsdFeed nor TwapPool set in StaticExtra")
 	}
 
 	return t.persist(p, extra, staticExtra, blockNumber), nil
@@ -181,6 +173,9 @@ func (t *PoolTracker) fetchTwap(ctx context.Context, twapPool, ethUsdFeed string
 }
 
 func (t *PoolTracker) persist(p entity.Pool, extra Extra, staticExtra StaticExtra, blockNumber *big.Int) entity.Pool {
+	var prev Extra
+	_ = json.Unmarshal([]byte(p.Extra), &prev)
+
 	extraBytes, _ := json.Marshal(extra)
 	p.Extra = string(extraBytes)
 	if extra.VToken != nil && extra.VQuote != nil {
@@ -191,29 +186,18 @@ func (t *PoolTracker) persist(p entity.Pool, extra Extra, staticExtra StaticExtr
 	}
 
 	if isTerminal(extra, staticExtra) {
-		// This launch can never be swapped through again, so stop feeding it to
-		// path-finding permanently. Timestamp is 1 rather than time.Now() -- and
-		// not 0, which pool-service's IsPoolActive special-cases as
-		// always-active -- so the pool looks maximally stale and is archived
-		// immediately instead of waiting out the inactive-duration window. Same
-		// convention as flap and pons-v2.
 		p.Reserves = entity.PoolReserves{"0", "0"}
 		p.Timestamp = 1
 		return p
 	}
 
-	p.Timestamp = time.Now().Unix()
+	if extra.BuyCount != prev.BuyCount || p.Timestamp == 0 {
+		p.Timestamp = time.Now().Unix()
+	}
+
 	return p
 }
 
-// isTerminal reports whether a launch is permanently unswappable. Every flag it
-// reads is one-way in StonkSafeLaunchpadV2: armed/aborted/graduated/bonded are
-// each assigned exactly once and never cleared, deadline is written once in
-// arm(), and eoaOnly lives in _modesOf, written once in createLaunch on a
-// non-upgradeable pad.
-//
-// Deliberately NOT terminal: an unarmed launch (the creator can still arm it)
-// and a stale oracle (the feed recovers).
 func isTerminal(extra Extra, staticExtra StaticExtra) bool {
 	switch {
 	case extra.Aborted, extra.Bonded, extra.Graduated:

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -2,7 +2,6 @@ package stonkbrokersfunv2
 
 import (
 	"context"
-	"math/big"
 	"os"
 	"testing"
 
@@ -125,12 +124,12 @@ func TestPoolTrackerTestSuite(t *testing.T) {
 //
 // It is not worth making. Exactly one launch exists across all 8 V3 pads (WETH
 // lane, id 1) and it is eoaOnly, so buy() reverts NotEoa() for any contract
-// caller including the executor: V3 adds zero routable liquidity today. This
-// test asserts that refusal, then lifts the flag to confirm the pricing path
-// underneath would work if a routable V3 launch ever appears.
+// caller including the executor. Discovery drops eoaOnly launches, so pointing
+// the lister at the V3 pad yields nothing at all: V3 would add zero routable
+// liquidity today. If a routable V3 launch ever appears, this test starts
+// failing and the decision gets revisited.
 func (ts *PoolTrackerTestSuite) TestV3Pad_ScopeDecision() {
 	t := ts.T()
-	ctx := context.Background()
 
 	client := ethrpc.New(robinhoodRPCURL()).
 		SetMulticallContract(common.HexToAddress(multicallAddress))
@@ -139,57 +138,13 @@ func (ts *PoolTrackerTestSuite) TestV3Pad_ScopeDecision() {
 		DexID: DexType, ChainID: 4663,
 		Pads: []string{wethV3Pad}, Lens: lensAddress,
 	}, client)
-	pools, _, err := lister.GetNewPools(ctx, nil)
-	ts.Require().NoError(err)
-	ts.Require().NotEmpty(pools)
 
-	tracker, err := NewPoolTracker(&Config{DexID: DexType, ChainID: 4663}, client)
-	ts.Require().NoError(err)
-	p, err := tracker.GetNewPoolState(ctx, pools[0], pool.GetNewPoolStateParams{})
-	ts.Require().NoError(err)
-	ts.Require().NotEmpty(p.Extra, "tracker must fill Extra for a V3 pad")
-
-	sim, err := NewPoolSimulator(p)
-	ts.Require().NoError(err)
-
-	amountIn := big.NewInt(0).SetUint64(10_000_000_000_000_000) // 0.01 WETH
-	quote := func(s *PoolSimulator) (*pool.CalcAmountOutResult, error) {
-		return s.CalcAmountOut(pool.CalcAmountOutParams{
-			TokenAmountIn: pool.TokenAmount{Token: p.Tokens[1].Address, Amount: amountIn},
-			TokenOut:      p.Tokens[0].Address,
-		})
-	}
-
-	se := mustStaticExtra(t, p)
-	ts.Require().True(se.EoaOnly, "V3 launch 1 is eoaOnly on-chain; discovery must carry the flag")
-	_, err = quote(sim)
-	ts.Require().ErrorIs(err, ErrEoaOnly, "an eoaOnly launch must never be quoted")
-
-	// Lift the gate to exercise the curve underneath it.
-	sim.staticExtra.EoaOnly = false
-	res, err := quote(sim)
-	ts.Require().NoError(err)
-
-	// The pad's own lens is the oracle of truth for the quote.
-	// quoteBuy returns two values, so ethrpc takes the copyTuple path and needs
-	// a single struct destination with matching field order.
-	var lens struct {
-		TokensOut *big.Int
-		TaxBps    *big.Int
-	}
-	launchID, ok := new(big.Int).SetString(se.LaunchID, 10)
-	ts.Require().True(ok)
-	req := client.NewRequest().SetContext(ctx)
-	req.AddCall(&ethrpc.Call{
-		ABI: lensABI, Target: lensAddress, Method: methodQuoteBuy,
-		Params: []any{common.HexToAddress(wethV3Pad), launchID, amountIn},
-	}, []any{&lens})
-	_, err = req.Aggregate()
-	ts.Require().NoError(err)
-
-	t.Logf("V3 %s: sim=%s lens=%s taxBps=%s", p.Address, res.TokenAmountOut.Amount, lens.TokensOut, lens.TaxBps)
-	ts.Require().Zero(res.TokenAmountOut.Amount.Cmp(lens.TokensOut),
-		"V3 pad must price identically to the lens, with no V3-specific code")
+	pools, _, err := lister.GetNewPools(context.Background(), nil)
+	ts.Require().NoError(err, "the V2 lister must decode a V3 pad unchanged")
+	ts.Require().Empty(pools,
+		"V3's only launch is eoaOnly and must be dropped; %d pool(s) came back, so a routable V3 launch now exists",
+		len(pools))
+	t.Logf("V3 WETH pad: %d routable launches (expected 0)", len(pools))
 }
 
 func mustStaticExtra(t *testing.T, p entity.Pool) StaticExtra {

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -44,7 +44,7 @@ func robinhoodRPCURL() string {
 // (AGENTS.md: don't set reserves at discovery time); GetNewPoolState fills
 // the real values.
 const testPoolJSON = `{
-	"address": "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f#176",
+	"address": "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f_176",
 	"exchange": "stonkbrokers-fun-v2",
 	"type": "stonkbrokers-fun-v2",
 	"timestamp": 1787720000,

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -2,6 +2,7 @@ package stonkbrokersfunv2
 
 import (
 	"context"
+	"math/big"
 	"os"
 	"testing"
 
@@ -152,4 +153,60 @@ func mustStaticExtra(t *testing.T, p entity.Pool) StaticExtra {
 	var se StaticExtra
 	require.NoError(t, json.Unmarshal([]byte(p.StaticExtra), &se))
 	return se
+}
+
+// TestQuoteMatchesLens is the correctness property that matters most: the
+// simulator's price must equal what the pad's own SafeLaunchLensV2 quotes, to
+// the wei, across the whole amount range. The lens is an independent on-chain
+// implementation of the same curve, so agreeing with it catches any drift in
+// the ported tax/rounding maths.
+func (ts *PoolTrackerTestSuite) TestQuoteMatchesLens() {
+	t := ts.T()
+	ctx := context.Background()
+
+	client := ethrpc.New(robinhoodRPCURL()).
+		SetMulticallContract(common.HexToAddress(multicallAddress))
+
+	var ep entity.Pool
+	ts.Require().NoError(json.Unmarshal([]byte(testPoolJSON), &ep))
+	p, err := ts.tracker.GetNewPoolState(ctx, ep, pool.GetNewPoolStateParams{})
+	ts.Require().NoError(err)
+
+	sim, err := NewPoolSimulator(p)
+	ts.Require().NoError(err)
+
+	launchID, ok := new(big.Int).SetString(mustStaticExtra(t, p).LaunchID, 10)
+	ts.Require().True(ok)
+
+	for _, amountIn := range []*big.Int{
+		big.NewInt(1),
+		big.NewInt(1_000_000_000_000),
+		big.NewInt(10_000_000_000_000_000),
+		big.NewInt(1_000_000_000_000_000_000),
+	} {
+		res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: p.Tokens[1].Address, Amount: amountIn},
+			TokenOut:      p.Tokens[0].Address,
+		})
+		ts.Require().NoError(err, "amountIn=%s", amountIn)
+
+		// quoteBuy returns two values, so ethrpc takes the copyTuple path and
+		// needs one struct destination.
+		var lens struct {
+			TokensOut *big.Int
+			TaxBps    *big.Int
+		}
+		req := client.NewRequest().SetContext(ctx).SetBlockNumber(new(big.Int).SetUint64(p.BlockNumber))
+		req.AddCall(&ethrpc.Call{
+			ABI: lensABI, Target: lensAddress, Method: methodQuoteBuy,
+			Params: []any{common.HexToAddress(wethPad), launchID, amountIn},
+		}, []any{&lens})
+		_, err = req.Aggregate()
+		ts.Require().NoError(err)
+
+		t.Logf("amountIn=%-20s sim=%-30s lens=%-30s taxBps=%s",
+			amountIn, res.TokenAmountOut.Amount, lens.TokensOut, lens.TaxBps)
+		ts.Require().Zero(res.TokenAmountOut.Amount.Cmp(lens.TokensOut),
+			"simulator disagrees with the lens at amountIn=%s", amountIn)
+	}
 }

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -1,0 +1,200 @@
+package stonkbrokersfunv2
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/test"
+)
+
+const (
+	defaultRobinhoodRPCURL = "https://rpc.mainnet.chain.robinhood.com"
+	multicallAddress       = "0xcA11bde05977b3631167028862bE2a173976CA11"
+	lensAddress            = "0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3"
+
+	// wethV3Pad is the WETH-lane Smart Launch V3 pad. V3 is deliberately out of
+	// the configured pad list -- see TestV3Pad_ScopeDecision.
+	wethV3Pad = "0x5BCEefBa6fDf437A7388aDC5c9056c827baca3B3"
+)
+
+// robinhoodRPCURL is the endpoint the live tests dial. The public RPC rate
+// limits aggressively (and answers Cloudflare challenges once it does), so
+// STONKBROKERS_RPC_URL can point these at a private/archive endpoint. Keep the
+// key in the environment, never in the repo.
+func robinhoodRPCURL() string {
+	if u := os.Getenv("STONKBROKERS_RPC_URL"); u != "" {
+		return u
+	}
+	return defaultRobinhoodRPCURL
+}
+
+// testPoolJSON is the reference launch used throughout output/explorer.md
+// and output/math.md: WETH V2 pad, on-chain launch id 176. Reserves start
+// at "0","0" -- this is exactly what dex-scaffold's discovery leaves behind
+// (AGENTS.md: don't set reserves at discovery time); GetNewPoolState fills
+// the real values.
+const testPoolJSON = `{
+	"address": "0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f#176",
+	"exchange": "stonkbrokers-fun-v2",
+	"type": "stonkbrokers-fun-v2",
+	"timestamp": 1787720000,
+	"reserves": ["0", "0"],
+	"tokens": [
+		{"address": "0x391d8735013cc60f7cca0f2ee611a14dc2e66666", "swappable": true},
+		{"address": "0x0bd7d308f8e1639fab988df18a8011f41eacad73", "swappable": true}
+	],
+	"extra": "{}",
+	"staticExtra": "{\"pad\":\"0xfcd61b25bbf3abd6cf0070d6328e351cc30eec9f\",\"lens\":\"0x25b5df581f4b2ed450203f375ad8a28b17f115b3\",\"launchId\":\"176\",\"isWethLane\":true,\"quoteDecimals\":18,\"bufferTaxBps\":9999,\"startTaxBps\":0,\"decayPerMinuteBps\":0,\"bufferSecs\":0,\"windowSecs\":0,\"startTime\":1787691927,\"deadline\":1787691927,\"openEnded\":true,\"postTaxBps\":100,\"maxBuyPpm\":0,\"gradMcapUsd8\":5000000000000,\"loadedSupply\":\"1000000000000000000000000000\",\"quoteUsdFeed\":\"0x78f3556b67e17df817d51ef5a990cdaf09e8d3a9\",\"ethUsdFeed\":\"0x78f3556b67e17df817d51ef5a990cdaf09e8d3a9\"}"
+}`
+
+type PoolTrackerTestSuite struct {
+	suite.Suite
+	tracker *PoolTracker
+}
+
+func (ts *PoolTrackerTestSuite) SetupSuite() {
+	cfg := &Config{
+		DexID:   DexType,
+		ChainID: 4663,
+	}
+	client := ethrpc.New(robinhoodRPCURL()).
+		SetMulticallContract(common.HexToAddress(multicallAddress))
+
+	tracker, err := NewPoolTracker(cfg, client)
+	ts.Require().NoError(err)
+	ts.tracker = tracker
+}
+
+// TestGetNewPoolState_LiveWethLaunch176 is the tracker-side half of the
+// live-verified WETH launch 176 fixture (paired with
+// TestCalcAmountOut_LiveVerifiedWethLaunch176 in pool_simulator_test.go).
+// It hits the real chain -- SkipCI so it doesn't flake CI on a network hop,
+// but genuinely proves GetNewPoolState decodes real on-chain bytes.
+func (ts *PoolTrackerTestSuite) TestGetNewPoolState_LiveWethLaunch176() {
+	t := ts.T()
+
+	var p entity.Pool
+	require.NoError(t, json.Unmarshal([]byte(testPoolJSON), &p))
+
+	updated, err := ts.tracker.GetNewPoolState(context.Background(), p, pool.GetNewPoolStateParams{})
+	require.NoError(t, err)
+
+	t.Logf("blockNumber: %d", updated.BlockNumber)
+	t.Logf("reserves:    %v", updated.Reserves)
+	t.Logf("extra:       %s", updated.Extra)
+
+	require.Greater(t, updated.BlockNumber, uint64(46_325_622), "block must be pinned forward, never fabricated")
+	require.Len(t, updated.Reserves, 2)
+	require.NotEqual(t, "0", updated.Reserves[0])
+	require.NotEqual(t, "0", updated.Reserves[1])
+
+	var extra Extra
+	require.NoError(t, json.Unmarshal([]byte(updated.Extra), &extra))
+	require.True(t, extra.Armed)
+	require.False(t, extra.Aborted)
+	require.NotNil(t, extra.DirectFeed)
+	require.True(t, extra.DirectFeed.Ok, "WETH lane's quoteUsdFeed must resolve (direct-feed mode)")
+	require.Nil(t, extra.Twap, "WETH lane is direct-feed mode, Twap must stay unset")
+}
+
+func TestPoolTrackerTestSuite(t *testing.T) {
+	t.Parallel()
+	test.SkipCI(t)
+	suite.Run(t, new(PoolTrackerTestSuite))
+}
+
+// TestV3Pad_ScopeDecision records WHY the 8 Smart Launch V3 (external-token /
+// BYO) pads are deliberately NOT in the pad list, and keeps that decision
+// honest by re-checking it against the chain.
+//
+// V3 needs no code of its own: the pads share the StonkSafeLaunchpadV2 ABI and
+// the SafeLaunchLensV2 lens, and `externalToken` -- the only distinguishing
+// field -- is written in createLaunch, emitted in LaunchCreated, and read
+// nowhere else in the pad or its four linked libraries, so it never branches
+// the buy path. Adding them would be a config-only change.
+//
+// It is not worth making. Exactly one launch exists across all 8 V3 pads (WETH
+// lane, id 1) and it is eoaOnly, so buy() reverts NotEoa() for any contract
+// caller including the executor: V3 adds zero routable liquidity today. This
+// test asserts that refusal, then lifts the flag to confirm the pricing path
+// underneath would work if a routable V3 launch ever appears.
+func (ts *PoolTrackerTestSuite) TestV3Pad_ScopeDecision() {
+	t := ts.T()
+	ctx := context.Background()
+
+	client := ethrpc.New(robinhoodRPCURL()).
+		SetMulticallContract(common.HexToAddress(multicallAddress))
+
+	lister := NewPoolsListUpdater(&Config{
+		DexID: DexType, ChainID: 4663,
+		Pads: []string{wethV3Pad}, Lens: lensAddress,
+	}, client)
+	pools, _, err := lister.GetNewPools(ctx, nil)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(pools)
+
+	tracker, err := NewPoolTracker(&Config{DexID: DexType, ChainID: 4663}, client)
+	ts.Require().NoError(err)
+	p, err := tracker.GetNewPoolState(ctx, pools[0], pool.GetNewPoolStateParams{})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(p.Extra, "tracker must fill Extra for a V3 pad")
+
+	sim, err := NewPoolSimulator(p)
+	ts.Require().NoError(err)
+
+	amountIn := big.NewInt(0).SetUint64(10_000_000_000_000_000) // 0.01 WETH
+	quote := func(s *PoolSimulator) (*pool.CalcAmountOutResult, error) {
+		return s.CalcAmountOut(pool.CalcAmountOutParams{
+			TokenAmountIn: pool.TokenAmount{Token: p.Tokens[1].Address, Amount: amountIn},
+			TokenOut:      p.Tokens[0].Address,
+		})
+	}
+
+	se := mustStaticExtra(t, p)
+	ts.Require().True(se.EoaOnly, "V3 launch 1 is eoaOnly on-chain; discovery must carry the flag")
+	_, err = quote(sim)
+	ts.Require().ErrorIs(err, ErrEoaOnly, "an eoaOnly launch must never be quoted")
+
+	// Lift the gate to exercise the curve underneath it.
+	sim.staticExtra.EoaOnly = false
+	res, err := quote(sim)
+	ts.Require().NoError(err)
+
+	// The pad's own lens is the oracle of truth for the quote.
+	// quoteBuy returns two values, so ethrpc takes the copyTuple path and needs
+	// a single struct destination with matching field order.
+	var lens struct {
+		TokensOut *big.Int
+		TaxBps    *big.Int
+	}
+	launchID, ok := new(big.Int).SetString(se.LaunchID, 10)
+	ts.Require().True(ok)
+	req := client.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{
+		ABI: lensABI, Target: lensAddress, Method: methodQuoteBuy,
+		Params: []any{common.HexToAddress(wethV3Pad), launchID, amountIn},
+	}, []any{&lens})
+	_, err = req.Aggregate()
+	ts.Require().NoError(err)
+
+	t.Logf("V3 %s: sim=%s lens=%s taxBps=%s", p.Address, res.TokenAmountOut.Amount, lens.TokensOut, lens.TaxBps)
+	ts.Require().Zero(res.TokenAmountOut.Amount.Cmp(lens.TokensOut),
+		"V3 pad must price identically to the lens, with no V3-specific code")
+}
+
+func mustStaticExtra(t *testing.T, p entity.Pool) StaticExtra {
+	t.Helper()
+	var se StaticExtra
+	require.NoError(t, json.Unmarshal([]byte(p.StaticExtra), &se))
+	return se
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -19,8 +19,12 @@ import (
 
 const (
 	defaultRobinhoodRPCURL = "https://rpc.mainnet.chain.robinhood.com"
-	multicallAddress       = "0xcA11bde05977b3631167028862bE2a173976CA11"
-	lensAddress            = "0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3"
+	// ArbMulticall2, matching pool-service's robinhood config. It must be this
+	// one and not Multicall3: the tracker pins its oracle read to the block
+	// aggregate() returns, and only this contract reports that in the
+	// eth_blockNumber domain. See GetNewPoolState's comment.
+	multicallAddress = "0x2cAC2D899eCC914d704FeaAE33ac1bF36277DaD1"
+	lensAddress      = "0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3"
 
 	// wethV3Pad is the WETH-lane Smart Launch V3 pad. V3 is deliberately out of
 	// the configured pad list -- see TestV3Pad_ScopeDecision.
@@ -209,4 +213,39 @@ func (ts *PoolTrackerTestSuite) TestQuoteMatchesLens() {
 		ts.Require().Zero(res.TokenAmountOut.Amount.Cmp(lens.TokensOut),
 			"simulator disagrees with the lens at amountIn=%s", amountIn)
 	}
+}
+
+// TestSnapshotBlockDomain guards the assumption GetNewPoolState now rests on:
+// that the configured multicall reports its block in the eth_blockNumber
+// domain. Robinhood Chain also exposes a block.number opcode counter that runs
+// roughly half as fast, and a block tag from that domain is rejected by
+// eth_call, so a client wired to Multicall3 would break every pinned read here.
+// One cheap assertion beats rediscovering that from a "pool marked untradeable"
+// log line.
+func (ts *PoolTrackerTestSuite) TestSnapshotBlockDomain() {
+	t := ts.T()
+	ctx := context.Background()
+
+	client := ethrpc.New(robinhoodRPCURL()).
+		SetMulticallContract(common.HexToAddress(multicallAddress))
+
+	var launchCount *big.Int
+	req := client.NewRequest().SetContext(ctx)
+	req.AddCall(&ethrpc.Call{ABI: PadABI, Target: wethPad, Method: methodLaunchCount}, []any{&launchCount})
+	resp, err := req.Aggregate()
+	ts.Require().NoError(err)
+	ts.Require().NotNil(resp.BlockNumber, "aggregate must report a block to pin to")
+
+	head, err := client.GetBlockNumber(ctx)
+	ts.Require().NoError(err)
+
+	agg := resp.BlockNumber.Uint64()
+	t.Logf("aggregate block=%d  eth_blockNumber=%d  delta=%d", agg, head, int64(agg)-int64(head))
+
+	// The two are read a moment apart, so allow drift -- but the wrong domain is
+	// off by millions, not by a handful of blocks.
+	const maxDrift = 5000
+	ts.Require().InDeltaf(float64(head), float64(agg), maxDrift,
+		"multicall %s reports block %d while eth_blockNumber is %d: this client is on the "+
+			"block.number opcode domain and pinned reads will fail", multicallAddress, agg, head)
 }

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -248,4 +249,63 @@ func (ts *PoolTrackerTestSuite) TestSnapshotBlockDomain() {
 	ts.Require().InDeltaf(float64(head), float64(agg), maxDrift,
 		"multicall %s reports block %d while eth_blockNumber is %d: this client is on the "+
 			"block.number opcode domain and pinned reads will fail", multicallAddress, agg, head)
+}
+
+// entity.Pool.Timestamp is the clock pool-service ages pools out on, so the
+// tracker must move it only when the launch actually traded -- otherwise every
+// interval refresh looks like activity and nothing ever archives.
+func TestPersist_TimestampTracksTradeCounter(t *testing.T) {
+	t.Parallel()
+
+	const was = int64(1787720000)
+	tracker := &PoolTracker{}
+	tradeable := StaticExtra{OpenEnded: true}
+
+	snapshot := func(buyCount uint64) Extra {
+		return Extra{
+			VQuote:   uint256.NewInt(1e18),
+			VToken:   uint256.NewInt(2e18),
+			Armed:    true,
+			BuyCount: buyCount,
+		}
+	}
+	stored := func(e Extra, timestamp int64) entity.Pool {
+		extraBytes, err := json.Marshal(e)
+		require.NoError(t, err)
+		return entity.Pool{Extra: string(extraBytes), Timestamp: timestamp}
+	}
+
+	t.Run("counter unchanged leaves the timestamp alone", func(t *testing.T) {
+		got := tracker.persist(stored(snapshot(7), was), snapshot(7), tradeable, big.NewInt(100))
+		require.Equal(t, was, got.Timestamp)
+	})
+
+	t.Run("counter moved bumps the timestamp", func(t *testing.T) {
+		got := tracker.persist(stored(snapshot(7), was), snapshot(8), tradeable, big.NewInt(100))
+		require.Greater(t, got.Timestamp, was)
+	})
+
+	t.Run("first sight starts the clock", func(t *testing.T) {
+		// Upstream reads timestamp 0 as "always active", so a launch that has
+		// never traded would otherwise stay resident forever.
+		got := tracker.persist(entity.Pool{Extra: "{}"}, snapshot(0), tradeable, big.NewInt(100))
+		require.Greater(t, got.Timestamp, was)
+	})
+
+	t.Run("terminal parks even on a fresh trade", func(t *testing.T) {
+		bonded := snapshot(9)
+		bonded.Bonded = true
+		got := tracker.persist(stored(snapshot(7), was), bonded, tradeable, big.NewInt(100))
+		require.EqualValues(t, 1, got.Timestamp)
+		require.Equal(t, entity.PoolReserves{"0", "0"}, got.Reserves)
+	})
+
+	t.Run("counter and fetch time are persisted", func(t *testing.T) {
+		got := tracker.persist(stored(snapshot(7), was), snapshot(8), tradeable, big.NewInt(100))
+
+		var extra Extra
+		require.NoError(t, json.Unmarshal([]byte(got.Extra), &extra))
+		require.EqualValues(t, 8, extra.BuyCount)
+		require.EqualValues(t, 100, got.BlockNumber)
+	})
 }

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/pool_tracker_test.go
@@ -38,9 +38,9 @@ func robinhoodRPCURL() string {
 	return defaultRobinhoodRPCURL
 }
 
-// testPoolJSON is the reference launch used throughout output/explorer.md
-// and output/math.md: WETH V2 pad, on-chain launch id 176. Reserves start
-// at "0","0" -- this is exactly what dex-scaffold's discovery leaves behind
+// testPoolJSON is this package's reference launch: WETH V2 pad, on-chain
+// launch id 176. Reserves start
+// at "0","0" -- this is exactly what discovery leaves behind
 // (AGENTS.md: don't set reserves at discovery time); GetNewPoolState fills
 // the real values.
 const testPoolJSON = `{

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
@@ -10,7 +10,7 @@ import (
 //
 // LaunchID is the ON-CHAIN launch id (StonkSafeLaunchpadV2.getLaunch's `id`
 // param), never the off-chain floor API's synthetic composite id -- see
-// output/explorer.md's "Corrections vs the PDF" #2.
+// the vendor PDF's own top-level id field, which is a frontend composite.
 type StaticExtra struct {
 	Pad           string `json:"pad"`
 	Lens          string `json:"lens"`
@@ -49,7 +49,6 @@ type StaticExtra struct {
 	// already exceeds the cap can never execute, whoever the recipient is.
 	// A trade under that bound may still revert if the recipient already
 	// holds a position on this launch -- see the routed-recipient caveat in
-	// output/verify.md.
 	MaxBuyPpm uint32 `json:"maxBuyPpm"`
 
 	// GradMcapUsd8 is the buy-side graduation gate compared against
@@ -57,7 +56,7 @@ type StaticExtra struct {
 	// comparison faithfully requires the oracle wiring below -- exactly one
 	// of QuoteUsdFeed / TwapPool is set, per the pad's constructor invariant
 	// (confirmed live: WETH/GME use QuoteUsdFeed direct feeds, STONK/USDG
-	// use TwapPool -- see output/math.md).
+	// use TwapPool).
 	GradMcapUsd8 uint64 `json:"gradMcapUsd8"`
 	LoadedSupply string `json:"loadedSupply"` // uint256, decimal string
 
@@ -117,7 +116,7 @@ type SwapInfo struct {
 	Graduates bool `json:"graduates"`
 }
 
-// PoolMeta is what dex-aggregator-encoding decodes from swap.PoolExtra to
+// PoolMeta is what the aggregator's encoder decodes from the pool extra to
 // build buy() calldata -- it needs the PAD contract address (the actual
 // callable target; entity.Pool.Address/StaticExtra.Pad is a synthetic
 // "pad#launchId" composite key, not itself a callable contract) and the
@@ -127,12 +126,10 @@ type PoolMeta struct {
 	LaunchID string `json:"launchId"`
 
 	// ApprovalAddress duplicates Pad under the shared pool.ApprovalInfo JSON
-	// contract -- aggregator-encoding's GetAddressToApproveMax decodes
-	// swap.PoolExtra into pool.ApprovalInfo{ApprovalAddress} for selectors
-	// registered with a custom (non-pool) approval target. See
-	// context/stonkbrokers/output/router-service.md. The executor must
-	// approve the PAD (not swap.Pool, which is the synthetic "pad#launchId"
-	// composite key) to spend its quote-asset balance before calling buy().
+	// contract, which the encoder reads to resolve a custom (non-pool)
+	// approval target. The executor must approve the PAD -- not the pool
+	// address, which is the synthetic "pad#launchId" composite key -- to
+	// spend its quote-asset balance before calling buy().
 	ApprovalAddress string `json:"approvalAddress"`
 	BlockNumber     uint64 `json:"blockNumber"`
 }

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
@@ -1,0 +1,138 @@
+package stonkbrokersfunv2
+
+import (
+	"github.com/holiman/uint256"
+)
+
+// StaticExtra holds per-launch data set once at arm/create and never
+// mutated again. One IPoolSimulator instance == one (pad, launchId) launch;
+// entity.Pool.Tokens is [token0=project token, token1=pad's quote asset].
+//
+// LaunchID is the ON-CHAIN launch id (StonkSafeLaunchpadV2.getLaunch's `id`
+// param), never the off-chain floor API's synthetic composite id -- see
+// output/explorer.md's "Corrections vs the PDF" #2.
+type StaticExtra struct {
+	Pad           string `json:"pad"`
+	Lens          string `json:"lens"`
+	LaunchID      string `json:"launchId"` // uint256, decimal string
+	IsWethLane    bool   `json:"isWethLane"`
+	QuoteDecimals uint8  `json:"quoteDecimals"`
+
+	// Tax-decay schedule (immutable once armed). currentTaxBps == BufferTaxBps
+	// while now < startTime+BufferSecs, then linearly decays
+	// DecayPerMinuteBps per minute elapsed past the buffer, floored at 0 (or
+	// PostTaxBps if OpenEnded) once decay reaches StartTaxBps. BufferTaxBps is
+	// the pad-wide BUFFER_TAX_BPS() constant (same for every launch on a pad).
+	BufferTaxBps      uint16 `json:"bufferTaxBps"`
+	StartTaxBps       uint16 `json:"startTaxBps"`
+	DecayPerMinuteBps uint16 `json:"decayPerMinuteBps"`
+	BufferSecs        uint32 `json:"bufferSecs"`
+	WindowSecs        uint32 `json:"windowSecs"`
+	StartTime         uint64 `json:"startTime"`
+	Deadline          uint64 `json:"deadline"`
+	OpenEnded         bool   `json:"openEnded"`
+	PostTaxBps        uint16 `json:"postTaxBps"`
+
+	// EoaOnly mirrors LaunchModes.eoaOnly. _tradeGates reverts NotEoa() when
+	// it is set and msg.sender != tx.origin. An aggregator swap ALWAYS calls
+	// buy() from the executor contract, so msg.sender can never equal
+	// tx.origin on this path -- an eoaOnly launch is permanently unroutable
+	// and CalcAmountOut must refuse it outright rather than quote a trade
+	// that is guaranteed to revert. 74 of 283 live launches set this.
+	EoaOnly bool `json:"eoaOnly"`
+
+	// MaxBuyPpm mirrors LaunchModes.maxBuyPpm. _buy credits
+	// boughtOf[id][recipient] += tokensOut and THEN reverts BuyCapExceeded()
+	// if that cumulative total passes loadedSupply*maxBuyPpm/1e6. The
+	// simulator cannot see the recipient's existing boughtOf balance, so it
+	// enforces the single-trade upper bound only: a quote whose own tokensOut
+	// already exceeds the cap can never execute, whoever the recipient is.
+	// A trade under that bound may still revert if the recipient already
+	// holds a position on this launch -- see the routed-recipient caveat in
+	// output/verify.md.
+	MaxBuyPpm uint32 `json:"maxBuyPpm"`
+
+	// GradMcapUsd8 is the buy-side graduation gate compared against
+	// mcapUsd8(id) computed with the POST-trade reserves. Reading that
+	// comparison faithfully requires the oracle wiring below -- exactly one
+	// of QuoteUsdFeed / TwapPool is set, per the pad's constructor invariant
+	// (confirmed live: WETH/GME use QuoteUsdFeed direct feeds, STONK/USDG
+	// use TwapPool -- see output/math.md).
+	GradMcapUsd8 uint64 `json:"gradMcapUsd8"`
+	LoadedSupply string `json:"loadedSupply"` // uint256, decimal string
+
+	QuoteUsdFeed   string `json:"quoteUsdFeed,omitempty"`
+	TwapPool       string `json:"twapPool,omitempty"`
+	TwapWindowSecs uint32 `json:"twapWindowSecs,omitempty"`
+	EthUsdFeed     string `json:"ethUsdFeed,omitempty"`
+	QuoteIsToken0  bool   `json:"quoteIsToken0,omitempty"`
+}
+
+// OracleReading is a raw Chainlink AggregatorV3 latestRoundData snapshot,
+// used both for direct-feed lanes (quote itself) and for the ETH/USD leg of
+// TWAP-mode lanes.
+type OracleReading struct {
+	Answer    *uint256.Int `json:"answer"` // raw int256 answer; tracker validates > 0 before storing
+	Decimals  uint8        `json:"decimals"`
+	UpdatedAt uint64       `json:"updatedAt"`
+	Ok        bool         `json:"ok"` // false if latestRoundData() reverted or answer <= 0 at fetch time
+}
+
+// TwapReading is a raw Uniswap-v3-style observe() snapshot for TWAP-mode
+// lanes (STONK, USDG), plus the ETH/USD leg needed to convert the
+// quote/WETH tick average into a USD mark.
+type TwapReading struct {
+	TickCumulativeOld int64         `json:"tickCumulativeOld"` // observe([window, 0])[0]
+	TickCumulativeNow int64         `json:"tickCumulativeNow"` // observe([window, 0])[1]
+	EthUsd            OracleReading `json:"ethUsd"`
+	Ok                bool          `json:"ok"` // false if observe() reverted at fetch time
+}
+
+// Extra is rewritten end-to-end on each tracker refresh.
+type Extra struct {
+	VQuote *uint256.Int `json:"vQuote"`
+	VToken *uint256.Int `json:"vToken"`
+
+	SellsEnabled bool `json:"sellsEnabled"`
+	Armed        bool `json:"armed"`
+	Graduated    bool `json:"graduated"`
+	Bonded       bool `json:"bonded"`
+	Aborted      bool `json:"aborted"`
+
+	// Exactly one of DirectFeed / Twap is populated, matching
+	// StaticExtra.QuoteUsdFeed / TwapPool. Backs the buy-side ErrStalePrice
+	// enforcement -- ported from SafeLaunchTwapLib (docs/source/.../SafeLaunchTwapLib.sol).
+	DirectFeed *OracleReading `json:"directFeed,omitempty"`
+	Twap       *TwapReading   `json:"twap,omitempty"`
+}
+
+// SwapInfo carries the post-trade virtual reserves for UpdateBalance to
+// apply -- CalcAmountOut must not mutate pool state itself.
+type SwapInfo struct {
+	NewVQuote *uint256.Int `json:"newVQuote"`
+	NewVToken *uint256.Int `json:"newVToken"`
+	// Graduates is true when this trade's post-trade mcap crosses
+	// GradMcapUsd8 -- mirrors StonkSafeLaunchpadV2._buy's `if (mcap >=
+	// l.gradMcapUsd8) _close(id, l);`. UpdateBalance sets Extra.Graduated.
+	Graduates bool `json:"graduates"`
+}
+
+// PoolMeta is what dex-aggregator-encoding decodes from swap.PoolExtra to
+// build buy() calldata -- it needs the PAD contract address (the actual
+// callable target; entity.Pool.Address/StaticExtra.Pad is a synthetic
+// "pad#launchId" composite key, not itself a callable contract) and the
+// on-chain LaunchID to pass as buy()'s id param.
+type PoolMeta struct {
+	Pad      string `json:"pad"`
+	LaunchID string `json:"launchId"`
+
+	// ApprovalAddress duplicates Pad under the shared pool.ApprovalInfo JSON
+	// contract -- aggregator-encoding's GetAddressToApproveMax decodes
+	// swap.PoolExtra into pool.ApprovalInfo{ApprovalAddress} for selectors
+	// registered with a custom (non-pool) approval target. See
+	// context/stonkbrokers/output/router-service.md. The executor must
+	// approve the PAD (not swap.Pool, which is the synthetic "pad#launchId"
+	// composite key) to spend its quote-asset balance before calling buy().
+	ApprovalAddress string `json:"approvalAddress"`
+	BlockNumber     uint64 `json:"blockNumber"`
+}

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
@@ -119,7 +119,7 @@ type SwapInfo struct {
 // PoolMeta is what the aggregator's encoder decodes from the pool extra to
 // build buy() calldata -- it needs the PAD contract address (the actual
 // callable target; entity.Pool.Address/StaticExtra.Pad is a synthetic
-// "pad#launchId" composite key, not itself a callable contract) and the
+// "pad_launchId" composite key, not itself a callable contract) and the
 // on-chain LaunchID to pass as buy()'s id param.
 type PoolMeta struct {
 	Pad      string `json:"pad"`
@@ -128,7 +128,7 @@ type PoolMeta struct {
 	// ApprovalAddress duplicates Pad under the shared pool.ApprovalInfo JSON
 	// contract, which the encoder reads to resolve a custom (non-pool)
 	// approval target. The executor must approve the PAD -- not the pool
-	// address, which is the synthetic "pad#launchId" composite key -- to
+	// address, which is the synthetic "pad_launchId" composite key -- to
 	// spend its quote-asset balance before calling buy().
 	ApprovalAddress string `json:"approvalAddress"`
 	BlockNumber     uint64 `json:"blockNumber"`

--- a/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
+++ b/pkg/liquidity-source/stonkbrokers-fun/v2/type.go
@@ -98,6 +98,15 @@ type Extra struct {
 	Bonded       bool `json:"bonded"`
 	Aborted      bool `json:"aborted"`
 
+	// BuyCount is the launch's on-chain trade counter. The pad increments it
+	// on buys AND sells alike (the name is the contract's), never decrements
+	// it, so a change between two refreshes is proof the curve moved -- which
+	// is what entity.Pool.Timestamp, the clock pool-service archives on, is
+	// bumped from. FetchedAt is when this snapshot was read, kept separately
+	// so refresh freshness stays legible once Timestamp no longer tracks it.
+	BuyCount  uint64 `json:"buyCount"`
+	FetchedAt int64  `json:"fetchedAt"`
+
 	// Exactly one of DirectFeed / Twap is populated, matching
 	// StaticExtra.QuoteUsdFeed / TwapPool. Backs the buy-side ErrStalePrice
 	// enforcement -- ported from SafeLaunchTwapLib (docs/source/.../SafeLaunchTwapLib.sol).

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -160,6 +160,7 @@ import (
 	pkg_liquiditysource_someswap_v2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v2"
 	pkg_liquiditysource_stabull "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/stabull"
 	pkg_liquiditysource_staderethx "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/staderethx"
+	pkg_liquiditysource_stonkbrokersfun_v2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/stonkbrokers-fun/v2"
 	pkg_liquiditysource_swell_rsweth "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/swell/rsweth"
 	pkg_liquiditysource_swell_sweth "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/swell/sweth"
 	pkg_liquiditysource_syncswapv2_aqua "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/aqua"
@@ -411,6 +412,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_someswap_v2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_stabull.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_staderethx.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_stonkbrokersfun_v2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_swell_rsweth.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_swell_sweth.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_syncswapv2_aqua.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -157,6 +157,7 @@ import (
 	someswapv1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v1"
 	someswapv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v2"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/staderethx"
+	stonkbrokersfunv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/stonkbrokers-fun/v2"
 	swapxv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/swap-x-v2"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/swell/rsweth"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/swell/sweth"
@@ -472,6 +473,7 @@ type Types struct {
 	MetronomeSwap              string
 	FluxProp                   string
 	ParityProp                 string
+	StonkbrokersFunV2          string
 }
 
 var (
@@ -716,5 +718,6 @@ var (
 		MetronomeSwap:              metronomeswap.DexType,
 		FluxProp:                   valueobject.ExchangeFluxProp,
 		ParityProp:                 parityprop.DexType,
+		StonkbrokersFunV2:          stonkbrokersfunv2.DexType,
 	}
 )

--- a/pkg/util/abi/parse.go
+++ b/pkg/util/abi/parse.go
@@ -50,6 +50,16 @@ func MustABIError(parsed abi.ABI, name string) abi.Error {
 	return abiErr
 }
 
+// MustABIEvent returns the named event, panicking if the ABI has no such name.
+func MustABIEvent(parsed abi.ABI, name string) abi.Event {
+	event, ok := parsed.Events[name]
+	if !ok {
+		panic(missingABIEntry("event", name, eventNames(parsed)))
+	}
+
+	return event
+}
+
 // missingABIEntry lists what the ABI does have, since the usual cause is a
 // rename or reading one contract's name against another contract's ABI.
 func missingABIEntry(kind, name string, have []string) string {
@@ -70,6 +80,15 @@ func methodNames(parsed abi.ABI) []string {
 func errorNames(parsed abi.ABI) []string {
 	names := make([]string, 0, len(parsed.Errors))
 	for name := range parsed.Errors {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+func eventNames(parsed abi.ABI) []string {
+	names := make([]string, 0, len(parsed.Events))
+	for name := range parsed.Events {
 		names = append(names, name)
 	}
 

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -264,6 +264,7 @@ const (
 	ExchangeSPendle                     = "spendle"
 	ExchangeSpookySwap                  = "spookyswap"
 	ExchangeStaderETHx                  = "staderethx"
+	ExchangeStonkbrokersFunV2           = "stonkbrokers-fun-v2"
 	ExchangeSuperlendV3                 = "superlend-v3"
 	ExchangeSushiSwap                   = "sushiswap"
 	ExchangeSwaapV2                     = "swaap-v2"


### PR DESCRIPTION
## Background

**StonkBrokers Smart Launch V2** is a launchpad on **Robinhood Chain** (chainId `4663`). Creators mint a token, the pad seeds a bonding curve, and the curve trades until a graduation market cap closes it and the raise bonds into a locked CL pool.

There is no factory to discover and no creation event to follow: 8 pads are statically deployed, one per quote lane, each hosting many independent launches keyed by a per-pad integer `launchId`.

| Lane | Pad |
|---|---|
| WETH | [`0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f`](https://robinhoodchain.blockscout.com/address/0xFCd61B25BbF3AbD6cf0070D6328E351cc30EEC9f) |
| STONK | [`0x8f6782c5aa37804d08a9b7bf3984ff3245fd6cd4`](https://robinhoodchain.blockscout.com/address/0x8f6782c5aa37804d08a9b7bf3984ff3245fd6cd4) |
| USDG | [`0xd4f20033586977a2511f4a2db4af7c79a340d70a`](https://robinhoodchain.blockscout.com/address/0xd4f20033586977a2511f4a2db4af7c79a340d70a) |
| GME | [`0x4b9dcd6ccfaef0f6d23065dd78e79d5e20ec8cfd`](https://robinhoodchain.blockscout.com/address/0x4b9dcd6ccfaef0f6d23065dd78e79d5e20ec8cfd) |
| NVDA | [`0xee96d955d5634813374ece4c74f2c0ff71b1f9fb`](https://robinhoodchain.blockscout.com/address/0xee96d955d5634813374ece4c74f2c0ff71b1f9fb) |
| AAPL | [`0xb0453a81cbf963903409fff18ad92941e1c7a864`](https://robinhoodchain.blockscout.com/address/0xb0453a81cbf963903409fff18ad92941e1c7a864) |
| SPCX | [`0x0c3b4eded41696eff0ed70841f132b519d81c947`](https://robinhoodchain.blockscout.com/address/0x0c3b4eded41696eff0ed70841f132b519d81c947) |
| USO | [`0xdb3c81c841ff88db6cdfbddb0ee049d162a6053b`](https://robinhoodchain.blockscout.com/address/0xdb3c81c841ff88db6cdfbddb0ee049d162a6053b) |

Shared read/quote lens `SafeLaunchLensV2`: [`0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3`](https://robinhoodchain.blockscout.com/address/0x25b5Df581f4b2Ed450203f375ad8A28b17F115B3). All pads and the lens are verified on Blockscout (solc 0.8.24, cancun, optimizer 200 runs).

`entity.Pool.Address` is a synthetic **`pad#launchId`** composite key — launch ids are per-pad, so the key is not a callable contract. The real pad address travels in `StaticExtra` / `PoolMeta`, the same shape Carbon uses.

## Pricing

Constant product over **virtual** reserves, isolated per launch:

```
tax       = quoteIn * currentTaxBps / 10_000
net       = quoteIn - tax
tokensOut = net * vToken / (vQuote + net)
vQuote   += net ;  vToken -= tokensOut
```

`currentTaxBps` is a flat buffer tax while `now < startTime + bufferSecs`, then decays `decayPerMinuteBps` per minute from `startTaxBps`, flooring at `postTaxBps` (open-ended launches) or 0.

After every buy the pad calls `mcapUsd8(id)` **unconditionally** to decide the graduation close, and that read is strict — so a stale quote-asset oracle reverts the entire buy, not just the graduation decision. The simulator reproduces that. Lanes quote either off a Chainlink-style direct feed or a Uniswap-v3-style TWAP; both paths are ported.

## Scope: buy only

`sell()` caps `tokensIn` to `boughtOf[id][account]`, and `setOperator` hardcodes the grant to `msg.sender` with no permit/signature variant:

```solidity
function setOperator(uint256 id, address operator, bool approved) external {
    if (operator == address(0) || operator == msg.sender) revert BadParam();
    operatorOf[msg.sender][id][operator] = approved;
```

A stateless aggregator route holds no `boughtOf` credit and cannot grant itself an operator approval in the same transaction, so sell is unreachable. `CalcAmountOut` returns `ErrSellNotSupported` for that direction. The vendor docs agree: "Transferred bags cannot be sold through the pad."

## Guards — no quote that reverts on-chain

Every `revert` reachable from `buy() → _launch → _tradeGates → _buy → _splitTax` was enumerated, and each was confirmed by an actual reverting call on a fork.

| Revert | Guard |
|---|---|
| `NotArmed` / `AbortedLaunch` / `AlreadyGraduated` | `ErrPoolNotArmed` / `ErrPoolAborted` / `ErrPoolGraduated` + `ErrPoolBonded` |
| `WindowClosed` | `ErrWindowClosed` |
| `ZeroTrade` (quoteIn 0, net 0, tokensOut 0) | `ErrZeroTrade` |
| `SlippageExceeded` | `ErrSlippageExceeded` |
| `StalePrice` | `ErrStalePrice` / `ErrBadOracleAnswer` |
| **`NotEoa`** | **`ErrEoaOnly`** |
| **`BuyCapExceeded`** | **`ErrBuyCapExceeded`** |

Two deserve attention:

**`eoaOnly` — 74 of 283 live launches (26%).** `_tradeGates` reverts `NotEoa()` when `eoaOnly && msg.sender != tx.origin`. An aggregator swap always calls `buy()` from an executor contract, so those launches are *permanently* unroutable. The flag was read during discovery but never persisted, so they quoted fine and would have reverted on execution.

**`maxBuyPpm` — 11 of 283.** `_buy` credits `boughtOf[id][recipient] += tokensOut` and *then* reverts past `loadedSupply * maxBuyPpm / 1e6`. Neither the simulator nor the pad's own `quoteBuy` applied it, so both quoted trades that cannot execute. Enforced here as a **single-trade upper bound** — see Known limitations for what that bound does not cover.

Not guarded, deliberately: `FeeOnTransferToken` (the quote asset is fixed per pad and all 8 lanes are plain ERC20s; not detectable from state) and transfer reverts inside `_splitTax` (third-party contract behaviour).

## Two chain-level quirks worth knowing

**Robinhood Chain has two independent block-number domains.** The `block.number` opcode and `eth_blockNumber` are separate counters:

```
eth_blockNumber                                    → 46364724
Multicall3.getBlockNumber() (block.number opcode)  → 25837525
eth_call pinned to the opcode-domain number        → "metadata is not found"
```

Multicall-reported block numbers therefore cannot be used to pin dependent `eth_call`s, which silently broke every oracle read. The tracker takes `eth_blockNumber` and pins to that.

Related, and relevant to anyone else integrating on this chain: the public RPC prunes state after roughly 6–8k blocks while the chain produces a block every **~0.101s**, so a pinned refresh has a **~10 minute** shelf life. A slow or rate-limited refresh pass silently degrades pools to untradeable. An archive endpoint removes the problem.

**go-ethereum single-tuple unpacking.** `getLaunch` and `modesOf` each return exactly one `tuple` output, so `Arguments.isTuple()` (`len(args) > 1`) is false and unpacking takes the `copyAtomic` path, which assigns into **field 0** of a struct destination rather than the struct itself. Unpacking straight into `launchRaw` wrote the whole tuple into `launchRaw.Token` (`[20]byte`) and panicked in `abi.setArray`. Fixed with one level of wrapper struct.

## Verification

**Quote correctness** — 32 of 32 quotes matched the on-chain lens **bit-for-bit**, across 7 pools, 3 quote assets, and amounts spanning 1e-06 → 100:

| Case | tax bps | vs lens |
|---|---|---|
| flat 100bps (#176) | 100 | EXACT ×5 |
| flat 200bps (#150) | 200 | EXACT ×5 |
| decay from 9900 (#163) | 100 | EXACT ×5 |
| decay from 1000 (#143) | 100 | EXACT ×5 |
| maxBuyPpm 20000 (#174) | 100 | EXACT ×5 |
| maxBuyPpm 42069 (#120) | 100 | EXACT ×5 |
| GME lane, deep (#24) | 100 | EXACT ×7 |

bps was derived two independent ways — read from the lens, and inverted out of the routed amount via `net = out*vQuote/(vToken-out)` — and the two agreed on every row.

**State transition** — a real `buyEth` executed on a fork at block 46382449 agreed with the simulator on all three quantities:

| | Simulator | Chain |
|---|---|---|
| tokensOut | `23534122942428164868379888` | ERC20 Transfer, identical |
| post-trade vQuote | `420249618506110198` | `getLaunch(176)`, identical |
| post-trade vToken | `975476603161746774578724101` | `getLaunch(176)`, identical |

A full aggregator-routed swap on a fork delivered `23534122942428164868379887`, matching its build quote exactly. `defaultGas` is set from that transaction's measured 405,466 gas rather than estimated.

**Boundaries** — every guard confirmed by a real reverting call:

| Case | On-chain |
|---|---|
| maxBuyPpm 2% (#174), 0.01 | `BuyCapExceeded` |
| maxBuyPpm 4.2069% (#120), 0.1 | `BuyCapExceeded` |
| not armed / aborted | `NotArmed` |
| bonded | `AlreadyGraduated` |
| unknown launch id | `UnknownLaunch` |
| zero amount | `ZeroTrade` |
| eoaOnly (#21), **EOA** sender | succeeds |
| eoaOnly (#21), **contract** sender | `NotEoa` |

**Amounts** on an uncapped launch, 1 wei → 100 ETH: monotonic and correctly asymptotic (100 ETH returns only ~4% more than 10 ETH as the curve approaches `vToken`), and a 1-wei buy still produces non-zero output, so the `ZeroTrade` floor is not hit prematurely.

Note that `eth_call` **cannot** test `eoaOnly`: it sets `tx.origin` to the `from` address, so `msg.sender == tx.origin` holds even when `from` is a contract, and an eoaOnly launch wrongly succeeds. The gate only appears in a genuine nested contract-to-contract call.

Suite: **36 tests passing**, including live integration suites. Live tests dial `STONKBROKERS_RPC_URL` when set and fall back to the public RPC, since the public endpoint rate-limits aggressively.

## Corrections to the vendor documentation

1. `launchIdOfToken` is a **single-argument** call on each **pad** (selector `0xa27d865a`), not a two-argument call on the lens — the lens ABI has 7 functions and does not include it.
2. The floor API's top-level `id` (e.g. `18000176`) is a frontend-synthetic composite; the real on-chain `launchId` is nested at `row.lane.launchId`.

## Smart Launch V3 deliberately excluded

The vendor docs also list 8 **V3** pads for external-token (BYO) launches. They share the same ABI and the same lens, and `externalToken` is written at `createLaunch`, emitted in `LaunchCreated`, and read nowhere else in the pad or in any of its four linked libraries — so it never branches the buy path and adding V3 would be a config-only change.

It is not worth making: **exactly one launch exists across all 8 V3 pads**, and it is `eoaOnly`, i.e. unroutable. `TestV3Pad_ScopeDecision` records the decision and re-checks it against the chain, so a routable V3 launch appearing later will surface.

## Known limitations

- **The `maxBuyPpm` bound is per-trade, not cumulative.** The on-chain check sums `boughtOf[id][recipient]` across a recipient's whole history, which a stateless quote cannot see, so a trade under the bound can still revert if that recipient already holds a position on the launch.
- **`eoaOnly` does not backfill.** Discovery dedupes against already-indexed pools, so the flag only lands for newly discovered launches; an existing index needs clearing for it to apply retroactively.
- **The decay ramp is unexercised live.** Every launch sampled had already passed its window, so tax had floored at `postTaxBps`; the ramp is covered by unit tests only.
- **TWAP lanes.** 59 pools quote off a TWAP. `observe` works at recent blocks; the failures observed during testing were the pinned-block pruning issue described above, not the TWAP port.
