### PR TITLE
feat(limitorder): cache operator signatures and fetch only the misses

### DIFF
--- a/pkg/source/limitorder/config.go
+++ b/pkg/source/limitorder/config.go
@@ -22,4 +22,11 @@ type Config struct {
 	// HTTPClient lets callers supply their own Transport. http.DefaultTransport keeps only
 	// 2 idle connections per host, which starves callers that fan RFQ out concurrently.
 	HTTPClient *http.Client `json:"-"`
+
+	// OpSignatureCacheTTL caps how long GetOpSignatures may serve an operator signature
+	// from memory instead of asking the limit-order backend. 0 disables the cache.
+	OpSignatureCacheTTL durationjson.Duration `json:"opSignatureCacheTTL"`
+	// OpSignatureValidityMargin is how far past now a cached signature must still be valid
+	// to be reused; defaults to defaultOpSignatureValidityMargin.
+	OpSignatureValidityMargin durationjson.Duration `json:"opSignatureValidityMargin"`
 }

--- a/pkg/source/limitorder/http_client.go
+++ b/pkg/source/limitorder/http_client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -19,6 +20,8 @@ const defaultHTTPTimeout = 30 * time.Second
 
 type httpClient struct {
 	client *resty.Client
+	// opSigCache is nil when caching is disabled; every method on it tolerates that.
+	opSigCache *opSignatureCache
 }
 
 // Deprecated: use NewHTTPClientWithConfig, which also supports a timeout, retries and a
@@ -65,7 +68,8 @@ func NewHTTPClientWithConfig(cfg *Config) *httpClient {
 		SetRetryCount(retryCount)
 
 	return &httpClient{
-		client: client,
+		client:     client,
+		opSigCache: newOpSignatureCache(cfg.OpSignatureCacheTTL.Duration, cfg.OpSignatureValidityMargin.Duration),
 	}
 }
 
@@ -152,6 +156,28 @@ func (c *httpClient) GetOpSignatures(
 	chainId ChainID,
 	orderIds []int64,
 ) ([]*operatorSignatures, error) {
+	cached, uncached := c.opSigCache.reusable(orderIds)
+	if len(uncached) == 0 {
+		return cached, nil
+	}
+
+	fetched, err := c.fetchOpSignatures(ctx, chainId, uncached)
+	if err != nil {
+		return nil, err
+	}
+	c.opSigCache.store(fetched)
+
+	if len(cached) == 0 {
+		return fetched, nil
+	}
+	return append(cached, fetched...), nil
+}
+
+func (c *httpClient) fetchOpSignatures(
+	ctx context.Context,
+	chainId ChainID,
+	orderIds []int64,
+) ([]*operatorSignatures, error) {
 	req := c.client.R().SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
 		SetQueryParam("chainId", strconv.Itoa(int(chainId))).
@@ -177,4 +203,97 @@ func (c *httpClient) GetOpSignatures(
 	}
 
 	return result.Data.OperatorSignatures, nil
+}
+
+// The operator signs (orderHash, opExpireTime) only — never amount, taker or recipient — and
+// the backend mints a new expiry only once the current one has less than its minimum valid
+// time left. Repeated calls for the same order inside that gap hand back a byte-identical
+// signature, so a cache hit is equivalent to a live call rather than an approximation of one.
+type opSignatureCache struct {
+	mu             sync.Mutex
+	entries        map[int64]opSignatureCacheEntry
+	ttl            time.Duration
+	validityMargin time.Duration
+}
+
+type opSignatureCacheEntry struct {
+	sig     operatorSignatures
+	staleAt time.Time
+}
+
+// defaultOpSignatureValidityMargin approximates "still valid when the tx executes": dex-lib
+// cannot see the target block time, so it requires the signature to outlive two Ethereum
+// blocks instead.
+const defaultOpSignatureValidityMargin = 24 * time.Second
+
+// maxCachedOpSignatures is the size past which unusable entries are swept before new ones are
+// stored. No entry survives its TTL, so a sweep always reclaims everything older than that.
+const maxCachedOpSignatures = 16384
+
+func newOpSignatureCache(ttl, validityMargin time.Duration) *opSignatureCache {
+	if ttl <= 0 {
+		return nil
+	}
+	if validityMargin <= 0 {
+		validityMargin = defaultOpSignatureValidityMargin
+	}
+
+	return &opSignatureCache{
+		entries:        make(map[int64]opSignatureCacheEntry),
+		ttl:            ttl,
+		validityMargin: validityMargin,
+	}
+}
+
+// reusable splits orderIds into the signatures that can be served from memory and the ids that
+// still have to be fetched.
+func (c *opSignatureCache) reusable(orderIds []int64) (cached []*operatorSignatures, uncached []int64) {
+	if c == nil {
+		return nil, orderIds
+	}
+
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, id := range orderIds {
+		entry, ok := c.entries[id]
+		if !ok || !entry.usableAt(now, c.validityMargin) {
+			uncached = append(uncached, id)
+			continue
+		}
+		sig := entry.sig
+		cached = append(cached, &sig)
+	}
+
+	return cached, uncached
+}
+
+func (c *opSignatureCache) store(sigs []*operatorSignatures) {
+	if c == nil || len(sigs) == 0 {
+		return
+	}
+
+	now := time.Now()
+	staleAt := now.Add(c.ttl)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) > maxCachedOpSignatures {
+		for id, entry := range c.entries {
+			if !entry.usableAt(now, c.validityMargin) {
+				delete(c.entries, id)
+			}
+		}
+	}
+	for _, sig := range sigs {
+		if sig == nil {
+			continue
+		}
+		c.entries[sig.ID] = opSignatureCacheEntry{sig: *sig, staleAt: staleAt}
+	}
+}
+
+func (e opSignatureCacheEntry) usableAt(now time.Time, validityMargin time.Duration) bool {
+	return now.Before(e.staleAt) && e.sig.OperatorSignatureExpiredAt > now.Add(validityMargin).Unix()
 }

--- a/pkg/source/limitorder/http_client_test.go
+++ b/pkg/source/limitorder/http_client_test.go
@@ -2,8 +2,12 @@ package limitorder
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -132,5 +136,148 @@ func TestNewHTTPClientWithRestyClient(t *testing.T) {
 		c := NewHTTPClientWithRestyClient(baseURL, injected)
 		assert.Equal(t, 5*time.Second, c.client.GetClient().Timeout)
 		assert.Equal(t, baseURL, c.client.BaseURL)
+	})
+}
+
+// opSigServer serves an operator signature per requested orderId and records the orderIds of
+// every request it receives.
+type opSigServer struct {
+	*httptest.Server
+
+	mu       sync.Mutex
+	requests [][]string
+}
+
+func newOpSigServer(t *testing.T, expiresIn time.Duration) *opSigServer {
+	t.Helper()
+
+	srv := &opSigServer{}
+	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		orderIds := r.URL.Query()["orderIds"]
+		srv.mu.Lock()
+		srv.requests = append(srv.requests, orderIds)
+		srv.mu.Unlock()
+
+		expiredAt := time.Now().Add(expiresIn).Unix()
+		orders := make([]string, 0, len(orderIds))
+		for _, id := range orderIds {
+			orders = append(orders, fmt.Sprintf(
+				`{"id":%s,"chainId":"1","operatorSignature":"0xsig%s","operatorSignatureExpiredAt":%d}`,
+				id, id, expiredAt))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"code":0,"data":{"orders":[%s]}}`, strings.Join(orders, ","))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func (s *opSigServer) recorded() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.requests)
+}
+
+// TestGetOpSignatures_Cache covers the operator-signature cache: the backend re-signs only
+// once the current expiry is nearly up, so a hit inside that window is byte-identical to a
+// live call.
+func TestGetOpSignatures_Cache(t *testing.T) {
+	const (
+		liveTTL      = time.Minute
+		liveExpiry   = 90 * time.Second
+		liveChainID  = ChainID(1)
+		expiringSoon = defaultOpSignatureValidityMargin / 2
+	)
+
+	newClient := func(baseURL string, cacheTTL time.Duration) *httpClient {
+		return NewHTTPClientWithConfig(&Config{
+			LimitOrderHTTPUrl:   baseURL,
+			OpSignatureCacheTTL: durationjson.Duration{Duration: cacheTTL},
+		})
+	}
+
+	t.Run("a repeated orderId is served from cache", func(t *testing.T) {
+		srv := newOpSigServer(t, liveExpiry)
+		c := newClient(srv.URL, liveTTL)
+
+		first, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+		require.NoError(t, err)
+		second, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+		require.NoError(t, err)
+
+		assert.Equal(t, [][]string{{"1"}}, srv.recorded())
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("only the uncached ids are fetched", func(t *testing.T) {
+		srv := newOpSigServer(t, liveExpiry)
+		c := newClient(srv.URL, liveTTL)
+
+		_, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1, 2})
+		require.NoError(t, err)
+		sigs, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1, 2, 3})
+		require.NoError(t, err)
+
+		assert.Equal(t, [][]string{{"1", "2"}, {"3"}}, srv.recorded())
+
+		signatureByID := make(map[int64]string, len(sigs))
+		for _, sig := range sigs {
+			signatureByID[sig.ID] = sig.OperatorSignature
+		}
+		assert.Equal(t, map[int64]string{1: "0xsig1", 2: "0xsig2", 3: "0xsig3"}, signatureByID)
+	})
+
+	t.Run("a signature expiring inside the validity margin is refetched", func(t *testing.T) {
+		srv := newOpSigServer(t, expiringSoon)
+		c := newClient(srv.URL, liveTTL)
+
+		_, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+		require.NoError(t, err)
+		_, err = c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+		require.NoError(t, err)
+
+		assert.Equal(t, [][]string{{"1"}, {"1"}}, srv.recorded())
+	})
+
+	t.Run("an entry past the cache TTL is refetched", func(t *testing.T) {
+		srv := newOpSigServer(t, liveExpiry)
+		c := newClient(srv.URL, time.Millisecond)
+
+		_, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+		require.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+		_, err = c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+		require.NoError(t, err)
+
+		assert.Equal(t, [][]string{{"1"}, {"1"}}, srv.recorded())
+	})
+
+	t.Run("zero TTL disables the cache", func(t *testing.T) {
+		srv := newOpSigServer(t, liveExpiry)
+		c := newClient(srv.URL, 0)
+
+		for range 2 {
+			_, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{1})
+			require.NoError(t, err)
+		}
+
+		assert.Equal(t, [][]string{{"1"}, {"1"}}, srv.recorded())
+	})
+
+	t.Run("concurrent callers share one cache", func(t *testing.T) {
+		srv := newOpSigServer(t, liveExpiry)
+		c := newClient(srv.URL, liveTTL)
+
+		var wg sync.WaitGroup
+		for i := range 32 {
+			wg.Go(func() {
+				sigs, err := c.GetOpSignatures(t.Context(), liveChainID, []int64{int64(i % 4)})
+				assert.NoError(t, err)
+				assert.Len(t, sigs, 1)
+			})
+		}
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
## Problem

`GetOpSignatures` calls the limit-order backend for **every** order on **every** RFQ. That endpoint is not read-only — it also writes (`UpdateOpSignatureExpTimeIfActive`), so each redundant call costs a DB write as well as a round trip.

## Why caching here is exact, not an approximation

The operator signs EIP-712 over `(orderHash, opExpireTime)` **only** — never amount, taker or recipient. And the backend (`limit-order` `order_impl.go`, `GetOperatorSignature`) mints a **new** expiry only when the current one has less than `OperatorSigMinimumValidTimeInSecs` left of its `OperatorSigExpTimeInSecs` window — `90s` / `60s` on mainnet.

So two calls for the same orderID inside that ~30s gap return a **byte-identical** signature. Serving one from memory is *equivalent to* calling live, not an estimate of it.

There is production precedent for exactly this: `1inch-resolver`'s `kslimitorder` handler caches per orderID and gates on `cached.expiredAt > nextBlockTime`.

## Design

Caching lives **inside** `GetOpSignatures`, not in a wrapper. That is the whole point: the win is splitting one request into hits and misses and fetching **only the misses**. A wrapper cannot do that — the function is always asked for the full id set.

```
GetOpSignatures(ctx, chainID, orderIds)
  1. reusable(orderIds) -> (cached, uncached)
  2. fetchOpSignatures(ctx, chainID, uncached)   // only the misses hit the network
  3. store(fetched)
  4. return cached ++ fetched
```

The exported contract is unchanged: still `([]*operatorSignatures, error)`, still `nil, nil` on empty data, same error wrapping.

**Reuse predicate.** An entry is served only while it is inside its TTL *and* `expiredAt > now + validityMargin`. The semantically correct bound is "still valid when the tx executes", but dex-lib does not know the target block time — so `validityMargin` stands in for it and defaults to **24s (~2 Ethereum blocks)**. Configurable.

**Storage.** `map[int64]entry` + `sync.Mutex`. Entries are stored **by value** and a fresh pointer is handed to each caller, so concurrent callers never share a mutable `*operatorSignatures`. Past `maxCachedOpSignatures` (16384) unusable entries are swept before new ones are stored; since no entry outlives its TTL, a sweep always reclaims the whole previous window. No LRU, no background goroutine.

**Negative results are not cached.** A dead order is dead forever, but negative caching adds risk for a small win — skipped in v1.

## Config — default OFF

```go
OpSignatureCacheTTL       durationjson.Duration `json:"opSignatureCacheTTL"`       // 0 = cache disabled (default)
OpSignatureValidityMargin durationjson.Duration `json:"opSignatureValidityMargin"` // default 24s
```

This is a shared library. `OpSignatureCacheTTL` defaults to `0`, so **a version bump alone cannot change router-service behaviour** — the consumer has to opt in. `NewHTTPClient` and `NewHTTPClientWithRestyClient` (both deprecated) get no cache at all. Internally the cache pointer is `nil` when disabled and every method is nil-receiver safe, so the disabled path is byte-for-byte the old code path.

## Tests

New `TestGetOpSignatures_Cache` against `httptest.NewServer`, counting the `orderIds` of every request:

| subtest | asserts |
|---|---|
| a repeated orderId is served from cache | 1 request total, identical results |
| only the uncached ids are fetched | requests are `[{1,2}, {3}]`; merged result has all of 1,2,3 |
| a signature expiring inside the validity margin is refetched | 2 requests |
| an entry past the cache TTL is refetched | 2 requests |
| zero TTL disables the cache | 2 requests |
| concurrent callers share one cache | clean under `-race` |

**Verified the tests catch the bug.** With `newOpSignatureCache` neutered to always return `nil` (cache removed), the two cache-behaviour tests fail as intended:

```
--- FAIL: TestGetOpSignatures_Cache/a_repeated_orderId_is_served_from_cache
    expected: [][]string{{"1"}}
    actual  : [][]string{{"1"}, {"1"}}
--- FAIL: TestGetOpSignatures_Cache/only_the_uncached_ids_are_fetched
    expected: [][]string{{"1","2"}, {"3"}}
    actual  : [][]string{{"1","2"}, {"1","2","3"}}
```

The other four subtests still pass without the cache — by construction, since they assert the no-cache request count.

## Checks

- `go build ./...` — clean
- `go vet ./pkg/source/limitorder/...` — clean
- `gofmt -l` / `goimports -local github.com/KyberNetwork/kyberswap-dex-lib` — clean on all three changed files
- `golangci-lint run ./pkg/source/limitorder/...` — 0 issues
- `CI=true go test ./pkg/source/limitorder/... -count=1 -race` — ok
- `go generate ./...` leaves the tree clean (no new simulator registered)

`TestGetOpSignatures_LiveAPI` fails locally with a Cloudflare geo-restriction page from `limit-order.kyberswap.com` ("Access from your country is currently restricted"). That is the endpoint, not this change; the test carries `test.SkipCI(t)` so CI does not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpoYU9hULTGoHo2kuosoax
