### PR TITLE
feat(umbrae): update DLMM to the V2 stack (Base, 2026-08-24 redeploy)

### DIFF
--- a/pkg/liquidity-source/umbrae/dlmm/abi/LBFactory.json
+++ b/pkg/liquidity-source/umbrae/dlmm/abi/LBFactory.json
@@ -1,16 +1,58 @@
 [
-  { "type": "function", "name": "allPairsLength", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "uint256" }] },
   {
-    "type": "function", "name": "allPairs", "stateMutability": "view",
-    "inputs": [{ "name": "index", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "address" }]
+    "type": "function",
+    "name": "allPairs",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    "type": "function", "name": "getVariableFeeCap", "stateMutability": "view",
-    "inputs": [
-      { "name": "binStep", "type": "uint16" },
-      { "name": "baseFee", "type": "uint16" }
+    "type": "function",
+    "name": "allPairsLength",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    "outputs": [{ "name": "variableFeeCap", "type": "uint16" }]
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getVariableFeeCap",
+    "inputs": [
+      {
+        "name": "binStep",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "baseFee",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "variableFeeCap",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
   }
 ]

--- a/pkg/liquidity-source/umbrae/dlmm/abi/LBPair.json
+++ b/pkg/liquidity-source/umbrae/dlmm/abi/LBPair.json
@@ -1,95 +1,170 @@
 [
-  { "type": "function", "name": "tokenX", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "address" }] },
-  { "type": "function", "name": "tokenY", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "address" }] },
-  { "type": "function", "name": "binStep", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "uint16" }] },
   {
-    "type": "function", "name": "getDecimals", "stateMutability": "view", "inputs": [],
-    "outputs": [
-      { "name": "decimalsX", "type": "uint8" },
-      { "name": "decimalsY", "type": "uint8" }
-    ]
-  },
-  { "type": "function", "name": "getActiveId", "stateMutability": "view", "inputs": [], "outputs": [{ "name": "", "type": "uint24" }] },
-  {
-    "type": "function", "name": "getQuoteState", "stateMutability": "view", "inputs": [],
+    "type": "function",
+    "name": "binStep",
+    "inputs": [],
     "outputs": [
       {
-        "name": "feeParams", "type": "tuple",
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDecimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "decimalsX",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "decimalsY",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getQuoteState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeParams",
+        "type": "tuple",
+        "internalType": "struct FeeHelper.FeeParameters",
         "components": [
-          { "name": "baseFactor", "type": "uint16" },
-          { "name": "filterPeriod", "type": "uint16" },
-          { "name": "decayPeriod", "type": "uint16" },
-          { "name": "reductionFactor", "type": "uint16" },
-          { "name": "variableFeeControl", "type": "uint16" },
-          { "name": "maxVolatilityAccumulator", "type": "uint24" },
-          { "name": "minSwapBps", "type": "uint16" }
+          {
+            "name": "baseFactor",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "filterPeriod",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "decayPeriod",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "reductionFactor",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "variableFeeControl",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "maxVolatilityAccumulator",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "minSwapBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
         ]
       },
-      { "name": "volatilityAccumulator", "type": "uint128" },
-      { "name": "volatilityReference", "type": "uint24" },
-      { "name": "lastVolatilityUpdate", "type": "uint40" },
-      { "name": "scaleX", "type": "uint256" },
-      { "name": "scaleY", "type": "uint256" },
-      { "name": "factory", "type": "address" }
-    ]
+      {
+        "name": "volatilityAccumulator",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "volatilityReference",
+        "type": "uint24",
+        "internalType": "uint24"
+      },
+      {
+        "name": "lastVolatilityUpdate",
+        "type": "uint40",
+        "internalType": "uint40"
+      },
+      {
+        "name": "scaleX",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "scaleY",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "factory",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    "type": "function", "name": "getPairStatistics", "stateMutability": "view", "inputs": [],
-    "outputs": [
-      { "name": "activeId", "type": "uint24" },
-      { "name": "reserveX", "type": "uint128" },
-      { "name": "reserveY", "type": "uint128" },
-      { "name": "protocolFeesX", "type": "uint128" },
-      { "name": "protocolFeesY", "type": "uint128" },
-      { "name": "volatility", "type": "uint128" },
-      { "name": "lastUpdateTimestamp", "type": "uint40" }
-    ]
-  },
-  {
-    "type": "function", "name": "getReserves", "stateMutability": "view", "inputs": [],
-    "outputs": [
-      { "name": "reserveX", "type": "uint128" },
-      { "name": "reserveY", "type": "uint128" }
-    ]
-  },
-  {
-    "type": "function", "name": "getBin", "stateMutability": "view",
-    "inputs": [{ "name": "id", "type": "uint24" }],
-    "outputs": [
-      { "name": "reserveX", "type": "uint128" },
-      { "name": "reserveY", "type": "uint128" }
-    ]
-  },
-  {
-    "type": "function", "name": "getFeeParameters", "stateMutability": "view", "inputs": [],
+    "type": "function",
+    "name": "getReserves",
+    "inputs": [],
     "outputs": [
       {
-        "name": "", "type": "tuple",
-        "components": [
-          { "name": "baseFactor", "type": "uint16" },
-          { "name": "filterPeriod", "type": "uint16" },
-          { "name": "decayPeriod", "type": "uint16" },
-          { "name": "reductionFactor", "type": "uint16" },
-          { "name": "variableFeeControl", "type": "uint16" },
-          { "name": "protocolShare", "type": "uint16" },
-          { "name": "maxVolatilityAccumulator", "type": "uint24" },
-          { "name": "minSwapBps", "type": "uint16" }
-        ]
+        "name": "reserveX",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "reserveY",
+        "type": "uint128",
+        "internalType": "uint128"
       }
-    ]
+    ],
+    "stateMutability": "view"
   },
   {
-    "type": "function", "name": "quoteSwap", "stateMutability": "view",
-    "inputs": [
-      { "name": "swapForY", "type": "bool" },
-      { "name": "amountIn", "type": "uint256" }
-    ],
+    "type": "function",
+    "name": "tokenX",
+    "inputs": [],
     "outputs": [
-      { "name": "amountOut", "type": "uint256" },
-      { "name": "consumedAmountIn", "type": "uint256" },
-      { "name": "finalBinId", "type": "uint24" },
-      { "name": "binsTraversed", "type": "uint256" },
-      { "name": "totalFee", "type": "uint256" }
-    ]
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenY",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   }
 ]

--- a/pkg/liquidity-source/umbrae/dlmm/abi/LBRouter.json
+++ b/pkg/liquidity-source/umbrae/dlmm/abi/LBRouter.json
@@ -1,15 +1,51 @@
 [
   {
-    "type": "function", "name": "swapExactTokensForTokens", "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "swapExactTokensForTokens",
     "inputs": [
-      { "name": "amountIn", "type": "uint256" },
-      { "name": "amountOutMin", "type": "uint256" },
-      { "name": "path", "type": "address[]" },
-      { "name": "binSteps", "type": "uint16[]" },
-      { "name": "pools", "type": "address[]" },
-      { "name": "to", "type": "address" },
-      { "name": "deadline", "type": "uint256" }
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountOutMin",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "path",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "binSteps",
+        "type": "uint16[]",
+        "internalType": "uint16[]"
+      },
+      {
+        "name": "pools",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    "outputs": [{ "name": "amountOut", "type": "uint256" }]
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
   }
 ]

--- a/pkg/liquidity-source/umbrae/dlmm/abi/PairViewer.json
+++ b/pkg/liquidity-source/umbrae/dlmm/abi/PairViewer.json
@@ -1,41 +1,85 @@
 [
   {
-    "type": "function", "name": "quoteSwap", "stateMutability": "view",
+    "type": "function",
+    "name": "getActiveBinsWithReserves",
     "inputs": [
-      { "name": "pair", "type": "address" },
-      { "name": "swapForY", "type": "bool" },
-      { "name": "amountIn", "type": "uint256" }
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
     "outputs": [
-      { "name": "amountOut", "type": "uint256" },
-      { "name": "consumedAmountIn", "type": "uint256" },
-      { "name": "finalBinId", "type": "uint24" },
-      { "name": "binsTraversed", "type": "uint256" },
-      { "name": "totalFee", "type": "uint256" }
-    ]
+      {
+        "name": "binIds",
+        "type": "uint24[]",
+        "internalType": "uint24[]"
+      },
+      {
+        "name": "reservesX",
+        "type": "uint128[]",
+        "internalType": "uint128[]"
+      },
+      {
+        "name": "reservesY",
+        "type": "uint128[]",
+        "internalType": "uint128[]"
+      },
+      {
+        "name": "totalShares",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    "type": "function", "name": "getActiveBinsWithReserves", "stateMutability": "view",
-    "inputs": [{ "name": "pair", "type": "address" }],
-    "outputs": [
-      { "name": "binIds", "type": "uint24[]" },
-      { "name": "reservesX", "type": "uint128[]" },
-      { "name": "reservesY", "type": "uint128[]" },
-      { "name": "totalShares", "type": "uint256[]" }
-    ]
-  },
-  {
-    "type": "function", "name": "getBinsInRange", "stateMutability": "view",
+    "type": "function",
+    "name": "quoteSwap",
     "inputs": [
-      { "name": "pair", "type": "address" },
-      { "name": "startId", "type": "uint24" },
-      { "name": "endId", "type": "uint24" }
+      {
+        "name": "pair",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "swapForY",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
     "outputs": [
-      { "name": "binIds", "type": "uint24[]" },
-      { "name": "reservesX", "type": "uint128[]" },
-      { "name": "reservesY", "type": "uint128[]" },
-      { "name": "totalShares", "type": "uint256[]" }
-    ]
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "consumedAmountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "finalBinId",
+        "type": "uint24",
+        "internalType": "uint24"
+      },
+      {
+        "name": "binsTraversed",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   }
 ]

--- a/pkg/liquidity-source/umbrae/dlmm/constant.go
+++ b/pkg/liquidity-source/umbrae/dlmm/constant.go
@@ -16,21 +16,32 @@ const (
 	// activeBinID is the 1:1 centre bin (2^23) — the price exponent's zero point.
 	activeBinID uint32 = 8388608
 
+	// minActiveBin is SwapCalculator.MIN_ACTIVE_BIN (2^22). A volatilityReference below it means
+	// "unset" — the anchored-volatility window starts fresh at the entry bin.
+	minActiveBin uint32 = 4194304
+
 	// Fee/price precision constants (mirror FeeHelper / BinHelper).
 	basisPoints = 10000
 	maxFeeBps   = 500 // FeeHelper.MAX_FEE — 5% total fee cap
+
+	// Swap movement bound (SwapMovement.isAllowed, V2 #278): a swap may not reach a bin further
+	// than MAX_BIN_ID_DISTANCE ids from the entry bin, nor further than MAX_CUMULATIVE_STEP_BPS
+	// worth of binStep. Execution reverts past the bound, so the simulator must refuse to quote
+	// through it.
+	maxBinIDDistance     uint64 = 2048
+	maxCumulativeStepBps uint64 = 10000
 
 	factoryMethodAllPairs          = "allPairs"
 	factoryMethodAllPairsLength    = "allPairsLength"
 	factoryMethodGetVariableFeeCap = "getVariableFeeCap"
 
-	pairMethodTokenX            = "tokenX"
-	pairMethodTokenY            = "tokenY"
-	pairMethodBinStep           = "binStep"
-	pairMethodGetDecimals       = "getDecimals"
-	pairMethodGetActiveID       = "getActiveId"
-	pairMethodGetQuoteState     = "getQuoteState"
-	pairMethodGetPairStatistics = "getPairStatistics"
+	pairMethodTokenX        = "tokenX"
+	pairMethodTokenY        = "tokenY"
+	pairMethodBinStep       = "binStep"
+	pairMethodGetDecimals   = "getDecimals"
+	pairMethodGetActiveID   = "getActiveId"
+	pairMethodGetQuoteState = "getQuoteState"
+	pairMethodGetReserves   = "getReserves"
 
 	viewerMethodActiveBins = "getActiveBinsWithReserves"
 	viewerMethodQuoteSwap  = "quoteSwap"
@@ -41,5 +52,7 @@ var (
 	ErrInvalidAmountIn       = errors.New("invalid amount in")
 	ErrInsufficientOutput    = errors.New("insufficient output amount")
 	ErrInsufficientLiquidity = errors.New("insufficient liquidity for full swap")
-	ErrInvalidPrice          = errors.New("invalid bin price")
+	ErrSwapMovementExceeded  = errors.New("swap exceeds movement bound from entry bin")
+	ErrPriceNotRepresentable = errors.New("bin price not representable")
+	ErrMathOverflow          = errors.New("math overflow")
 )

--- a/pkg/liquidity-source/umbrae/dlmm/math.go
+++ b/pkg/liquidity-source/umbrae/dlmm/math.go
@@ -17,9 +17,10 @@ func pow10(n uint8) *uint256.Int {
 }
 
 // getNormalizedPriceFromId computes (1 + binStep/10000)^(binId-ACTIVE_BIN) in 1e18 fixed point,
-// mirroring the DEPLOYED BinHelper.getPriceFromId exactly: plain 1e18 exponentiation-by-squaring
-// (base = numerator*1e18/denominator; result = result*base/1e18; base = base*base/1e18), including
-// the saturate-on-overflow guard. (Note: this is NOT the 128.128 algorithm in the stale source.)
+// mirroring the deployed BinHelper.getNormalizedPriceFromId exactly: plain 1e18
+// exponentiation-by-squaring (base = numerator*1e18/denominator; result = result*base/1e18;
+// base = base*base/1e18), including the saturate-on-overflow guard. Sentinels: 0 (underflow) and
+// 2^256-1 (overflow); isNormalizedPriceRepresentable rejects both.
 func getNormalizedPriceFromId(binID uint32, binStep uint16) *uint256.Int {
 	exponent := int64(binID) - int64(activeBinID)
 	if exponent == 0 {
@@ -66,31 +67,73 @@ func mulDiv1e18Capped(a, b *uint256.Int) *uint256.Int {
 	return r.Div(r, e18)
 }
 
-// getPriceFromId returns the bin price in Y native decimals (Y per 1 whole X), mirroring the
-// deployed BinHelper.getPriceFromId.
-func getPriceFromId(binID uint32, binStep uint16, decimalsY uint8) (*uint256.Int, error) {
-	normalized := getNormalizedPriceFromId(binID, binStep)
-	if decimalsY <= 18 {
-		return new(uint256.Int).Div(normalized, pow10(18-decimalsY)), nil
-	}
-	return new(uint256.Int).Mul(normalized, pow10(decimalsY-18)), nil
+// isNormalizedPriceRepresentable mirrors BinHelper.isNormalizedPriceRepresentable: both saturation
+// sentinels fail closed (V2 rejects unrepresentable bins in BOTH swap directions, #126/#121).
+func isNormalizedPriceRepresentable(price *uint256.Int) bool {
+	return !price.IsZero() && price.Cmp(uMaxU) != 0
 }
 
-// calculateDynamicFee mirrors the DEPLOYED FeeHelper.calculateDynamicFee: baseFee + quadratic
-// variable fee (capped at variableFeeCap when nonzero), total capped at MAX_FEE. Returns the fee
-// rate in basis points.
-func calculateDynamicFee(baseFactor, variableFeeControl uint16, volatility *uint256.Int, binStep, variableFeeCap uint16) *uint256.Int {
+// mulDivFloor mirrors SwapCalculator._mulDivFloor: a*(b/d) + (a*(b%d))/d. The intermediates are
+// NOT 512-bit — a uint256 overflow reverts on-chain, so it errors here rather than wrapping.
+func mulDivFloor(a, b, d *uint256.Int) (*uint256.Int, error) {
+	q := new(uint256.Int).Div(b, d)
+	r := new(uint256.Int).Mod(b, d)
+	t1, over := new(uint256.Int).MulOverflow(a, q)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	t2, over := new(uint256.Int).MulOverflow(a, r)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	t2.Div(t2, d)
+	res, over := new(uint256.Int).AddOverflow(t1, t2)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	return res, nil
+}
+
+// mulDivCeil mirrors SwapCalculator._mulDivCeil: a*(b/d) + (a*(b%d) + d - 1)/d, erroring where the
+// checked Solidity arithmetic would revert.
+func mulDivCeil(a, b, d *uint256.Int) (*uint256.Int, error) {
+	q := new(uint256.Int).Div(b, d)
+	r := new(uint256.Int).Mod(b, d)
+	t1, over := new(uint256.Int).MulOverflow(a, q)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	t2, over := new(uint256.Int).MulOverflow(a, r)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	t2, over = t2.AddOverflow(t2, d)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	t2.Sub(t2, uint256.NewInt(1))
+	t2.Div(t2, d)
+	res, over := new(uint256.Int).AddOverflow(t1, t2)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	return res, nil
+}
+
+// calculateDynamicFee mirrors the deployed FeeHelper.calculateDynamicFee: baseFee + quadratic
+// variable fee, total capped at MAX_FEE. The variableFeeCap clamp is UNCONDITIONAL in V2 — a zero
+// cap pins the variable part to zero (#147), it does not mean "no cap". Returns the fee rate in
+// basis points.
+func calculateDynamicFee(baseFactor, variableFeeControl uint16, volatility uint64, binStep, variableFeeCap uint16) *uint256.Int {
 	totalFee := uint256.NewInt(uint64(baseFactor))
 	if variableFeeControl != 0 {
-		prod := new(uint256.Int).Mul(volatility, uint256.NewInt(uint64(binStep)))
+		prod := new(uint256.Int).Mul(uint256.NewInt(volatility), uint256.NewInt(uint64(binStep)))
 		prod.Mul(prod, prod)
 		prod.Mul(prod, uint256.NewInt(uint64(variableFeeControl)))
 		prod.Div(prod, e10)
-		if variableFeeCap > 0 {
-			cap := uint256.NewInt(uint64(variableFeeCap))
-			if prod.Cmp(cap) > 0 {
-				prod = cap
-			}
+		feeCap := uint256.NewInt(uint64(variableFeeCap))
+		if prod.Cmp(feeCap) > 0 {
+			prod = feeCap
 		}
 		totalFee.Add(totalFee, prod)
 	}
@@ -101,8 +144,7 @@ func calculateDynamicFee(baseFactor, variableFeeControl uint16, volatility *uint
 }
 
 // applyVolatilityDecay mirrors FeeHelper.applyVolatilityDecay: linear decay over decayPeriod, with
-// a floor of 1 to avoid premature rounding to 0. Used by the tracker to decay the accumulator to
-// the tracked block.
+// a floor of 1 to avoid premature rounding to 0.
 func applyVolatilityDecay(volatility uint64, timeDelta, decayPeriod uint64) uint64 {
 	if decayPeriod == 0 || timeDelta >= decayPeriod {
 		return 0
@@ -114,52 +156,86 @@ func applyVolatilityDecay(volatility uint64, timeDelta, decayPeriod uint64) uint
 	return decayed
 }
 
-// getFeeAmountFrom mirrors FeeHelper.getFeeAmountFrom: amount * totalFee / (10000 + totalFee).
-func getFeeAmountFrom(amount, totalFee *uint256.Int) *uint256.Int {
-	var num, den uint256.Int
-	num.Mul(amount, totalFee)
-	den.Add(uBP, totalFee)
-	return num.Div(&num, &den)
+// getDecayedVolatility mirrors FeeHelper.getDecayedVolatility: the accumulator holds constant
+// inside the filter window and decays linearly only after it lapses.
+func getDecayedVolatility(volatility, lastUpdate, filterPeriod, decayPeriod, now uint64) uint64 {
+	if now <= lastUpdate {
+		return volatility
+	}
+	delta := now - lastUpdate
+	if delta < filterPeriod {
+		return volatility
+	}
+	return applyVolatilityDecay(volatility, delta, decayPeriod)
 }
 
-// simulateBinSwap mirrors UmbraeLBPairUpgradeable._simulateBinSwap. All amounts are in the
-// 18-decimal normalized space. binReserveOut is the output-side reserve of the bin (reserveY when
-// swapForY, else reserveX).
-func simulateBinSwap(
-	binReserveOut, amountInNormalized, price, precisionX, scaleIn, scaleOut *uint256.Int,
+// getFeeAmountFrom mirrors the deployed FeeHelper.getFeeAmountFrom: a CEILING division with
+// denominator (10000 + totalFee), clamped so the fee never consumes the whole amount. (V1 floored;
+// the V2 ceil + clamp are both load-bearing for wei-exactness.)
+func getFeeAmountFrom(amount, totalFee *uint256.Int) (*uint256.Int, error) {
+	if amount.IsZero() || totalFee.IsZero() {
+		return uint256.NewInt(0), nil
+	}
+	den := new(uint256.Int).Add(uBP, totalFee)
+	num, over := new(uint256.Int).MulOverflow(amount, totalFee)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	num, over = num.AddOverflow(num, den)
+	if over {
+		return nil, ErrMathOverflow
+	}
+	num.Sub(num, uint256.NewInt(1))
+	fee := num.Div(num, den)
+	if fee.Cmp(amount) >= 0 {
+		fee = new(uint256.Int).Sub(amount, uint256.NewInt(1))
+	}
+	return fee, nil
+}
+
+// calculateSwapWithinBin mirrors SwapCalculator.calculateSwapWithinBin. All amounts crossing this
+// boundary are 18-decimal normalized; the price math runs in native units with the decimal
+// conversion folded into priceDenominator = scaleY * 10^decimalsX (identical in both directions).
+// Output floors, input-consumed-on-depletion ceils (against the swapper). A zero-output bin is
+// skipped, not charged (H-02/#203): returns (0, 0).
+func calculateSwapWithinBin(
+	binReserveOut, amountInNormalized, normPrice, priceDenominator, scaleIn, scaleOut *uint256.Int,
 	swapForY bool,
-) (amountOutNormalized, amountInLeftNormalized *uint256.Int) {
+) (amountOutNormalized, amountInConsumedNormalized *uint256.Int, err error) {
 	amountInNative := new(uint256.Int).Div(amountInNormalized, scaleIn)
 
-	maxAmountOutNative := new(uint256.Int)
+	var maxOutNative *uint256.Int
 	if swapForY {
-		maxAmountOutNative.Mul(amountInNative, price)
-		maxAmountOutNative.Div(maxAmountOutNative, precisionX)
+		maxOutNative, err = mulDivFloor(amountInNative, normPrice, priceDenominator)
 	} else {
-		maxAmountOutNative.Mul(amountInNative, precisionX)
-		maxAmountOutNative.Div(maxAmountOutNative, price)
+		maxOutNative, err = mulDivFloor(amountInNative, priceDenominator, normPrice)
 	}
-	maxAmountOut := new(uint256.Int).Mul(maxAmountOutNative, scaleOut)
-
-	if maxAmountOut.Cmp(binReserveOut) <= 0 {
-		return maxAmountOut, uint256.NewInt(0)
+	if err != nil {
+		return nil, nil, err
+	}
+	maxOut, over := new(uint256.Int).MulOverflow(maxOutNative, scaleOut)
+	if over {
+		return nil, nil, ErrMathOverflow
 	}
 
-	// Bin depleted: output capped at the bin reserve; back out the consumed input.
-	amountOutNormalized = new(uint256.Int).Set(binReserveOut)
+	if maxOut.IsZero() {
+		return uint256.NewInt(0), uint256.NewInt(0), nil
+	}
+	if maxOut.Cmp(binReserveOut) <= 0 {
+		return maxOut, new(uint256.Int).Set(amountInNormalized), nil
+	}
+
+	// Bin depleted: output capped at the bin reserve; back out the consumed input, ceiling.
 	binReserveOutNative := new(uint256.Int).Div(binReserveOut, scaleOut)
-	consumedNative := new(uint256.Int)
+	var consumedNative *uint256.Int
 	if swapForY {
-		consumedNative.Mul(binReserveOutNative, precisionX)
-		consumedNative.Div(consumedNative, price)
+		consumedNative, err = mulDivCeil(binReserveOutNative, priceDenominator, normPrice)
 	} else {
-		consumedNative.Mul(binReserveOutNative, price)
-		consumedNative.Div(consumedNative, precisionX)
+		consumedNative, err = mulDivCeil(binReserveOutNative, normPrice, priceDenominator)
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 	consumed := new(uint256.Int).Mul(consumedNative, scaleIn)
-	amountInLeftNormalized = new(uint256.Int)
-	if amountInNormalized.Cmp(consumed) > 0 {
-		amountInLeftNormalized.Sub(amountInNormalized, consumed)
-	}
-	return amountOutNormalized, amountInLeftNormalized
+	return new(uint256.Int).Set(binReserveOut), consumed, nil
 }

--- a/pkg/liquidity-source/umbrae/dlmm/math_test.go
+++ b/pkg/liquidity-source/umbrae/dlmm/math_test.go
@@ -16,32 +16,68 @@ func TestNormalizedPriceFromId(t *testing.T) {
 	require.Equal(t, uint256.NewInt(997506234413965087), getNormalizedPriceFromId(activeBinID-1, 25))
 }
 
-func TestGetPriceFromId_DecimalScaling(t *testing.T) {
-	// 18-decimal quote: price equals the normalized price.
-	p, err := getPriceFromId(activeBinID, 25, 18)
-	require.NoError(t, err)
-	require.Equal(t, e18, p)
+func TestIsNormalizedPriceRepresentable(t *testing.T) {
+	require.True(t, isNormalizedPriceRepresentable(e18))
+	require.False(t, isNormalizedPriceRepresentable(uint256.NewInt(0)))
+	require.False(t, isNormalizedPriceRepresentable(new(uint256.Int).Set(uMaxU)))
+}
 
-	// 6-decimal quote (e.g. USDC): price = normalized / 10^12 = 10^6 at the centre bin.
-	p6, err := getPriceFromId(activeBinID, 25, 6)
+func TestMulDivFloorCeil(t *testing.T) {
+	// floor(7*3/2) = 10, ceil = 11 — split-formula path: 7*(3/2) + 7*(3%2)/2 = 7 + 3 = 10.
+	f, err := mulDivFloor(uint256.NewInt(7), uint256.NewInt(3), uint256.NewInt(2))
 	require.NoError(t, err)
-	require.Equal(t, uint256.NewInt(1000000), p6)
+	require.Equal(t, uint256.NewInt(10), f)
+	c, err := mulDivCeil(uint256.NewInt(7), uint256.NewInt(3), uint256.NewInt(2))
+	require.NoError(t, err)
+	require.Equal(t, uint256.NewInt(11), c)
+	// Exact division: floor == ceil.
+	f, err = mulDivFloor(uint256.NewInt(6), uint256.NewInt(4), uint256.NewInt(3))
+	require.NoError(t, err)
+	c, err = mulDivCeil(uint256.NewInt(6), uint256.NewInt(4), uint256.NewInt(3))
+	require.NoError(t, err)
+	require.Equal(t, f, c)
+	// The intermediates are NOT 512-bit: a*(b/d) overflowing must error like the on-chain revert.
+	_, err = mulDivFloor(uMaxU, uMaxU, uint256.NewInt(1))
+	require.ErrorIs(t, err, ErrMathOverflow)
 }
 
 func TestCalculateDynamicFee(t *testing.T) {
-	// vol=0 -> just the base factor (varFeeCap 0 = no cap).
-	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 4000, uint256.NewInt(0), 25, 0))
+	// vol=0 -> just the base factor.
+	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 4000, 0, 25, 100))
 	// vol=100, binStep=25, control=4000: (100*25)^2 * 4000 / 1e10 = 2 -> 32 bps.
-	require.Equal(t, uint256.NewInt(32), calculateDynamicFee(30, 4000, uint256.NewInt(100), 25, 0))
+	require.Equal(t, uint256.NewInt(32), calculateDynamicFee(30, 4000, 100, 25, 100))
 	// variableFeeControl=0 disables the variable term.
-	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 0, uint256.NewInt(9999), 25, 0))
-	// Capped at MAX_FEE (500) when uncapped variable fee is huge.
-	require.Equal(t, uMaxFee, calculateDynamicFee(30, 4000, uint256.NewInt(35000), 25, 0))
+	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 0, 9999, 25, 100))
+	// V2 #147: the cap clamp is UNCONDITIONAL — a zero cap pins the variable part to zero.
+	require.Equal(t, uint256.NewInt(30), calculateDynamicFee(30, 4000, 100, 25, 0))
 	// variableFeeCap caps the variable term: vol=100 gives variableFee 2, cap at 1 -> 31 bps.
-	require.Equal(t, uint256.NewInt(31), calculateDynamicFee(30, 4000, uint256.NewInt(100), 25, 1))
+	require.Equal(t, uint256.NewInt(31), calculateDynamicFee(30, 4000, 100, 25, 1))
+	// Capped at MAX_FEE (500) when the capped variable fee still exceeds it.
+	require.Equal(t, uMaxFee, calculateDynamicFee(30, 4000, 35000, 25, 65535))
 }
 
 func TestGetFeeAmountFrom(t *testing.T) {
-	// 1e18 at 30 bps fee = floor(1e18*30/10030) = floor(3e19/10030).
-	require.Equal(t, uint256.NewInt(2991026919242273), getFeeAmountFrom(e18, uint256.NewInt(30)))
+	// V2 ceils: 1e18 at 30 bps = ceil(1e18*30/10030) = 2991026919242274 (V1 floored to ...273).
+	fee, err := getFeeAmountFrom(e18, uint256.NewInt(30))
+	require.NoError(t, err)
+	require.Equal(t, uint256.NewInt(2991026919242274), fee)
+	// The fee can never consume the whole amount: ceil(1*30/10030)=1 >= 1 clamps to amount-1 = 0.
+	fee, err = getFeeAmountFrom(uint256.NewInt(1), uint256.NewInt(30))
+	require.NoError(t, err)
+	require.True(t, fee.IsZero())
+	// Zero fee rate charges nothing.
+	fee, err = getFeeAmountFrom(e18, uint256.NewInt(0))
+	require.NoError(t, err)
+	require.True(t, fee.IsZero())
+}
+
+func TestVolatilityDecay(t *testing.T) {
+	// Inside the filter window the accumulator holds constant.
+	require.Equal(t, uint64(1000), getDecayedVolatility(1000, 100, 30, 600, 120))
+	// Past the filter window it decays linearly over decayPeriod: delta=300 of 600 -> half.
+	require.Equal(t, uint64(500), getDecayedVolatility(1000, 100, 30, 600, 400))
+	// Past decayPeriod it is zero.
+	require.Equal(t, uint64(0), getDecayedVolatility(1000, 100, 30, 600, 701))
+	// Non-zero floor of 1 while decaying.
+	require.Equal(t, uint64(1), getDecayedVolatility(1, 100, 30, 600, 400))
 }

--- a/pkg/liquidity-source/umbrae/dlmm/pool_simulator.go
+++ b/pkg/liquidity-source/umbrae/dlmm/pool_simulator.go
@@ -16,11 +16,10 @@ import (
 type PoolSimulator struct {
 	pool.Pool
 
-	binStep    uint16
-	decimalsY  uint8
-	scaleX     *uint256.Int // 10^(18-decimalsX)
-	scaleY     *uint256.Int // 10^(18-decimalsY)
-	precisionX *uint256.Int // 10^decimalsX
+	binStep          uint16
+	scaleX           *uint256.Int // 10^(18-decimalsX)
+	scaleY           *uint256.Int // 10^(18-decimalsY)
+	priceDenominator *uint256.Int // scaleY * 10^decimalsX — identical in both swap directions
 
 	activeID uint32
 	bins     []Bin          // sorted ascending by ID; normalized reserves
@@ -28,10 +27,14 @@ type PoolSimulator struct {
 
 	fp             FeeParameters
 	variableFeeCap uint16
-	startVol       *uint256.Int // volatility accumulator, already decayed to the tracked block
-	volRef         uint32       // volatility reference bin (== activeId when idle)
-	minSwap        *uint256.Int // precomputed _getMinSwapForVolatility threshold (native units)
-	router         string       // DLMM Router: the token spender / approval target
+	// Raw volatility state (V2 anchored-displacement model). The working volatility and window
+	// anchor are derived per swap exactly as PairSwapLib.performSwap does, using the tracked
+	// timestamp as the clock.
+	volAcc       uint64
+	volRef       uint32 // anchor bin id; < 2^22 means unset
+	lastVolUpd   uint64
+	trackedAt    uint64
+	router       string // DLMM Router: the token spender / approval target
 }
 
 var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
@@ -53,6 +56,7 @@ func NewPoolSimulator(ep entity.Pool) (*PoolSimulator, error) {
 		binIndex[b.ID] = i
 	}
 
+	scaleY := pow10(18 - static.DecimalsY)
 	s := &PoolSimulator{
 		Pool: pool.Pool{Info: pool.PoolInfo{
 			Address:     ep.Address,
@@ -62,40 +66,22 @@ func NewPoolSimulator(ep entity.Pool) (*PoolSimulator, error) {
 			Reserves:    lo.Map(ep.Reserves, func(r string, _ int) *big.Int { return bignumber.NewBig(r) }),
 			BlockNumber: ep.BlockNumber,
 		}},
-		binStep:        static.BinStep,
-		decimalsY:      static.DecimalsY,
-		scaleX:         pow10(18 - static.DecimalsX),
-		scaleY:         pow10(18 - static.DecimalsY),
-		precisionX:     pow10(static.DecimalsX),
-		activeID:       extra.ActiveID,
-		bins:           bins,
-		binIndex:       binIndex,
-		fp:             extra.FeeParameters,
-		variableFeeCap: extra.VariableFeeCap,
-		startVol:       uint256.NewInt(extra.VolatilityAccumulator),
-		volRef:         extra.VolatilityReference,
-		minSwap:        minSwapForVolatility(extra.NativeReserveX, extra.NativeReserveY, extra.FeeParameters.MinSwapBps),
-		router:         static.Router,
+		binStep:          static.BinStep,
+		scaleX:           pow10(18 - static.DecimalsX),
+		scaleY:           scaleY,
+		priceDenominator: new(uint256.Int).Mul(scaleY, pow10(static.DecimalsX)),
+		activeID:         extra.ActiveID,
+		bins:             bins,
+		binIndex:         binIndex,
+		fp:               extra.FeeParameters,
+		variableFeeCap:   extra.VariableFeeCap,
+		volAcc:           extra.VolatilityAccumulator,
+		volRef:           extra.VolatilityReference,
+		lastVolUpd:       extra.LastVolatilityUpdate,
+		trackedAt:        extra.Timestamp,
+		router:           static.Router,
 	}
 	return s, nil
-}
-
-// minSwapForVolatility mirrors the DEPLOYED _getMinSwapForVolatility:
-// (nativeReserveX + nativeReserveY) * minSwapBps / 10000 (no bin-step factor). Returns 0 when
-// minSwapBps is 0 (matching the deployed early return).
-func minSwapForVolatility(nativeX, nativeY string, minSwapBps uint16) *uint256.Int {
-	if minSwapBps == 0 {
-		return uint256.NewInt(0)
-	}
-	total := new(uint256.Int)
-	if x, err := uint256.FromDecimal(nativeX); err == nil {
-		total.Add(total, x)
-	}
-	if y, err := uint256.FromDecimal(nativeY); err == nil {
-		total.Add(total, y)
-	}
-	total.Mul(total, uint256.NewInt(uint64(minSwapBps)))
-	return total.Div(total, uBP)
 }
 
 func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
@@ -115,6 +101,7 @@ func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 		return nil, err
 	}
 	if amountOut.Sign() <= 0 {
+		// The pair reverts LBPair__InsufficientAmountOut on a zero output even with amountOutMin=0.
 		return nil, ErrInsufficientOutput
 	}
 
@@ -126,31 +113,62 @@ func (s *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.Cal
 	}, nil
 }
 
-// traverse reproduces the deployed pair swap() loop: it starts from the tracked (already-decayed)
-// volatility, ramps it by distance from volRef as bins are crossed, and applies the dynamic fee per
-// bin. Returns the native output, native total fee, and post-swap bin updates. It errors with
-// ErrInsufficientLiquidity when the book runs out of bins before the whole input is consumed,
-// mirroring the on-chain swap()'s LBPair__InsufficientLiquidityForSwap revert
+// traverse reproduces the deployed PairSwapLib.performSwap loop:
+//   - the per-bin fee is charged on the remaining GROSS input (native decimals) BEFORE pricing,
+//     with the unspent slice of a partially-consumed bin's fee returned to the gross remainder;
+//   - the working volatility is the anchored displacement |bin - anchor| on top of the window
+//     base, clamped at maxVolatilityAccumulator (V2 R12/M-3 — no cumulative ratchet);
+//   - a bin with no output-side reserve, or whose price rounds the output to zero, is skipped
+//     uncharged;
+//   - it errors with ErrInsufficientLiquidity when the book runs dry and with
+//     ErrSwapMovementExceeded when the walk would leave the movement bound — both are execution
+//     reverts on-chain (the view-quote's partial fill would over-promise a reverting route).
 func (s *PoolSimulator) traverse(amountIn *uint256.Int, swapForY bool) (*uint256.Int, *uint256.Int, SwapInfo, error) {
 	scaleIn, scaleOut := s.scaleX, s.scaleY
 	if !swapForY {
 		scaleIn, scaleOut = s.scaleY, s.scaleX
 	}
 
-	currentBinID := s.activeID
+	entryBinID := s.activeID
+
+	// Derive the working volatility and window anchor (PairSwapLib.performSwap lines 81–147).
+	vol := getDecayedVolatility(s.volAcc, s.lastVolUpd, uint64(s.fp.FilterPeriod), uint64(s.fp.DecayPeriod), s.trackedAt)
+	var anchor uint32
+	var volBase uint64
+	var sinceVolUpd uint64
+	if s.trackedAt > s.lastVolUpd {
+		sinceVolUpd = s.trackedAt - s.lastVolUpd
+	}
+	if s.volRef < minActiveBin || sinceVolUpd >= uint64(s.fp.FilterPeriod) {
+		anchor, volBase = entryBinID, vol
+	} else {
+		anchor = s.volRef
+		if disp := distanceFrom(entryBinID, anchor); vol > disp {
+			volBase = vol - disp
+		} else {
+			volBase = 0
+		}
+	}
+
+	currentBinID := entryBinID
 	amountInLeft := new(uint256.Int).Set(amountIn)
 	amountOutNormalized := uint256.NewInt(0)
 	totalFee := uint256.NewInt(0)
-	volatility := new(uint256.Int).Set(s.startVol) // already decayed to the tracked block
-	var binsTraversed int
+	crossed := false
 
 	updates := make(map[int]binUpdate)
 
 	for !amountInLeft.IsZero() {
-		feeRate := calculateDynamicFee(s.fp.BaseFactor, s.fp.VariableFeeControl, volatility, s.binStep, s.variableFeeCap)
-		binTotalFee := getFeeAmountFrom(amountInLeft, feeRate)
+		feeRate := calculateDynamicFee(s.fp.BaseFactor, s.fp.VariableFeeControl, vol, s.binStep, s.variableFeeCap)
+		binTotalFee, err := getFeeAmountFrom(amountInLeft, feeRate)
+		if err != nil {
+			return nil, nil, SwapInfo{}, err
+		}
 		amountInAfterFee := new(uint256.Int).Sub(amountInLeft, binTotalFee)
-		amountInAfterFeeNormalized := new(uint256.Int).Mul(amountInAfterFee, scaleIn)
+		amountInAfterFeeNormalized, over := new(uint256.Int).MulOverflow(amountInAfterFee, scaleIn)
+		if over {
+			return nil, nil, SwapInfo{}, ErrMathOverflow
+		}
 
 		if idx, ok := s.binIndex[currentBinID]; ok {
 			b := s.workingBin(updates, idx)
@@ -159,34 +177,36 @@ func (s *PoolSimulator) traverse(amountIn *uint256.Int, swapForY bool) (*uint256
 				binReserveOut = b.ReserveX
 			}
 			if binReserveOut != nil && !binReserveOut.IsZero() { // hasLiquidityForSwap
-				price, err := getPriceFromId(currentBinID, s.binStep, s.decimalsY)
+				price := getNormalizedPriceFromId(currentBinID, s.binStep)
+				if !isNormalizedPriceRepresentable(price) {
+					return nil, nil, SwapInfo{}, ErrPriceNotRepresentable
+				}
+
+				binAmountOut, consumedNorm, err := calculateSwapWithinBin(
+					binReserveOut, amountInAfterFeeNormalized, price, s.priceDenominator, scaleIn, scaleOut, swapForY)
 				if err != nil {
 					return nil, nil, SwapInfo{}, err
 				}
-				if price.IsZero() {
-					return nil, nil, SwapInfo{}, ErrInvalidPrice
+
+				if !binAmountOut.IsZero() {
+					amountOutNormalized.Add(amountOutNormalized, binAmountOut)
+
+					// Fee proration to what was actually consumed; the unspent fee slice returns to
+					// the gross remainder (PairSwapLib._swapCurrentBin).
+					actualConsumed := new(uint256.Int).Div(consumedNorm, scaleIn)
+					actualTotalFee := uint256.NewInt(0)
+					if actualConsumed.Sign() > 0 && amountInAfterFee.Sign() > 0 {
+						actualTotalFee.Mul(binTotalFee, actualConsumed)
+						actualTotalFee.Div(actualTotalFee, amountInAfterFee)
+					}
+					totalFee.Add(totalFee, actualTotalFee)
+
+					netLeftNorm := new(uint256.Int).Sub(amountInAfterFeeNormalized, consumedNorm)
+					amountInLeft = new(uint256.Int).Div(netLeftNorm, scaleIn)
+					amountInLeft.Add(amountInLeft, new(uint256.Int).Sub(binTotalFee, actualTotalFee))
+
+					s.recordBinUpdate(updates, idx, binAmountOut, consumedNorm, swapForY)
 				}
-
-				binAmountOut, amountInLeftNorm := simulateBinSwap(
-					binReserveOut, amountInAfterFeeNormalized, price, s.precisionX, scaleIn, scaleOut, swapForY)
-
-				amountOutNormalized.Add(amountOutNormalized, binAmountOut)
-
-				actualConsumedNorm := new(uint256.Int).Sub(amountInAfterFeeNormalized, amountInLeftNorm)
-				actualConsumed := new(uint256.Int).Div(actualConsumedNorm, scaleIn)
-
-				actualTotalFee := uint256.NewInt(0)
-				if actualConsumed.Sign() > 0 && amountInAfterFee.Sign() > 0 {
-					actualTotalFee.Mul(binTotalFee, actualConsumed)
-					actualTotalFee.Div(actualTotalFee, amountInAfterFee)
-				}
-				totalFee.Add(totalFee, actualTotalFee)
-
-				amountInLeftAfterSwap := new(uint256.Int).Div(amountInLeftNorm, scaleIn)
-				leftoverFee := new(uint256.Int).Sub(binTotalFee, actualTotalFee)
-				amountInLeft.Add(amountInLeftAfterSwap, leftoverFee)
-
-				s.recordBinUpdate(updates, idx, binAmountOut, actualConsumedNorm, swapForY)
 			}
 		}
 
@@ -198,15 +218,15 @@ func (s *PoolSimulator) traverse(amountIn *uint256.Int, swapForY bool) (*uint256
 		if !found {
 			return nil, nil, SwapInfo{}, ErrInsufficientLiquidity
 		}
-		currentBinID = nextBin
-		binsTraversed++
-
-		// _wouldUpdateVolatility: outside the filter period (snapshot model), the gate reduces to
-		// amountIn >= minSwap && a fee was charged. Ramp volatility by distance from the reference.
-		if amountIn.Cmp(s.minSwap) >= 0 && totalFee.Sign() > 0 {
-			dist := min(distanceFrom(currentBinID, s.volRef), uint64(s.fp.MaxVolatilityAccumulator))
-			volatility = uint256.NewInt(dist)
+		// SwapMovement.isAllowed: bounded distance from the ENTRY bin of this swap. Execution
+		// reverts LBPair__SwapBinDistanceExceeded past it.
+		dist := distanceFrom(nextBin, entryBinID)
+		if dist > maxBinIDDistance || dist*uint64(s.binStep) > maxCumulativeStepBps {
+			return nil, nil, SwapInfo{}, ErrSwapMovementExceeded
 		}
+		currentBinID = nextBin
+		crossed = true
+		vol = min(volBase+distanceFrom(nextBin, anchor), uint64(s.fp.MaxVolatilityAccumulator))
 	}
 
 	amountOut := new(uint256.Int).Div(amountOutNormalized, scaleOut)
@@ -214,6 +234,9 @@ func (s *PoolSimulator) traverse(amountIn *uint256.Int, swapForY bool) (*uint256
 	return amountOut, totalFee, SwapInfo{
 		newActiveID: currentBinID,
 		binUpdates:  lo.Values(updates),
+		binsCrossed: crossed,
+		newVolAcc:   vol,
+		newVolRef:   anchor,
 	}, nil
 }
 
@@ -226,7 +249,8 @@ func (s *PoolSimulator) workingBin(updates map[int]binUpdate, idx int) Bin {
 }
 
 // recordBinUpdate applies a bin's post-swap reserves (output reduced, input increased by the net
-// consumed) so UpdateBalance can replay them without recomputing.
+// consumed) so UpdateBalance can replay them without recomputing. Fees never enter bin reserves in
+// V2 — only the post-fee consumed input does.
 func (s *PoolSimulator) recordBinUpdate(updates map[int]binUpdate, idx int, outDelta, inDeltaNorm *uint256.Int, swapForY bool) {
 	cur := s.workingBin(updates, idx)
 	newX := new(uint256.Int).Set(orZero(cur.ReserveX))
@@ -241,10 +265,9 @@ func (s *PoolSimulator) recordBinUpdate(updates map[int]binUpdate, idx int, outD
 	updates[idx] = binUpdate{index: idx, reserveX: newX, reserveY: newY}
 }
 
-// findNextActiveBin returns the next non-empty bin in the swap direction. Direction is set from
-// observed on-chain behaviour (verified against the pair's quoteSwap): selling X for Y pushes the
-// price down (descending bin ids), selling Y for X pushes it up (ascending). Y lives in bins below
-// the active bin, X above — so swapForY (X->Y, taking Y out) walks DOWN and !swapForY walks UP.
+// findNextActiveBin returns the next bin with liquidity in the swap direction: selling X for Y
+// pushes the price down (descending bin ids), selling Y for X pushes it up (ascending). Unchanged
+// from V1 and re-verified against the deployed PairSwapLib.findNextActiveBin bitmap walk.
 func (s *PoolSimulator) findNextActiveBin(current uint32, swapForY bool) (uint32, bool) {
 	if !swapForY { // Y->X: search up
 		i := sort.Search(len(s.bins), func(i int) bool { return s.bins[i].ID > current })
@@ -271,6 +294,14 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 		// Reassign the element (copy-on-write) so cloned states never share these pointers.
 		s.bins[u.index] = Bin{ID: s.bins[u.index].ID, ReserveX: u.reserveX, ReserveY: u.reserveY}
 	}
+	// Volatility persistence mirrors the pair: the reference/clock are only written when at least
+	// one bin was crossed (PairSwapLib.performSwap lines 153–159), so a same-bin swap leaves the
+	// decay clock untouched.
+	if si.binsCrossed {
+		s.volAcc = si.newVolAcc
+		s.volRef = si.newVolRef
+		s.lastVolUpd = s.trackedAt
+	}
 }
 
 func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
@@ -281,8 +312,8 @@ func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
 }
 
 // GetApprovalAddress returns the DLMM Router — the swap entry point KyberSwap's executor approves
-// and calls. The pair itself is a BeaconProxy that reverts on direct swap calls ("No extension"), so
-// the pair address is never a valid spender.
+// and calls (it transferFroms the input straight to the first pool and enforces the final
+// amountOutMin).
 func (s *PoolSimulator) GetApprovalAddress(_, _ string) string {
 	return s.router
 }

--- a/pkg/liquidity-source/umbrae/dlmm/pool_simulator_test.go
+++ b/pkg/liquidity-source/umbrae/dlmm/pool_simulator_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	tokenX = "0x14a4e80d633af55ace1160c320f5a36d41cced3e" // U1
-	tokenY = "0x4200000000000000000000000000000000000006" // WETH
+	tokenX = "0x4200000000000000000000000000000000000006" // WETH (tokenX = lower address)
+	tokenY = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" // USDC
 )
 
 func newSim(t *testing.T, static StaticExtra, extra Extra) *PoolSimulator {
@@ -22,7 +22,7 @@ func newSim(t *testing.T, static StaticExtra, extra Extra) *PoolSimulator {
 	se, _ := json.Marshal(static)
 	ex, _ := json.Marshal(extra)
 	sim, err := NewPoolSimulator(entity.Pool{
-		Address:     "0x697b72320656e6dc60db7a4bfb95084c9d9c55a0",
+		Address:     "0x4a27eeff8abe2a467425fdac65e5b579e26a90b5",
 		Exchange:    DexType,
 		Type:        DexType,
 		Reserves:    entity.PoolReserves{"0", "0"},
@@ -36,8 +36,15 @@ func newSim(t *testing.T, static StaticExtra, extra Extra) *PoolSimulator {
 
 func u(v string) *uint256.Int { return uint256.MustFromDecimal(v) }
 
+// baseFeeParams keeps the variable term off (variableFeeControl=0) so hand-computed fixtures only
+// exercise the base fee.
+func baseFeeParams() FeeParameters {
+	return FeeParameters{BaseFactor: 30, VariableFeeControl: 0, MaxVolatilityAccumulator: 35000}
+}
+
 // TestCalcAmountOut_SingleBin verifies the full traversal arithmetic against a hand-computed case:
 // one active bin, 18/18 decimals, binStep 25, base fee 30 bps, variable fee disabled.
+// V2 fee CEILS: fee = ceil(1e18*30/10030) = 2991026919242274 (V1 floored to ...273).
 func TestCalcAmountOut_SingleBin(t *testing.T) {
 	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}
 	extra := Extra{
@@ -45,12 +52,7 @@ func TestCalcAmountOut_SingleBin(t *testing.T) {
 		Bins: []Bin{
 			{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}, // 1000 Y
 		},
-		FeeParameters: FeeParameters{
-			BaseFactor: 30, VariableFeeControl: 0,
-			MaxVolatilityAccumulator: 35000, MinSwapBps: 0,
-		},
-		NativeReserveX: "0",
-		NativeReserveY: "1000000000000000000000",
+		FeeParameters: baseFeeParams(),
 	}
 	sim := newSim(t, static, extra)
 
@@ -59,9 +61,9 @@ func TestCalcAmountOut_SingleBin(t *testing.T) {
 		TokenOut:      tokenY,
 	})
 	require.NoError(t, err)
-	// inAfterFee = 1e18 - floor(1e18*30/10030); at a 1:1 bin price the full inAfterFee converts.
-	require.Equal(t, "997008973080757727", res.TokenAmountOut.Amount.String())
-	require.Equal(t, "2991026919242273", res.Fee.Amount.String())
+	// inAfterFee = 1e18 - 2991026919242274; at a 1:1 bin price the full inAfterFee converts.
+	require.Equal(t, "997008973080757726", res.TokenAmountOut.Amount.String())
+	require.Equal(t, "2991026919242274", res.Fee.Amount.String())
 }
 
 func TestCalcAmountOut_UpdateBalanceAndClone(t *testing.T) {
@@ -71,9 +73,7 @@ func TestCalcAmountOut_UpdateBalanceAndClone(t *testing.T) {
 		Bins: []Bin{
 			{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")},
 		},
-		FeeParameters:  FeeParameters{BaseFactor: 30, VariableFeeControl: 0, MaxVolatilityAccumulator: 35000},
-		NativeReserveX: "0",
-		NativeReserveY: "1000000000000000000000",
+		FeeParameters: baseFeeParams(),
 	}
 	sim := newSim(t, static, extra)
 	in := big.NewInt(1_000_000_000_000_000_000)
@@ -98,72 +98,102 @@ func TestCalcAmountOut_UpdateBalanceAndClone(t *testing.T) {
 	require.Equal(t, u("1000000000000000000000"), clone.(*PoolSimulator).bins[0].ReserveY)
 }
 
-// TestCalcAmountOut_DecimalScaling exercises the native<->normalized conversion (scaleIn/scaleOut/
-// precisionX) and the decimalsY price adjustment on a synthetic 6-dec X / 18-dec Y pool — the path
-// no on-chain Umbrae pair covers yet (all live pairs are 18/18). Values are hand-computed at the
-// active (1:1 normalized) bin, base fee 30 bps, variable fee off. The fee is charged in input-token
-// native decimals, so the 6-dec direction rounds coarser than 18/18 — that mirrors the contract.
+// TestCalcAmountOut_DecimalScaling exercises the native<->normalized conversion and the V2 unified
+// price domain (priceDenominator = scaleY * 10^decimalsX, identical in both directions) on an
+// 18-dec X / 6-dec Y pool — the live WETH/USDC shape. Values are hand-computed at the active
+// (1:1 normalized) bin, base fee 30 bps, variable fee off. The fee is charged in input-token
+// native decimals and CEILS, so the 6-dec direction rounds coarser — that mirrors the contract.
 func TestCalcAmountOut_DecimalScaling(t *testing.T) {
-	// scaleX = 10^(18-6) = 1e12, precisionX = 10^6, scaleY = 1.
-	static := StaticExtra{BinStep: 25, DecimalsX: 6, DecimalsY: 18}
+	// scaleX = 1, scaleY = 10^(18-6) = 1e12, priceDenominator = 1e12 * 1e18 = 1e30.
+	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 6}
 	extra := Extra{
 		ActiveID: activeBinID,
 		Bins: []Bin{
-			// Normalized reserves: 1000 of each token (X: 1e9 native * 1e12 scale = 1e21; Y: 1e21).
+			// Normalized reserves: 1000 of each token (X: 1e21; Y: 1e9 native * 1e12 scale = 1e21).
 			{ID: activeBinID, ReserveX: u("1000000000000000000000"), ReserveY: u("1000000000000000000000")},
 		},
-		FeeParameters:  FeeParameters{BaseFactor: 30, VariableFeeControl: 0, MaxVolatilityAccumulator: 35000, MinSwapBps: 0},
-		NativeReserveX: "1000000000", NativeReserveY: "1000000000000000000000",
+		FeeParameters: baseFeeParams(),
 	}
 	sim := newSim(t, static, extra)
 
-	// X->Y: 1 whole X = 1e6 native in. Fee (native X) = floor(1e6*30/10030) = 2991.
+	// X->Y: 1 whole X = 1e18 native in. Fee (native X) = ceil(1e18*30/10030) = 2991026919242274.
+	// net = 997008973080757726; out native Y = floor(net * 1e18 / 1e30) = 997008 (6-dec).
 	resXY, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
-		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: big.NewInt(1_000_000)}, TokenOut: tokenY,
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: big.NewInt(1_000_000_000_000_000_000)}, TokenOut: tokenY,
 	})
 	require.NoError(t, err)
-	require.Equal(t, "997009000000000000", resXY.TokenAmountOut.Amount.String(), "X->Y out (Y, 18-dec)")
-	require.Equal(t, "2991", resXY.Fee.Amount.String(), "X->Y fee (X, 6-dec)")
+	require.Equal(t, "997008", resXY.TokenAmountOut.Amount.String(), "X->Y out (Y, 6-dec)")
+	require.Equal(t, "2991026919242274", resXY.Fee.Amount.String(), "X->Y fee (X, 18-dec)")
 
-	// Y->X: 1 Y = 1e18 native in. Fee (native Y) = floor(1e18*30/10030); out floors to 6-dec X.
+	// Y->X: 1 whole Y = 1e6 native in. Fee (native Y) = ceil(1e6*30/10030) = 2992 (V1: 2991).
+	// net = 997008; out native X = floor(997008 * 1e30 / 1e18 / 1) = 997008e12.
 	resYX, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
-		TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: big.NewInt(1_000_000_000_000_000_000)}, TokenOut: tokenX,
+		TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: big.NewInt(1_000_000)}, TokenOut: tokenX,
 	})
 	require.NoError(t, err)
-	require.Equal(t, "997008", resYX.TokenAmountOut.Amount.String(), "Y->X out (X, 6-dec)")
-	require.Equal(t, "2991026919242273", resYX.Fee.Amount.String(), "Y->X fee (Y, 18-dec)")
+	require.Equal(t, "997008000000000000", resYX.TokenAmountOut.Amount.String(), "Y->X out (X, 18-dec)")
+	require.Equal(t, "2992", resYX.Fee.Amount.String(), "Y->X fee (Y, 6-dec)")
 }
 
 // TestCalcAmountOut_InsufficientLiquidity covers the case that reverts on-chain: the input requires
 // more output than the whole book holds. Because the router-service always sends the full amountIn,
-// a partial fill would revert on-chain (LBPair__InsufficientLiquidityForSwap), so the simulator must
-// return ErrInsufficientLiquidity instead of a partial quote (mirrors liquiditybookv21.getSwapOut).
+// a partial fill would leave the route reverting on-chain (LBPair__InsufficientLiquidityForSwap),
+// so the simulator must return ErrInsufficientLiquidity instead of a partial quote.
 func TestCalcAmountOut_InsufficientLiquidity(t *testing.T) {
 	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}
 	// Single active bin with only 1000 Y. A huge X input cannot be fully consumed.
 	extra := Extra{
-		ActiveID:       activeBinID,
-		Bins:           []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
-		FeeParameters:  FeeParameters{BaseFactor: 30, MaxVolatilityAccumulator: 35000},
-		NativeReserveX: "0", NativeReserveY: "1000000000000000000000",
+		ActiveID:      activeBinID,
+		Bins:          []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
+		FeeParameters: baseFeeParams(),
 	}
 	sim := newSim(t, static, extra)
 
-	in := new(big.Int).Exp(big.NewInt(10), big.NewInt(30), nil) // 1e30 X, far more than the bin can absorb
+	in := new(big.Int).Exp(big.NewInt(10), big.NewInt(24), nil) // 1e24 X, far more than the bin can absorb
 	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
 		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: in}, TokenOut: tokenY,
 	})
 	require.ErrorIs(t, err, ErrInsufficientLiquidity)
 }
 
+// TestCalcAmountOut_MovementBound covers the V2 movement bound (SwapMovement.isAllowed, #278): a
+// swap may not reach a bin further than distance*binStep = 10000 bps from the entry bin — at
+// binStep 25 that is 400 bins. Execution reverts there, so the simulator must refuse the quote.
+func TestCalcAmountOut_MovementBound(t *testing.T) {
+	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}
+	mk := func(farOffset uint32) *PoolSimulator {
+		return newSim(t, static, Extra{
+			ActiveID: activeBinID,
+			Bins: []Bin{
+				{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000")},          // 1 Y
+				{ID: activeBinID - farOffset, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}, // 1000 Y
+			},
+			FeeParameters: baseFeeParams(),
+		})
+	}
+	in := big.NewInt(2_000_000_000_000_000_000) // 2 X — drains the active bin, needs the far bin
+
+	// Far bin at distance 400 (400*25 = 10000 bps): allowed.
+	res, err := mk(400).CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: in}, TokenOut: tokenY,
+	})
+	require.NoError(t, err)
+	require.Positive(t, res.TokenAmountOut.Amount.Sign())
+
+	// Far bin at distance 401 (401*25 > 10000 bps): the walk must refuse, as execution reverts.
+	_, err = mk(401).CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokenX, Amount: in}, TokenOut: tokenY,
+	})
+	require.ErrorIs(t, err, ErrSwapMovementExceeded)
+}
+
 // TestCalcAmountOut_FullyConsumable ensures a swap the book can fully absorb succeeds (no error).
 func TestCalcAmountOut_FullyConsumable(t *testing.T) {
 	static := StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}
 	extra := Extra{
-		ActiveID:       activeBinID,
-		Bins:           []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
-		FeeParameters:  FeeParameters{BaseFactor: 30, MaxVolatilityAccumulator: 35000},
-		NativeReserveX: "0", NativeReserveY: "1000000000000000000000",
+		ActiveID:      activeBinID,
+		Bins:          []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
+		FeeParameters: baseFeeParams(),
 	}
 	sim := newSim(t, static, extra)
 
@@ -176,10 +206,9 @@ func TestCalcAmountOut_FullyConsumable(t *testing.T) {
 
 func TestCalcAmountOut_InvalidToken(t *testing.T) {
 	sim := newSim(t, StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18}, Extra{
-		ActiveID:       activeBinID,
-		Bins:           []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
-		FeeParameters:  FeeParameters{BaseFactor: 30, MaxVolatilityAccumulator: 35000},
-		NativeReserveX: "0", NativeReserveY: "1000000000000000000000",
+		ActiveID:      activeBinID,
+		Bins:          []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
+		FeeParameters: baseFeeParams(),
 	})
 	_, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
 		TokenAmountIn: pool.TokenAmount{Token: "0xdead", Amount: big.NewInt(1)}, TokenOut: tokenY,
@@ -188,12 +217,11 @@ func TestCalcAmountOut_InvalidToken(t *testing.T) {
 }
 
 func TestGetMetaInfo_ApprovalAddressMatchesRouter(t *testing.T) {
-	router := "0x4965dd6877ca9de77caca2f57996651e7af23c93"
+	router := "0x5a7673d413f510f4b5c191d96837694c5942bf38" // V2 DLMM Router
 	sim := newSim(t, StaticExtra{BinStep: 25, DecimalsX: 18, DecimalsY: 18, Router: router}, Extra{
-		ActiveID:       activeBinID,
-		Bins:           []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
-		FeeParameters:  FeeParameters{BaseFactor: 30, MaxVolatilityAccumulator: 35000},
-		NativeReserveX: "0", NativeReserveY: "1000000000000000000000",
+		ActiveID:      activeBinID,
+		Bins:          []Bin{{ID: activeBinID, ReserveX: u("0"), ReserveY: u("1000000000000000000000")}},
+		FeeParameters: baseFeeParams(),
 	})
 	meta, ok := sim.GetMetaInfo(tokenX, tokenY).(PoolMeta)
 	require.True(t, ok)

--- a/pkg/liquidity-source/umbrae/dlmm/pool_tracker.go
+++ b/pkg/liquidity-source/umbrae/dlmm/pool_tracker.go
@@ -22,7 +22,7 @@ type PoolTracker struct {
 	ethrpcClient *ethrpc.Client
 }
 
-// feeParamsRPC mirrors the DEPLOYED FeeHelper.FeeParameters tuple (7 fields, no protocolShare).
+// feeParamsRPC mirrors the deployed FeeHelper.FeeParameters tuple (7 fields, no protocolShare).
 type feeParamsRPC struct {
 	BaseFactor               uint16
 	FilterPeriod             uint16
@@ -35,22 +35,17 @@ type feeParamsRPC struct {
 
 type quoteStateRPC struct {
 	FeeParams             feeParamsRPC
-	VolatilityAccumulator *big.Int
-	VolatilityReference   *big.Int
-	LastVolatilityUpdate  *big.Int
-	ScaleX                *big.Int
-	ScaleY                *big.Int
+	VolatilityAccumulator *big.Int // uint128
+	VolatilityReference   *big.Int // uint24 — the anchor bin id in V2
+	LastVolatilityUpdate  *big.Int // uint40
+	ScaleX                *big.Int // 10^(18-decimalsX)
+	ScaleY                *big.Int // 10^(18-decimalsY)
 	Factory               common.Address
 }
 
-type pairStatsRPC struct {
-	ActiveId            *big.Int
-	ReserveX            *big.Int
-	ReserveY            *big.Int
-	ProtocolFeesX       *big.Int
-	ProtocolFeesY       *big.Int
-	Volatility          *big.Int
-	LastUpdateTimestamp *big.Int
+type reservesRPC struct {
+	ReserveX *big.Int
+	ReserveY *big.Int
 }
 
 type activeBinsRPC struct {
@@ -78,18 +73,18 @@ func (t *PoolTracker) GetNewPoolState(
 		return p, err
 	}
 
-	// All reads pinned to one block. The deployed pair routes reserves/bins/quotes to an extension,
-	// so reserves/bins come via the PairViewer; fee + volatility state come via getQuoteState.
+	// All reads pinned to one block. Fee + volatility state come via getQuoteState; native total
+	// reserves via getReserves; per-bin reserves via the PairViewer.
 	var (
 		activeID  *big.Int
 		quote     quoteStateRPC
-		stats     pairStatsRPC
+		reserves  reservesRPC
 		activeBin activeBinsRPC
 	)
 	resp, err := t.ethrpcClient.R().SetContext(ctx).
 		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetActiveID}, []any{&activeID}).
 		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetQuoteState}, []any{&quote}).
-		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetPairStatistics}, []any{&stats}).
+		AddCall(&ethrpc.Call{ABI: pairABI, Target: p.Address, Method: pairMethodGetReserves}, []any{&reserves}).
 		AddCall(&ethrpc.Call{ABI: viewerABI, Target: t.config.ViewerAddress, Method: viewerMethodActiveBins, Params: []any{common.HexToAddress(p.Address)}}, []any{&activeBin}).
 		TryBlockAndAggregate()
 	if err != nil {
@@ -104,11 +99,19 @@ func (t *PoolTracker) GetNewPoolState(
 		Method: factoryMethodGetVariableFeeCap,
 		Params: []any{static.BinStep, quote.FeeParams.BaseFactor},
 	}, []any{&variableFeeCap}).Call(); err != nil {
-		// getVariableFeeCap is best-effort (0 = no cap), matching the deployed try/catch.
+		// Best-effort fallback, mirroring the viewer's try/catch. NOTE: in V2 a zero cap pins the
+		// variable fee to zero (#147), so log it — a silent 0 here under-quotes the fee.
+		logger.WithFields(logger.Fields{"pool_id": p.Address, "error": err}).
+			Warn("getVariableFeeCap failed; defaulting to 0 (variable fee pinned to zero)")
 		variableFeeCap = 0
 	}
 
-	// Bins from the viewer are already normalized (18-decimal); use directly, drop empties.
+	// The V2 viewer reports bin reserves in NATIVE decimals (the V1 viewer reported 18-decimal
+	// normalized — this flipped in the redeploy). The swap math runs on normalized values, and bin
+	// reserves only ever change by whole multiples of the scale factors, so scaling back up is
+	// exact. Drop empty bins.
+	scaleX, _ := uint256.FromBig(quote.ScaleX)
+	scaleY, _ := uint256.FromBig(quote.ScaleY)
 	bins := make([]Bin, 0, len(activeBin.BinIds))
 	for i, id := range activeBin.BinIds {
 		rx, _ := uint256.FromBig(activeBin.ReservesX[i])
@@ -116,12 +119,13 @@ func (t *PoolTracker) GetNewPoolState(
 		if (rx == nil || rx.IsZero()) && (ry == nil || ry.IsZero()) {
 			continue
 		}
-		bins = append(bins, Bin{ID: uint32(id.Uint64()), ReserveX: orZero(rx), ReserveY: orZero(ry)})
+		bins = append(bins, Bin{
+			ID:       uint32(id.Uint64()),
+			ReserveX: new(uint256.Int).Mul(orZero(rx), scaleX),
+			ReserveY: new(uint256.Int).Mul(orZero(ry), scaleY),
+		})
 	}
 	sort.Slice(bins, func(i, j int) bool { return bins[i].ID < bins[j].ID })
-
-	// Decay the accumulator to "now" (≈ tracked block) exactly as _getDecayedVolatility does.
-	startVol := decayedVolatility(quote, uint64(time.Now().Unix()))
 
 	extra := Extra{
 		ActiveID: uint32(activeID.Uint64()),
@@ -136,10 +140,10 @@ func (t *PoolTracker) GetNewPoolState(
 			MinSwapBps:               quote.FeeParams.MinSwapBps,
 		},
 		VariableFeeCap:        variableFeeCap,
-		VolatilityAccumulator: startVol,
+		VolatilityAccumulator: quote.VolatilityAccumulator.Uint64(),
 		VolatilityReference:   uint32(quote.VolatilityReference.Uint64()),
-		NativeReserveX:        stats.ReserveX.String(),
-		NativeReserveY:        stats.ReserveY.String(),
+		LastVolatilityUpdate:  quote.LastVolatilityUpdate.Uint64(),
+		Timestamp:             uint64(time.Now().Unix()),
 	}
 
 	extraBytes, err := json.Marshal(extra)
@@ -148,25 +152,10 @@ func (t *PoolTracker) GetNewPoolState(
 	}
 
 	p.Extra = string(extraBytes)
-	p.Reserves = entity.PoolReserves{stats.ReserveX.String(), stats.ReserveY.String()}
+	p.Reserves = entity.PoolReserves{reserves.ReserveX.String(), reserves.ReserveY.String()}
 	p.BlockNumber = blockNumber.Uint64()
 	p.Timestamp = time.Now().Unix()
 
 	logger.WithFields(logger.Fields{"pool_id": p.Address, "bins": len(bins), "block": p.BlockNumber}).Info("finished getting new pool state")
 	return p, nil
-}
-
-// decayedVolatility mirrors the viewer's _getDecayedVolatility: constant during the filter period,
-// linear decay after, to zero past decayPeriod.
-func decayedVolatility(q quoteStateRPC, now uint64) uint64 {
-	vol := q.VolatilityAccumulator.Uint64()
-	last := q.LastVolatilityUpdate.Uint64()
-	if now <= last {
-		return vol
-	}
-	delta := now - last
-	if delta < uint64(q.FeeParams.FilterPeriod) {
-		return vol
-	}
-	return applyVolatilityDecay(vol, delta, uint64(q.FeeParams.DecayPeriod))
 }

--- a/pkg/liquidity-source/umbrae/dlmm/type.go
+++ b/pkg/liquidity-source/umbrae/dlmm/type.go
@@ -17,6 +17,8 @@ type StaticExtra struct {
 
 // FeeParameters mirrors the DEPLOYED FeeHelper.FeeParameters (7 fields; no protocolShare —
 // protocol share is global on the factory). maxVolatilityAccumulator is uint24 on-chain.
+// reductionFactor and minSwapBps are carried for ABI fidelity but are DEAD in the V2 swap path:
+// nothing reads reductionFactor, and the V1 min-swap volatility gate was removed.
 type FeeParameters struct {
 	BaseFactor               uint16 `json:"baseFactor"`
 	FilterPeriod             uint16 `json:"filterPeriod"`
@@ -27,8 +29,8 @@ type FeeParameters struct {
 	MinSwapBps               uint16 `json:"minSwapBps"`
 }
 
-// Bin is one discrete liquidity bin. Reserves are in the 18-decimal normalized space (native
-// getBin() reserves multiplied by the token scale factor).
+// Bin is one discrete liquidity bin. Reserves are in the 18-decimal normalized space (the pair
+// stores them normalized; the viewer reports native, so the tracker scales back up).
 type Bin struct {
 	ID       uint32       `json:"id"`
 	ReserveX *uint256.Int `json:"reserveX"`
@@ -36,22 +38,24 @@ type Bin struct {
 }
 
 // Extra is the mutable per-pool state refreshed each block. The dynamic fee depends on the
-// volatility accumulator + reference, which the deployed pair exposes via getQuoteState(); the
-// tracker decays the accumulator to the tracked block and the simulator ramps it from the reference
-// as bins are crossed, matching the deployed quoteSwap().
+// anchored-displacement volatility model (V2 R12/M-3): the accumulator is the displacement from a
+// per-window anchor bin (volatilityReference), decayed only once the filter window has lapsed. The
+// tracker stores the raw on-chain state plus the tracked timestamp; the simulator derives the
+// working volatility exactly as the deployed quote path does.
 type Extra struct {
 	ActiveID       uint32        `json:"activeId"`
 	Bins           []Bin         `json:"bins"` // sorted ascending by ID; normalized reserves
 	FeeParameters  FeeParameters `json:"feeParameters"`
 	VariableFeeCap uint16        `json:"variableFeeCap"` // from Factory.getVariableFeeCap(binStep, baseFactor)
-	// Volatility state for the dynamic-fee ramp. VolatilityAccumulator is already decayed to the
-	// tracked block, and VolatilityReference is the reference bin (== activeId when idle).
+	// Raw volatility state from getQuoteState(), NOT pre-decayed: the filter-window decision
+	// (decay vs anchor reuse) must be made at quote time against the same clock.
 	VolatilityAccumulator uint64 `json:"volatilityAccumulator"`
-	VolatilityReference   uint32 `json:"volatilityReference"`
-	// Native (un-normalized) total reserves; feed the min-swap-for-volatility threshold exactly as
-	// the deployed _getMinSwapForVolatility does (native sum * minSwapBps / 10000).
-	NativeReserveX string `json:"nativeReserveX"`
-	NativeReserveY string `json:"nativeReserveY"`
+	VolatilityReference   uint32 `json:"volatilityReference"` // anchor bin id; < 2^22 means unset
+	LastVolatilityUpdate  uint64 `json:"lastVolatilityUpdate"`
+	// Timestamp the state was tracked at; the simulator's clock for decay/window decisions. The
+	// quote is a snapshot — fees drift as the accumulator decays between tracking and execution
+	// (same caveat as the DAMM package's currentFeeBps snapshot).
+	Timestamp uint64 `json:"timestamp"`
 }
 
 // binUpdate records a post-swap bin reserve (normalized) for UpdateBalance to apply by index,
@@ -65,6 +69,11 @@ type binUpdate struct {
 type SwapInfo struct {
 	newActiveID uint32
 	binUpdates  []binUpdate
+	// Volatility persistence mirrors the pair: the accumulator/anchor/clock are only written when
+	// at least one bin was crossed.
+	binsCrossed bool
+	newVolAcc   uint64
+	newVolRef   uint32
 }
 
 type PoolMeta struct {

--- a/pkg/liquidity-source/umbrae/dlmm/verification_test.go
+++ b/pkg/liquidity-source/umbrae/dlmm/verification_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/KyberNetwork/ethrpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 
@@ -16,18 +17,28 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
-// Canonical Base mainnet U1/WETH DLMM pair (binStep 25), its factory and the PairViewer.
+// V2 stack, Base mainnet (deployed 2026-08-24). verifyPair is the WETH/USDC binStep-10 pair — the
+// one holding the live liquidity; it is also the sharpest decimals test (18/6).
 const (
-	verifyPair     = "0x697b72320656e6dc60db7a4bfb95084c9d9c55a0"
-	verifyFactory  = "0x17Da44dcbdffD8c715be7A368E19F252C2940Fee"
-	verifyViewer   = "0xbA3A5400A95b055b1412e18ad1978EdF32Fc3F05"
-	verifyRouter   = "0x4965DD6877ca9DE77caca2f57996651e7AF23c93"
+	verifyPair     = "0x4a27eeff8abe2a467425fdac65e5b579e26a90b5"
+	verifyFactory  = "0x9DBB9289d0D75508b5D8EE01FfE4eb7c412F733b"
+	verifyViewer   = "0xEaBC5b163bF79CdCE31027E722361802FAbBe8fD"
+	verifyRouter   = "0x5A7673d413f510f4b5c191d96837694C5942bF38"
 	multicall3Base = "0xcA11bde05977b3631167028862bE2a173976CA11"
 )
 
+// Per-direction amount spreads: tokenX is WETH (18 dec), tokenY is USDC (6 dec).
+func verifyAmounts(swapForY bool) []*big.Int {
+	if swapForY { // WETH in
+		return []*big.Int{exp10(14), exp10(15), exp10(16), exp10(17), exp10(18), mul(exp10(18), 10)}
+	} // USDC in
+	return []*big.Int{exp10(4), exp10(5), exp10(6), exp10(7), exp10(8), exp10(9)}
+}
+
 // TestVerifyAgainstChain is the end-to-end gate: real PoolTracker -> PoolSimulator -> compared to
-// the pair's on-chain quoteSwap (via PairViewer) across a spread of amounts in both directions, all
-// pinned to the tracked block. Set UMBRAE_BASE_RPC_URL to run.
+// the on-chain quoteSwap (via PairViewer) across a spread of amounts in both directions, all pinned
+// to the tracked block. The simulator's volatility clock is pinned to the tracked block's timestamp
+// so the dynamic fee matches the view call exactly. Set UMBRAE_BASE_RPC_URL to run.
 func TestVerifyAgainstChain(t *testing.T) {
 	rpcURL := os.Getenv("UMBRAE_BASE_RPC_URL")
 	if rpcURL == "" {
@@ -37,11 +48,10 @@ func TestVerifyAgainstChain(t *testing.T) {
 	ctx := context.Background()
 
 	// Full ingestion pipeline: static config (as the lister persists it) -> tracker -> simulator.
-	sim, tokenX, tokenY, pinBlock := buildLiveSimulator(t, ctx, client)
+	sim, tokenX, tokenY, pinBlock := buildLiveSimulator(t, ctx, client, rpcURL)
 	require.Equal(t, verifyRouter, sim.GetApprovalAddress(tokenX, tokenY),
 		"approval address must be the DLMM Router, not the pair")
 
-	amounts := []*big.Int{exp10(14), exp10(15), exp10(16), exp10(17), exp10(18), mul(exp10(18), 10), mul(exp10(18), 1000)}
 	for _, swapForY := range []bool{true, false} {
 		tokenIn, tokenOut := tokenX, tokenY
 		if !swapForY {
@@ -51,16 +61,19 @@ func TestVerifyAgainstChain(t *testing.T) {
 		if !swapForY {
 			dir = "Y->X"
 		}
-		for _, amt := range amounts {
+		for _, amt := range verifyAmounts(swapForY) {
 			chainOut, consumed, binsTrav, _ := viewerQuoteSwap(t, ctx, client, pinBlock, swapForY, amt)
 			res, cerr := sim.CalcAmountOut(pool.CalcAmountOutParams{
 				TokenAmountIn: pool.TokenAmount{Token: tokenIn, Amount: amt}, TokenOut: tokenOut,
 			})
 
 			if consumed.Cmp(amt) < 0 {
+				// The viewer partial-fills where execution would revert (dry book or movement
+				// bound); the simulator must reject rather than over-promise.
 				t.Logf("%s in=%-24s | consumed=%-24s (partial) bins=%-3s -> sim err=%v", dir, amt, consumed, binsTrav, cerr)
-				require.ErrorIs(t, cerr, ErrInsufficientLiquidity,
-					"%s in=%s: viewer partial-filled (swap() reverts), sim must reject", dir, amt)
+				require.Error(t, cerr, "%s in=%s: viewer partial-filled (swap() reverts), sim must reject", dir, amt)
+				require.True(t, cerr == ErrInsufficientLiquidity || cerr == ErrSwapMovementExceeded,
+					"%s in=%s: expected liquidity/movement rejection, got %v", dir, amt, cerr)
 				continue
 			}
 			require.NoError(t, cerr, "%s in=%s: fully-consumable swap must succeed", dir, amt)
@@ -71,10 +84,9 @@ func TestVerifyAgainstChain(t *testing.T) {
 	}
 }
 
-// TestVerifyListerLive exercises the real PoolsListUpdater against the live DLMM factory: enumerate
-// pairs, then assert the canonical U1/WETH pair is discovered with correctly-persisted StaticExtra
-// (binStep, decimals, router). This is the on-chain discovery path the verification test skips (it
-// builds the entity.Pool inline). Set UMBRAE_BASE_RPC_URL to run.
+// TestVerifyListerLive exercises the real PoolsListUpdater against the live V2 factory: enumerate
+// pairs, then assert the liquid WETH/USDC binStep-10 pair is discovered with correctly-persisted
+// StaticExtra (binStep, decimals, router). Set UMBRAE_BASE_RPC_URL to run.
 func TestVerifyListerLive(t *testing.T) {
 	rpcURL := os.Getenv("UMBRAE_BASE_RPC_URL")
 	if rpcURL == "" {
@@ -100,17 +112,17 @@ func TestVerifyListerLive(t *testing.T) {
 			break
 		}
 	}
-	require.NotNil(t, found, "canonical U1/WETH pair not enumerated by the factory lister")
+	require.NotNil(t, found, "WETH/USDC binStep-10 pair not enumerated by the factory lister")
 
 	var se StaticExtra
 	require.NoError(t, json.Unmarshal([]byte(found.StaticExtra), &se))
-	require.Equal(t, uint16(25), se.BinStep, "binStep")
+	require.Equal(t, uint16(10), se.BinStep, "binStep")
 	require.Equal(t, verifyRouter, se.Router, "router persisted into StaticExtra")
 	require.Len(t, found.Tokens, 2)
 	require.NotEmpty(t, found.Tokens[0].Address)
 	require.NotEmpty(t, found.Tokens[1].Address)
 	require.Equal(t, entity.PoolReserves{"0", "0"}, found.Reserves, "lister leaves reserves at 0 for the tracker")
-	t.Logf("canonical pair OK: binStep=%d decX=%d decY=%d router=%s tokens=[%s,%s]",
+	t.Logf("liquid pair OK: binStep=%d decX=%d decY=%d router=%s tokens=[%s,%s]",
 		se.BinStep, se.DecimalsX, se.DecimalsY, se.Router, found.Tokens[0].Address, found.Tokens[1].Address)
 }
 
@@ -143,16 +155,21 @@ func TestVerifyUpdateBalance(t *testing.T) {
 	}
 	client := ethrpc.New(rpcURL).SetMulticallContract(common.HexToAddress(multicall3Base))
 	ctx := context.Background()
-	sim, tokenX, tokenY, pinBlock := buildLiveSimulator(t, ctx, client)
+	sim, tokenX, tokenY, pinBlock := buildLiveSimulator(t, ctx, client, rpcURL)
+	_ = tokenX
 
-	// Y->X is the liquid direction for this pool; pick amounts that cross several bins.
-	for _, amt := range []*big.Int{exp10(15), exp10(16), exp10(17)} {
-		_, _, _, chainFinalBin := viewerQuoteSwap(t, ctx, client, pinBlock, false, amt)
+	// USDC (Y) in: amounts that cross several bins on a ~$3k book.
+	for _, amt := range []*big.Int{exp10(6), exp10(7), exp10(8)} {
+		_, consumed, _, chainFinalBin := viewerQuoteSwap(t, ctx, client, pinBlock, false, amt)
 
 		hop := sim.CloneState() // never mutate the shared base
 		res, err := hop.CalcAmountOut(pool.CalcAmountOutParams{
 			TokenAmountIn: pool.TokenAmount{Token: tokenY, Amount: amt}, TokenOut: tokenX,
 		})
+		if consumed.Cmp(amt) < 0 {
+			require.Error(t, err, "viewer partial-filled, sim must reject (amt=%s)", amt)
+			continue
+		}
 		require.NoError(t, err)
 		si := res.SwapInfo.(SwapInfo)
 		require.Equal(t, chainFinalBin.Uint64(), uint64(si.newActiveID),
@@ -185,8 +202,10 @@ func TestVerifyUpdateBalance(t *testing.T) {
 }
 
 // buildLiveSimulator runs the real lister-equivalent static config + tracker -> simulator pipeline
-// against the canonical pair, returning the simulator, its token addresses and the pinned block.
-func buildLiveSimulator(t *testing.T, ctx context.Context, client *ethrpc.Client) (*PoolSimulator, string, string, *big.Int) {
+// against the liquid pair, returning the simulator, its token addresses and the pinned block. The
+// Extra's volatility clock is re-pinned to the tracked block's timestamp so quote comparisons at
+// that block are exact (production uses wall-clock time, which tracks head within seconds).
+func buildLiveSimulator(t *testing.T, ctx context.Context, client *ethrpc.Client, rpcURL string) (*PoolSimulator, string, string, *big.Int) {
 	t.Helper()
 	var (
 		tokenXAddr, tokenYAddr common.Address
@@ -211,6 +230,20 @@ func buildLiveSimulator(t *testing.T, ctx context.Context, client *ethrpc.Client
 	tracker := NewPoolTracker(&Config{DexID: DexType, FactoryAddress: verifyFactory, ViewerAddress: verifyViewer, RouterAddress: verifyRouter}, client)
 	ep, err = tracker.GetNewPoolState(ctx, ep, pool.GetNewPoolStateParams{})
 	require.NoError(t, err)
+
+	// Re-pin the volatility clock to the tracked block's timestamp.
+	ec, err := ethclient.DialContext(ctx, rpcURL)
+	require.NoError(t, err)
+	defer ec.Close()
+	header, err := ec.HeaderByNumber(ctx, new(big.Int).SetUint64(ep.BlockNumber))
+	require.NoError(t, err)
+	var extra Extra
+	require.NoError(t, json.Unmarshal([]byte(ep.Extra), &extra))
+	extra.Timestamp = header.Time
+	eb, err := json.Marshal(extra)
+	require.NoError(t, err)
+	ep.Extra = string(eb)
+
 	sim, err := NewPoolSimulator(ep)
 	require.NoError(t, err)
 	return sim, tokenXAddr.Hex(), tokenYAddr.Hex(), new(big.Int).SetUint64(ep.BlockNumber)


### PR DESCRIPTION
## Why

Umbrae's original DLMM stack (integrated in #1524, patched in #1526) was exploited on 2026-08-06 and paused the same day. That stack is permanently **withdrawal-only** — the addresses this lib currently quotes serve no swaps. A rebuilt V2 stack was deployed to Base on 2026-08-24 and has been taking production traffic since 2026-08-25. This PR updates `umbrae-dlmm` to the V2 contracts and swap engine. **Until it lands, umbrae-dlmm should be considered dead-pooled** — we recommend disabling the source in routing config if it is enabled anywhere.

`umbrae-damm` is unaffected (contract unchanged; re-verified 10/10 wei-exact against the live pair).

## New deployment config (Base, chain 8453)

The package stays fully config-driven; these are the values our side will supply / that replace the retired ones:

| Config field | V2 address |
|---|---|
| `factoryAddress` | `0x9DBB9289d0D75508b5D8EE01FfE4eb7c412F733b` |
| `viewerAddress` | `0xEaBC5b163bF79CdCE31027E722361802FAbBe8fD` |
| `routerAddress` | `0x5A7673d413f510f4b5c191d96837694C5942bF38` |

Pair discovery is unchanged (factory enumeration; creation is permissionless — 3 pairs live at time of writing). The router's `swapExactTokensForTokens` signature is unchanged, so execution encoding should carry over; note V2's router requires explicit pool addresses (no zero-address auto-discovery) and exact-output swaps are disabled on-chain.

## What changed in the simulator (V2 swap engine)

- **Unified 1e18 price domain** — per-bin amounts via split `mulDiv` floor/ceil (`a*(b/d) + a*(b%d)/d`, not 512-bit; overflow errors like the on-chain revert) with `priceDenominator = scaleY * 10^decimalsX`, identical in both directions. Unrepresentable bin prices fail closed.
- **Fee ceils** (denominator `10000 + fee`, clamped below the full amount) and is **prorated per bin** to the consumed input; the unspent slice returns to the gross remainder.
- **Anchored-displacement volatility** — working vol = window base + `|bin − anchor|` (no cumulative ratchet), filter-window decay semantics. The V1 min-swap volatility gate no longer exists on-chain and is deleted.
- **Movement bound** — quotes reaching further than 2048 bins or `distance*binStep > 10000` bps from the entry bin are refused (execution reverts there; the view quote would partial-fill and over-promise).
- **`variableFeeCap` clamp is unconditional** (a zero cap pins the variable fee to zero), zero-output bins are skipped uncharged.
- **Tracker** — the V2 viewer reports bin reserves in **native** decimals (V1 reported 18-dec normalized); they are scaled back up exactly. Volatility state is stored raw with its clock; `getPairStatistics` replaced by `getReserves`. ABIs regenerated from the Basescan-verified V2 contracts.
- Partial-fill semantics keep #1526's behavior: input the tracked book cannot fully consume returns `ErrInsufficientLiquidity` (or `ErrSwapMovementExceeded`) instead of a partial quote.

## Verification (live Base, pinned block)

`TestVerifyAgainstChain` (env-gated `UMBRAE_BASE_RPC_URL`): tracker → simulator vs `PairViewer.quoteSwap` on the WETH/USDC binStep-10 pair — the sharpest decimals case (18/6):

```
X->Y in=1e14  chain=250060          sim=250060          bins=0   OK
X->Y in=1e15  chain=2500606        sim=2500606         bins=0   OK
X->Y in=1e16  chain=24985300       sim=24985300        bins=1   OK
X->Y in=1e17  chain=249314423      sim=249314423       bins=6   OK
X->Y in=1e18  chain=2453906825     sim=2453906825      bins=31  OK
X->Y in=1e19  partial (viewer consumed < in)  -> sim rejects   OK
Y->X in=1e4   chain=3992637116731        sim=3992637116731        bins=0  OK
Y->X in=1e5   chain=39926371167316       sim=39926371167316       bins=0  OK
Y->X in=1e6   chain=399263711673168      sim=399263711673168      bins=0  OK
Y->X in=1e7   chain=3990732885760534     sim=3990732885760534     bins=1  OK
Y->X in=1e8   partial -> sim rejects  OK
Y->X in=1e9   partial -> sim rejects  OK
```

`TestVerifyUpdateBalance`: `SwapInfo.newActiveID` matches the on-chain `finalBinId`; bin write-backs verbatim; depleted-book monotonicity on the second hop. `TestVerifyListerLive`: all live pairs enumerated with correct static extras. Offline unit tests cover the V2 fee ceiling, unconditional cap, movement bound, 18/6 decimal scaling, and the split-mulDiv rounding, with hand-computed fixtures.

cc @NgoKimPhu (merged #1524/#1526) — happy to adjust to whatever config/rollout process you prefer for the address cutover.

Assisted-by: AI