### PR TITLE
fix(lint): drop redundant embedded-field selectors in flowstate-c1

### DIFF
--- a/pkg/liquidity-source/flowstate-c1/pool_simulator.go
+++ b/pkg/liquidity-source/flowstate-c1/pool_simulator.go
@@ -131,9 +131,11 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 
 func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
 	return MetaInfo{
-		Market:      s.StaticExtra.Market,
+		Market: s.Market,
+		// Pool keeps the qualifier: s.Pool resolves to the embedded pool.Pool,
+		// not StaticExtra.Pool.
 		Pool:        s.StaticExtra.Pool,
-		QuoteAsset:  s.StaticExtra.QuoteAsset,
+		QuoteAsset:  s.QuoteAsset,
 		BlockNumber: s.Info.BlockNumber,
 	}
 }


### PR DESCRIPTION
main is currently red on `ci / lint`, which fails every open PR against it.

```
pkg/liquidity-source/flowstate-c1/pool_simulator.go:134:18: QF1008: could remove embedded field "StaticExtra" from selector (staticcheck)
pkg/liquidity-source/flowstate-c1/pool_simulator.go:136:18: QF1008: could remove embedded field "StaticExtra" from selector (staticcheck)
```

Introduced by #1631. `PoolSimulator` embeds both `pool.Pool` and `StaticExtra`, so `s.StaticExtra.Market` and `s.StaticExtra.QuoteAsset` can drop the qualifier.

`s.StaticExtra.Pool` is left as-is on purpose — `s.Pool` would resolve to the embedded `pool.Pool` instead, which is exactly why staticcheck flags only the other two. Added an inline comment so it is not "tidied up" later.

Verified locally with golangci-lint (0 issues) and `go test ./pkg/liquidity-source/flowstate-c1/...` passing.