### PR TITLE
fix(gsm-4626): enforce GHO facilitator bucket limit and fix inflated reserve

### DIFF
--- a/pkg/liquidity-source/gsm-4626/abi/GhoReserve.json
+++ b/pkg/liquidity-source/gsm-4626/abi/GhoReserve.json
@@ -1,0 +1,12 @@
+[
+  {
+    "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "name": "getUsage",
+    "outputs": [
+      {"internalType": "uint256", "name": "limit", "type": "uint256"},
+      {"internalType": "uint256", "name": "used", "type": "uint256"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/gsm-4626/abis.go
+++ b/pkg/liquidity-source/gsm-4626/abis.go
@@ -10,6 +10,7 @@ var (
 	gsm4626ABI       abi.ABI
 	priceStrategyABI abi.ABI
 	feeStrategyABI   abi.ABI
+	ghoReserveABI    abi.ABI
 )
 
 func init() {
@@ -20,6 +21,7 @@ func init() {
 		{&gsm4626ABI, gsm4626Bytes},
 		{&priceStrategyABI, priceStrategyBytes},
 		{&feeStrategyABI, feeStrategyBytes},
+		{&ghoReserveABI, ghoReserveBytes},
 	}
 
 	for _, b := range builder {

--- a/pkg/liquidity-source/gsm-4626/constant.go
+++ b/pkg/liquidity-source/gsm-4626/constant.go
@@ -18,6 +18,8 @@ const (
 	gsmMethodGetFeeStrategy        = "getFeeStrategy"
 	gsmMethodGetGhoReserve         = "getGhoReserve"
 
+	ghoReserveMethodGetUsage = "getUsage"
+
 	priceStrategyMethodPriceRatio = "PRICE_RATIO"
 
 	feeStrategyMethodGetSellFee = "getSellFee"
@@ -38,4 +40,5 @@ var (
 	ErrExogenousAssetExposureTooHigh                = errors.New("EXOGENOUS_ASSET_EXPOSURE_TOO_HIGH")
 	ErrCannotSwap                                   = errors.New("cannot swap")
 	ErrInvalidAmount                                = errors.New("invalid amount")
+	ErrGhoLimitExceeded                             = errors.New("LIMIT_EXCEEDED")
 )

--- a/pkg/liquidity-source/gsm-4626/embed.go
+++ b/pkg/liquidity-source/gsm-4626/embed.go
@@ -10,3 +10,6 @@ var priceStrategyBytes []byte
 
 //go:embed abi/FeeStrategy.json
 var feeStrategyBytes []byte
+
+//go:embed abi/GhoReserve.json
+var ghoReserveBytes []byte

--- a/pkg/liquidity-source/gsm-4626/pool_simulator.go
+++ b/pkg/liquidity-source/gsm-4626/pool_simulator.go
@@ -4,13 +4,14 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/samber/lo"
+
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 	u256 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/big256"
 	bignum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
-	"github.com/goccy/go-json"
-	"github.com/holiman/uint256"
-	"github.com/samber/lo"
 )
 
 var _ = pool.RegisterFactory0(DexType, NewPoolSimulator)
@@ -31,6 +32,13 @@ func NewPoolSimulator(p entity.Pool) (*PoolSimulator, error) {
 	var staticExtra StaticExtra
 	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
 		return nil, err
+	}
+
+	if extra.GhoLimit == nil {
+		extra.GhoLimit = new(uint256.Int)
+	}
+	if extra.GhoUsed == nil {
+		extra.GhoUsed = new(uint256.Int)
 	}
 
 	return &PoolSimulator{
@@ -57,13 +65,14 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	amountIn := uint256.MustFromBig(params.TokenAmountIn.Amount)
 
 	var (
-		amountOut *uint256.Int
-		fee       *uint256.Int
+		amountOut   *uint256.Int
+		fee         *uint256.Int
+		grossAmount *uint256.Int
 	)
 
 	isBuy := strings.EqualFold(tokenIn, s.Info.Tokens[0])
 	if isBuy {
-		amountOut, fee = s.getAssetAmountForBuyAsset(amountIn)
+		amountOut, fee, grossAmount = s.getAssetAmountForBuyAsset(amountIn)
 
 		if amountOut.Sign() <= 0 {
 			return nil, ErrInvalidAmount
@@ -73,9 +82,13 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		}
 	} else {
 		amountOut, fee = s.getGhoAmountForSellAsset(amountIn)
+		grossAmount = new(uint256.Int).Add(amountOut, fee)
 
 		if new(uint256.Int).Add(s.CurrentExposure, amountIn).Gt(s.ExposureCap) {
 			return nil, ErrExogenousAssetExposureTooHigh
+		}
+		if new(uint256.Int).Add(s.GhoUsed, grossAmount).Gt(s.GhoLimit) {
+			return nil, ErrGhoLimitExceeded
 		}
 	}
 
@@ -89,7 +102,7 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 			Amount: fee.ToBig(),
 		},
 		Gas:      lo.Ternary(isBuy, getAssetAmountForBuyAssetGas+buyAssetGas, sellAssetGas),
-		SwapInfo: &SwapInfo{isBuy},
+		SwapInfo: &SwapInfo{IsBuy: isBuy, GrossAmount: grossAmount},
 	}, nil
 }
 
@@ -97,14 +110,22 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 	swapInfo := params.SwapInfo.(*SwapInfo)
 	if swapInfo.IsBuy {
 		s.CurrentExposure = new(uint256.Int).Sub(s.CurrentExposure, uint256.MustFromBig(params.TokenAmountOut.Amount))
+
+		if s.GhoUsed.Lt(swapInfo.GrossAmount) {
+			s.GhoUsed = new(uint256.Int)
+		} else {
+			s.GhoUsed = new(uint256.Int).Sub(s.GhoUsed, swapInfo.GrossAmount)
+		}
 	} else {
 		s.CurrentExposure = new(uint256.Int).Add(s.CurrentExposure, uint256.MustFromBig(params.TokenAmountIn.Amount))
+		s.GhoUsed = new(uint256.Int).Add(s.GhoUsed, swapInfo.GrossAmount)
 	}
 }
 
 func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
 	cloned := *s
 	cloned.CurrentExposure = new(uint256.Int).Set(s.CurrentExposure)
+	cloned.GhoUsed = new(uint256.Int).Set(s.GhoUsed)
 
 	return &cloned
 }
@@ -145,7 +166,7 @@ func (s *PoolSimulator) getAssetPriceInGho(assetAmount *uint256.Int, roundUp boo
 	return vaultAssets
 }
 
-func (s *PoolSimulator) getAssetAmountForBuyAsset(maxGhoAmount *uint256.Int) (*uint256.Int, *uint256.Int) {
+func (s *PoolSimulator) getAssetAmountForBuyAsset(maxGhoAmount *uint256.Int) (*uint256.Int, *uint256.Int, *uint256.Int) {
 	grossAmount := s.getGrossAmountFromTotalBought(maxGhoAmount)
 	assetAmount := s.getGhoPriceInAsset(grossAmount, false)
 	finalGrossAmount := s.getAssetPriceInGho(assetAmount, true)
@@ -154,7 +175,7 @@ func (s *PoolSimulator) getAssetAmountForBuyAsset(maxGhoAmount *uint256.Int) (*u
 	finalFee := new(uint256.Int)
 	u256.MulDivUp(finalFee, finalGrossAmount, s.BuyFee, percentageFactor)
 
-	return assetAmount, finalFee
+	return assetAmount, finalFee, finalGrossAmount
 }
 
 func (s *PoolSimulator) getGrossAmountFromTotalBought(totalAmount *uint256.Int) *uint256.Int {

--- a/pkg/liquidity-source/gsm-4626/pool_simulator_test.go
+++ b/pkg/liquidity-source/gsm-4626/pool_simulator_test.go
@@ -4,19 +4,20 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	"github.com/goccy/go-json"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
 )
 
 var (
 	entityPool entity.Pool
-	_          = json.Unmarshal([]byte(`{"address":"0x535b2f7c20b9c83d70e519cf9991578ef9816b7b","exchange":"gsm-4626","type":"gsm-4626","tokens":[{"address":"0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f","symbol":"GHO","decimals":18,"swappable":true},{"address":"0x7bc3485026ac48b6cf9baf0a377477fff5703af8","symbol":"waEthUSDT","decimals":6,"swappable":true}],"extra":"{\"canSwap\":true,\"buyFee\":\"15\",\"sellFee\":\"0\",\"currentExposure\":\"318074276664\",\"exposureCap\":\"25000000000000\",\"rate\":\"1146698616999179571600457092\"}","staticExtra":"{\"priceRatio\":\"1000000000000000000\"}","blockNumber":23791585}`), &entityPool)
+	_          = json.Unmarshal([]byte(`{"address":"0x535b2f7c20b9c83d70e519cf9991578ef9816b7b","exchange":"gsm-4626","type":"gsm-4626","tokens":[{"address":"0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f","symbol":"GHO","decimals":18,"swappable":true},{"address":"0x7bc3485026ac48b6cf9baf0a377477fff5703af8","symbol":"waEthUSDT","decimals":6,"swappable":true}],"extra":"{\"canSwap\":true,\"buyFee\":\"15\",\"sellFee\":\"0\",\"currentExposure\":\"318074276664\",\"exposureCap\":\"25000000000000\",\"rate\":\"1146698616999179571600457092\",\"ghoLimit\":\"200000000000000000000000\",\"ghoUsed\":\"0\"}","staticExtra":"{\"priceRatio\":\"1000000000000000000\"}","blockNumber":23791585}`), &entityPool)
 	poolSim    = lo.Must(NewPoolSimulator(entityPool))
 	tokens     = entityPool.Tokens
 )
@@ -49,6 +50,14 @@ func TestCalcAmountOut(t *testing.T) {
 			expectedAmountOut: bignumber.NewBig("114669861699000000000000"),
 			expectedError:     assert.NoError,
 		},
+		{
+			name:          "sell asset exceeds gho facilitator limit",
+			tokenInIdx:    1,
+			tokenOutIdx:   0,
+			amountIn:      bignumber.NewBig("200000000000"),
+			rate:          bignumber.NewBig("1146698616999179571600457092"),
+			expectedError: func(t assert.TestingT, err error, _ ...any) bool { return assert.ErrorIs(t, err, ErrGhoLimitExceeded) },
+		},
 	}
 
 	for _, tc := range tests {
@@ -80,4 +89,54 @@ func TestCalcAmountOut(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGhoUsedRoundTrip guards against underflowing GhoUsed on the buy-asset path when
+// GhoUsed starts at zero (the common case: paying GHO in doesn't need to have been
+// preceded by a sell within the same simulator instance).
+func TestGhoUsedRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cloned := poolSim.CloneState().(*PoolSimulator)
+	cloned.Rate.SetFromBig(bignumber.NewBig("1146696576337460102970261542"))
+
+	buyResult, err := cloned.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokens[0].Address, Amount: big.NewInt(1000000000000000000)},
+		TokenOut:      tokens[1].Address,
+	})
+	assert.NoError(t, err)
+	cloned.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: tokens[0].Address, Amount: big.NewInt(1000000000000000000)},
+		TokenAmountOut: *buyResult.TokenAmountOut,
+		Fee:            *buyResult.Fee,
+		SwapInfo:       buyResult.SwapInfo,
+	})
+	assert.True(t, cloned.GhoUsed.IsZero())
+
+	sellResult, err := cloned.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokens[1].Address, Amount: big.NewInt(100000000000)},
+		TokenOut:      tokens[0].Address,
+	})
+	assert.NoError(t, err)
+	assert.True(t, sellResult.TokenAmountOut.Amount.Sign() > 0)
+}
+
+// TestNewPoolSimulatorMissingGhoUsage guards against a nil-pointer panic on pools whose
+// stale Extra (persisted before ghoLimit/ghoUsed were tracked) omits these fields.
+func TestNewPoolSimulatorMissingGhoUsage(t *testing.T) {
+	t.Parallel()
+
+	p := entityPool
+	p.Extra = `{"canSwap":true,"buyFee":"15","sellFee":"0","currentExposure":"318074276664","exposureCap":"25000000000000","rate":"1146698616999179571600457092"}`
+
+	sim, err := NewPoolSimulator(p)
+	require.NoError(t, err)
+	assert.NotNil(t, sim.GhoLimit)
+	assert.NotNil(t, sim.GhoUsed)
+
+	_, err = sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: tokens[1].Address, Amount: big.NewInt(100000000000)},
+		TokenOut:      tokens[0].Address,
+	})
+	assert.ErrorIs(t, err, ErrGhoLimitExceeded)
 }

--- a/pkg/liquidity-source/gsm-4626/pool_tracker.go
+++ b/pkg/liquidity-source/gsm-4626/pool_tracker.go
@@ -50,6 +50,10 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool,
 		rate            *big.Int
 		feeStrategy     common.Address
 		tokenBalance    *big.Int
+		ghoUsage        struct {
+			Limit *big.Int `abi:"limit"`
+			Used  *big.Int `abi:"used"`
+		}
 	)
 	resp, err := t.ethrpcClient.NewRequest().SetContext(ctx).
 		AddCall(&ethrpc.Call{
@@ -84,6 +88,12 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool,
 			Method: abi.Erc20BalanceOfMethod,
 			Params: []any{staticExtra.GhoReserve},
 		}, []any{&tokenBalance}).
+		AddCall(&ethrpc.Call{
+			ABI:    ghoReserveABI,
+			Target: staticExtra.GhoReserve.String(),
+			Method: ghoReserveMethodGetUsage,
+			Params: []any{common.HexToAddress(p.Address)},
+		}, []any{&ghoUsage}).
 		Aggregate()
 	if err != nil {
 		return p, err
@@ -122,13 +132,26 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool,
 		Rate:            uint256.MustFromBig(rate),
 		BuyFee:          uint256.MustFromBig(buyFee),
 		SellFee:         uint256.MustFromBig(sellFee),
+		GhoLimit:        uint256.MustFromBig(ghoUsage.Limit),
+		GhoUsed:         uint256.MustFromBig(ghoUsage.Used),
 	})
 	if err != nil {
 		return p, err
 	}
 	p.Extra = string(extraBytes)
 	p.Timestamp = time.Now().Unix()
-	p.Reserves = []string{tokenBalance.String(), currentExposure.String()}
+
+	// tokenBalance is GhoReserve's total balance shared across all its facilitators;
+	// this pool can only ever draw up to its own remaining bucket (ghoLimit - ghoUsed).
+	availableGho := new(big.Int).Sub(ghoUsage.Limit, ghoUsage.Used)
+	if availableGho.Sign() < 0 {
+		availableGho.SetInt64(0)
+	}
+	ghoReserve := availableGho
+	if tokenBalance.Cmp(availableGho) < 0 {
+		ghoReserve = tokenBalance
+	}
+	p.Reserves = []string{ghoReserve.String(), currentExposure.String()}
 
 	if resp.BlockNumber != nil {
 		p.BlockNumber = resp.BlockNumber.Uint64()

--- a/pkg/liquidity-source/gsm-4626/type.go
+++ b/pkg/liquidity-source/gsm-4626/type.go
@@ -17,6 +17,8 @@ type Extra struct {
 	CurrentExposure *uint256.Int `json:"currentExposure"`
 	ExposureCap     *uint256.Int `json:"exposureCap"`
 	Rate            *uint256.Int `json:"rate"`
+	GhoLimit        *uint256.Int `json:"ghoLimit"`
+	GhoUsed         *uint256.Int `json:"ghoUsed"`
 }
 
 type Meta struct {
@@ -24,5 +26,6 @@ type Meta struct {
 }
 
 type SwapInfo struct {
-	IsBuy bool `json:"isBuy"`
+	IsBuy       bool         `json:"isBuy"`
+	GrossAmount *uint256.Int `json:"grossAmount"`
 }


### PR DESCRIPTION
Sell-asset swaps only checked ExposureCap on the underlying asset, never
GhoReserve's per-pool facilitator bucket (limit/used from getUsage), so
quotes that pass simulation revert on-chain with LIMIT_EXCEEDED. Also
track the pool's own remaining GHO capacity instead of GhoReserve's raw
token balance, which is shared across all its facilitators and reads as
an absurdly large reserve[0].

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QDG6LaMvpJREm559ZjtZFZ
