### PR TITLE
feat(lunarbase): support v0.4.0 punishment-model pools alongside concentration-curve model

### DIFF
--- a/pkg/liquidity-source/lunarbase/abi.go
+++ b/pkg/liquidity-source/lunarbase/abi.go
@@ -40,6 +40,13 @@ const coreABIJSON = `[
   },
   {
     "inputs": [],
+    "name": "maxPunishmentX24",
+    "outputs": [{"internalType": "uint32", "name": "", "type": "uint32"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getXReserve",
     "outputs": [{"internalType": "uint112", "name": "", "type": "uint112"}],
     "stateMutability": "view",
@@ -137,6 +144,17 @@ const coreABIJSON = `[
       {"indexed": false, "internalType": "uint32", "name": "concentrationK", "type": "uint32"}
     ],
     "name": "ConcentrationKSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true,  "internalType": "bool",   "name": "xToY",         "type": "bool"},
+      {"indexed": false, "internalType": "uint32",  "name": "punishmentX24", "type": "uint32"},
+      {"indexed": false, "internalType": "uint32",  "name": "feeAskX24",    "type": "uint32"},
+      {"indexed": false, "internalType": "uint32",  "name": "feeBidX24",    "type": "uint32"}
+    ],
+    "name": "PunishmentApplied",
     "type": "event"
   },
   {

--- a/pkg/liquidity-source/lunarbase/constant.go
+++ b/pkg/liquidity-source/lunarbase/constant.go
@@ -23,6 +23,7 @@ var (
 	topicSwapExecuted      = crypto.Keccak256Hash([]byte("SwapExecuted(address,bool,uint256,uint256,uint256)"))
 	topicConcentrationKSet = crypto.Keccak256Hash([]byte("ConcentrationKSet(uint32)"))
 	topicBlockDelaySet     = crypto.Keccak256Hash([]byte("BlockDelaySet(uint48)"))
+	topicPunishmentApplied = crypto.Keccak256Hash([]byte("PunishmentApplied(bool,uint24,uint24,uint24)"))
 
 	ErrStalePool             = errors.WithMessage(pool.ErrUnsupported, "stale pool")
 	ErrInvalidToken          = errors.New("invalid token")

--- a/pkg/liquidity-source/lunarbase/flash_block_subscriber.go
+++ b/pkg/liquidity-source/lunarbase/flash_block_subscriber.go
@@ -40,6 +40,7 @@ type poolState struct {
 	LatestUpdateBlock uint64
 	BlockDelay        uint64
 	ConcentrationK    uint32
+	MaxPunishmentX24  uint32
 	BlockNumber       uint64
 
 	StateUpdatedAt    time.Time
@@ -208,6 +209,7 @@ func (s *FlashBlockSubscriber) connectAndListen(ctx context.Context) error {
 		{topicSync, "Sync"},
 		{topicSwapExecuted, "SwapExecuted"},
 		{topicConcentrationKSet, "ConcentrationKSet"},
+		{topicPunishmentApplied, "PunishmentApplied"},
 		{topicBlockDelaySet, "BlockDelaySet"},
 	}
 
@@ -274,6 +276,11 @@ func (s *FlashBlockSubscriber) connectAndListen(ctx context.Context) error {
 		case log := <-subs[4].ch:
 			s.processLog(log)
 		case err := <-subs[4].sub.Err():
+			return fmt.Errorf("punishmentApplied subscription error: %w", err)
+
+		case log := <-subs[5].ch:
+			s.processLog(log)
+		case err := <-subs[5].sub.Err():
 			return fmt.Errorf("blockDelaySet subscription error: %w", err)
 		}
 	}
@@ -369,6 +376,8 @@ func (s *FlashBlockSubscriber) processLog(log types.Log) {
 		s.handleSwapExecuted(log)
 	case topicConcentrationKSet:
 		s.handleConcentrationKSet(log)
+	case topicPunishmentApplied:
+		s.handlePunishmentApplied(log)
 	case topicBlockDelaySet:
 		s.handleBlockDelaySet(log)
 	}
@@ -488,6 +497,27 @@ func (s *FlashBlockSubscriber) handleBlockDelaySet(log types.Log) {
 	}
 
 	s.latestState.BlockDelay = bd
+}
+
+// handlePunishmentApplied applies the post-swap directional fees carried by
+// a punishment-model pool's PunishmentApplied(bool indexed xToY, uint24
+// punishmentX24, uint24 feeAskX24, uint24 feeBidX24) event. The indexed
+// xToY param is not part of Inputs.Unpack's return; only the three
+// non-indexed fields are.
+func (s *FlashBlockSubscriber) handlePunishmentApplied(log types.Log) {
+	values, err := coreABI.Events["PunishmentApplied"].Inputs.Unpack(log.Data)
+	if err != nil || len(values) < 3 {
+		return
+	}
+
+	feeAsk, ok1 := values[1].(uint32)
+	feeBid, ok2 := values[2].(uint32)
+	if !ok1 || !ok2 {
+		return
+	}
+
+	s.latestState.FeeAskX24 = feeAsk
+	s.latestState.FeeBidX24 = feeBid
 }
 
 func subscribeNewHeads(ctx context.Context, client *rpc.Client, ch chan<- *types.Header) (*rpc.ClientSubscription, error) {

--- a/pkg/liquidity-source/lunarbase/helper.go
+++ b/pkg/liquidity-source/lunarbase/helper.go
@@ -32,15 +32,16 @@ type rpcState struct {
 func fetchRPCState(ctx context.Context, coreAddress string, chainID valueobject.ChainID, ethrpcClient *ethrpc.Client,
 	overrides map[common.Address]gethclient.OverrideAccount) (*rpcState, error) {
 	var (
-		tokenX         common.Address
-		tokenY         common.Address
-		paused         bool
-		blockDelay     uint64
-		concentrationK uint32
-		anchorPrice    *big.Int
-		reserveX       *big.Int
-		reserveY       *big.Int
-		state          struct {
+		tokenX           common.Address
+		tokenY           common.Address
+		paused           bool
+		blockDelay       uint64
+		concentrationK   uint32
+		maxPunishmentX24 uint32
+		anchorPrice      *big.Int
+		reserveX         *big.Int
+		reserveY         *big.Int
+		state            struct {
 			AnchorPrice       *big.Int
 			FeeAskX24         uint32
 			FeeBidX24         uint32
@@ -48,7 +49,7 @@ func fetchRPCState(ctx context.Context, coreAddress string, chainID valueobject.
 		}
 	)
 
-	resp, err := ethrpcClient.NewRequest().SetContext(ctx).SetOverrides(overrides).AddCall(&ethrpc.Call{
+	req := ethrpcClient.NewRequest().SetContext(ctx).SetOverrides(overrides).AddCall(&ethrpc.Call{
 		ABI:    coreABI,
 		Target: coreAddress,
 		Method: "X",
@@ -61,10 +62,19 @@ func fetchRPCState(ctx context.Context, coreAddress string, chainID valueobject.
 		Target: coreAddress,
 		Method: "blockDelay",
 	}, []any{&blockDelay}).AddCall(&ethrpc.Call{
+		// concentrationK and maxPunishmentX24 are mutually exclusive across
+		// contract versions: pools on the old concentration-curve model only
+		// have the former; pools upgraded to the punishment model (SDK
+		// v0.4.0) only have the latter. Exactly one is expected to revert, so
+		// these two calls alone are allowed to fail within the batch below.
 		ABI:    coreABI,
 		Target: coreAddress,
 		Method: "concentrationK",
 	}, []any{&concentrationK}).AddCall(&ethrpc.Call{
+		ABI:    coreABI,
+		Target: coreAddress,
+		Method: "maxPunishmentX24",
+	}, []any{&maxPunishmentX24}).AddCall(&ethrpc.Call{
 		ABI:    coreABI,
 		Target: coreAddress,
 		Method: "getXReserve",
@@ -84,9 +94,29 @@ func fetchRPCState(ctx context.Context, coreAddress string, chainID valueobject.
 		ABI:    coreABI,
 		Target: coreAddress,
 		Method: "anchorPrice",
-	}, []any{&anchorPrice}).Aggregate()
+	}, []any{&anchorPrice})
+
+	const (
+		idxConcentrationK   = 3
+		idxMaxPunishmentX24 = 4
+	)
+	resp, err := req.TryBlockAndAggregate()
 	if err != nil {
 		return nil, err
+	}
+	for i, ok := range resp.Result {
+		if !ok && i != idxConcentrationK && i != idxMaxPunishmentX24 {
+			return nil, ErrQuoteFailed
+		}
+	}
+	if !resp.Result[idxConcentrationK] && !resp.Result[idxMaxPunishmentX24] {
+		return nil, ErrQuoteFailed
+	}
+	if !resp.Result[idxConcentrationK] {
+		concentrationK = 0
+	}
+	if !resp.Result[idxMaxPunishmentX24] {
+		maxPunishmentX24 = 0
 	}
 	blockNumber := resp.BlockNumber.Uint64()
 
@@ -122,6 +152,7 @@ func fetchRPCState(ctx context.Context, coreAddress string, chainID valueobject.
 			Paused:            paused,
 			BlockDelay:        blockDelay,
 			ConcentrationK:    concentrationK,
+			MaxPunishmentX24:  maxPunishmentX24,
 		},
 	}, nil
 }

--- a/pkg/liquidity-source/lunarbase/math.go
+++ b/pkg/liquidity-source/lunarbase/math.go
@@ -198,7 +198,170 @@ func quoteYToX(params *PoolParams, dy *uint256.Int) *QuoteResult {
 	return out
 }
 
+// maxU24 mirrors Solidity uint24::MAX, the punishment sentinel meaning "100%".
+const maxU24 = 1<<24 - 1
+
+// xValueInY writes dst = mulDivDown(mulDivDown(amountX, sqrtPriceX96, Q96), sqrtPriceX96, Q96),
+// matching the on-chain SwapLib._xValueInY nested-floor rounding exactly.
+func xValueInY(dst, amountX, sqrtPriceX96 *uint256.Int) *uint256.Int {
+	var scratch uint256.Int
+	big256.MulDivDown(&scratch, amountX, sqrtPriceX96, q96)
+	return big256.MulDivDown(dst, &scratch, sqrtPriceX96, q96)
+}
+
+// punishmentX24 computes the desired directional fee increment for a
+// punishment-model pool (SwapLib.punishmentX24 / mechanism.rs try_punishment_x24).
+func punishmentX24(params *PoolParams, amountIn *uint256.Int, xToY bool) uint32 {
+	if amountIn.IsZero() || params.MaxPunishmentX24 == 0 || params.SqrtPriceX96.IsZero() {
+		return 0
+	}
+
+	var xWealth, inventoryWealth uint256.Int
+	xValueInY(&xWealth, params.ReserveX, params.SqrtPriceX96)
+	inventoryWealth.Add(&xWealth, params.ReserveY)
+	if inventoryWealth.IsZero() {
+		return 0
+	}
+
+	var swapWealth uint256.Int
+	if xToY {
+		xValueInY(&swapWealth, amountIn, params.SqrtPriceX96)
+	} else {
+		swapWealth.Set(amountIn)
+	}
+	if swapWealth.IsZero() {
+		return 0
+	}
+
+	maximum := uint64(params.MaxPunishmentX24)
+	if params.MaxPunishmentX24 == maxU24 {
+		maximum = 1 << 24
+	}
+
+	var calculated uint256.Int
+	if !swapWealth.Lt(&inventoryWealth) {
+		calculated.SetUint64(maximum)
+	} else {
+		var maxU uint256.Int
+		maxU.SetUint64(maximum)
+		big256.MulDivUp(&calculated, &maxU, &swapWealth, &inventoryWealth)
+	}
+	if !calculated.IsUint64() || calculated.Uint64() >= 1<<24 {
+		return maxU24
+	}
+	return uint32(calculated.Uint64())
+}
+
+// applyPunishment saturating-adds a desired punishment to the matching
+// directional fee (SwapLib.saturatingFeeX24 / mechanism.rs try_apply_punishment).
+// It returns the effective fee to use for pricing this swap and mutates
+// *feeAskX24 / *feeBidX24 in place to the post-swap persisted fees.
+func applyPunishment(feeAskX24, feeBidX24 *uint32, desiredX24 uint32, xToY bool) uint32 {
+	if xToY {
+		available := maxU24 - *feeBidX24
+		applied := desiredX24
+		if applied > available {
+			applied = available
+		}
+		*feeBidX24 += applied
+		return *feeBidX24
+	}
+	available := maxU24 - *feeAskX24
+	applied := desiredX24
+	if applied > available {
+		applied = available
+	}
+	*feeAskX24 += applied
+	return *feeAskX24
+}
+
+// applyFee mirrors SwapLib.applyFee / mechanism.rs try_apply_fee: charge
+// feeQ24 on grossOutput, then scale by the caller's fee multiplier (1 for a
+// whitelisted/base-fee caller).
+func applyFee(out *QuoteResult, grossOutput *uint256.Int, feeQ24X24 uint32, feeMultiplier *uint256.Int) {
+	if feeQ24X24 == maxU24 {
+		out.AmountOut.Clear()
+		out.Fee.Set(grossOutput)
+		return
+	}
+
+	var baseFee, feeQ24 uint256.Int
+	feeQ24.SetUint64(uint64(feeQ24X24))
+	big256.MulDivDown(&baseFee, grossOutput, &feeQ24, q24)
+
+	if feeMultiplier.Cmp(big256.U1) <= 0 || baseFee.IsZero() {
+		out.Fee.Set(&baseFee)
+		out.AmountOut.Sub(grossOutput, &baseFee)
+		return
+	}
+
+	var maxOverBase uint256.Int
+	maxOverBase.Div(big256.UMax, &baseFee)
+	if feeMultiplier.Gt(&maxOverBase) {
+		out.AmountOut.Clear()
+		out.Fee.Set(grossOutput)
+		return
+	}
+
+	var fee uint256.Int
+	fee.Mul(&baseFee, feeMultiplier)
+	if !fee.Lt(grossOutput) {
+		out.AmountOut.Clear()
+		out.Fee.Set(grossOutput)
+		return
+	}
+	out.Fee.Set(&fee)
+	out.AmountOut.Sub(grossOutput, &fee)
+}
+
+// punishmentQuoteXToY prices a swap on the linear-anchor, directional-punishment
+// model (no concentration curve). It mirrors mechanism.rs quote_x_to_y and
+// mutates params.FeeAskX24/FeeBidX24 in place to the post-swap persisted fees.
+func punishmentQuoteXToY(out *QuoteResult, params *PoolParams, dx *uint256.Int) *QuoteResult {
+	desired := punishmentX24(params, dx, true)
+	effectiveFee := applyPunishment(&params.FeeAskX24, &params.FeeBidX24, desired, true)
+
+	var grossOutput uint256.Int
+	xValueInY(&grossOutput, dx, params.SqrtPriceX96)
+	out.SqrtPriceNext.Set(params.SqrtPriceX96)
+	if grossOutput.IsZero() || grossOutput.Gt(params.ReserveY) {
+		out.AmountOut.Clear()
+		out.Fee.Clear()
+		return out
+	}
+	applyFee(out, &grossOutput, effectiveFee, big256.U1)
+	return out
+}
+
+// punishmentQuoteYToX mirrors mechanism.rs quote_y_to_x.
+func punishmentQuoteYToX(out *QuoteResult, params *PoolParams, dy *uint256.Int) *QuoteResult {
+	desired := punishmentX24(params, dy, false)
+	effectiveFee := applyPunishment(&params.FeeAskX24, &params.FeeBidX24, desired, false)
+
+	out.SqrtPriceNext.Set(params.SqrtPriceX96)
+	if params.SqrtPriceX96.IsZero() {
+		out.AmountOut.Clear()
+		out.Fee.Clear()
+		return out
+	}
+
+	var scratch, grossOutput uint256.Int
+	big256.MulDivDown(&scratch, dy, q96, params.SqrtPriceX96)
+	big256.MulDivDown(&grossOutput, &scratch, q96, params.SqrtPriceX96)
+	if grossOutput.IsZero() || grossOutput.Gt(params.ReserveX) {
+		out.AmountOut.Clear()
+		out.Fee.Clear()
+		return out
+	}
+	applyFee(out, &grossOutput, effectiveFee, big256.U1)
+	return out
+}
+
 func quoteXToYInto(out *QuoteResult, params *PoolParams, dx *uint256.Int) *QuoteResult {
+	if params.ConcentrationK == 0 {
+		return punishmentQuoteXToY(out, params, dx)
+	}
+
 	var (
 		cQ48      uint256.Int
 		pBid      uint256.Int
@@ -245,6 +408,10 @@ func quoteXToYInto(out *QuoteResult, params *PoolParams, dx *uint256.Int) *Quote
 }
 
 func quoteYToXInto(out *QuoteResult, params *PoolParams, dy *uint256.Int) *QuoteResult {
+	if params.ConcentrationK == 0 {
+		return punishmentQuoteYToX(out, params, dy)
+	}
+
 	var (
 		cQ48      uint256.Int
 		pAsk      uint256.Int

--- a/pkg/liquidity-source/lunarbase/math_punishment_test.go
+++ b/pkg/liquidity-source/lunarbase/math_punishment_test.go
@@ -1,0 +1,121 @@
+package lunarbase
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+)
+
+// bscPunishmentParams reproduces live state pinned at BSC block 119902916 for
+// pool 0x00007904d186680C709519e71f4Dc3e2DF8f1b99, which has upgraded to the
+// lunarbase-pmm-math v0.4.0 linear-anchor / directional-punishment model
+// (concentrationK() reverts on-chain; maxPunishmentX24() returns 83886).
+func bscPunishmentParams() *PoolParams {
+	return &PoolParams{
+		SqrtPriceX96:     uint256.MustFromDecimal("2124565750896485315338783686656"),
+		FeeAskX24:        7975,
+		FeeBidX24:        2188,
+		ReserveX:         uint256.MustFromDecimal("39134580821500176234"),
+		ReserveY:         uint256.MustFromDecimal("42770804199297762732014"),
+		ConcentrationK:   0,
+		MaxPunishmentX24: 83886,
+	}
+}
+
+// TestPunishmentQuoteMatchesOnChain cross-checks quoteXToYInto against the
+// same swap replayed by hand against on-chain `quoteXToY(dx)` at the pinned
+// block, with the caller's fee multiplier (blacklistFeeMultiplier=4 for a
+// non-whitelisted caller) divided back out to isolate the base (multiplier=1)
+// math this package implements.
+func TestPunishmentQuoteMatchesOnChain(t *testing.T) {
+	params := bscPunishmentParams()
+	dx := uint256.MustFromDecimal("1000000000000000000")
+
+	result := quoteXToY(params, dx)
+
+	if got, want := result.AmountOut.Dec(), "718956327424094777629"; got != want {
+		t.Errorf("amountOut = %s, want %s", got, want)
+	}
+	if got, want := result.Fee.Dec(), "130254275905269392"; got != want {
+		t.Errorf("fee = %s, want %s", got, want)
+	}
+	if got, want := result.SqrtPriceNext.Dec(), "2124565750896485315338783686656"; got != want {
+		t.Errorf("sqrtPriceNext = %s, want %s", got, want)
+	}
+	if got, want := params.FeeBidX24, uint32(3039); got != want {
+		t.Errorf("post-swap FeeBidX24 = %d, want %d (punishment must persist onto the pool params)", got, want)
+	}
+	if got, want := params.FeeAskX24, uint32(7975); got != want {
+		t.Errorf("post-swap FeeAskX24 = %d, want %d (opposite direction must not move)", got, want)
+	}
+}
+
+// TestPunishmentSaturatesOnlySameDirection ports mechanism.rs's
+// punishment_saturates_only_same_direction: applying a punishment near the
+// uint24 ceiling must saturate at MAX_U24 on the swapped direction and leave
+// the other direction's fee untouched.
+func TestPunishmentSaturatesOnlySameDirection(t *testing.T) {
+	feeAsk, feeBid := uint32(7), uint32(maxU24-5)
+	effective := applyPunishment(&feeAsk, &feeBid, 100, true)
+
+	if effective != maxU24 {
+		t.Errorf("effective fee = %d, want %d", effective, maxU24)
+	}
+	if feeBid != maxU24 {
+		t.Errorf("feeBid = %d, want %d", feeBid, maxU24)
+	}
+	if feeAsk != 7 {
+		t.Errorf("feeAsk = %d, want unchanged 7", feeAsk)
+	}
+}
+
+// TestPunishmentSplitYieldsMoreOutput ports mechanism.rs's
+// full_immediate_punishment_split_regression_matches_solidity: splitting one
+// large swap into chunks through a punishment pool, persisting the ratcheting
+// fee between chunks via UpdateBalance's contract (mutate-in-place
+// PoolParams), must yield strictly more total output than a single swap of
+// the same size. If UpdateBalance fails to persist the punishment, router
+// split-planning would over-estimate output and under-deliver on execution.
+func TestPunishmentSplitYieldsMoreOutput(t *testing.T) {
+	reserve := uint256.MustFromDecimal("1000000000000000000000000")
+	single := &PoolParams{
+		SqrtPriceX96:     new(uint256.Int).Lsh(uint256.NewInt(1), 96),
+		ReserveX:         new(uint256.Int).Set(reserve),
+		ReserveY:         new(uint256.Int).Set(reserve),
+		MaxPunishmentX24: maxU24,
+	}
+	split := &PoolParams{
+		SqrtPriceX96:     new(uint256.Int).Set(single.SqrtPriceX96),
+		ReserveX:         new(uint256.Int).Set(reserve),
+		ReserveY:         new(uint256.Int).Set(reserve),
+		MaxPunishmentX24: maxU24,
+	}
+
+	total := reserve
+	singleResult := quoteXToY(single, total)
+
+	chunk := uint256.MustFromDecimal("100000000000000000000000")
+	splitTotalOut := new(uint256.Int)
+	for i := 0; i < 10; i++ {
+		r := quoteXToY(split, chunk)
+		splitTotalOut.Add(splitTotalOut, r.AmountOut)
+		split.ReserveX.Add(split.ReserveX, chunk)
+		split.ReserveY.Sub(split.ReserveY, new(uint256.Int).Add(r.AmountOut, r.Fee))
+	}
+
+	if got, want := singleResult.AmountOut.Dec(), "500000000000000000000000"; got != want {
+		t.Fatalf("single amountOut = %s, want %s", got, want)
+	}
+	if got, want := splitTotalOut.Dec(), "724999934434890747070315"; got != want {
+		t.Fatalf("split total amountOut = %s, want %s", got, want)
+	}
+	if got, want := single.FeeBidX24, uint32(8_388_608); got != want {
+		t.Errorf("single post-swap FeeBidX24 = %d, want %d", got, want)
+	}
+	if got, want := split.FeeBidX24, uint32(8_388_610); got != want {
+		t.Errorf("split post-swap FeeBidX24 = %d, want %d", got, want)
+	}
+	if !splitTotalOut.Gt(singleResult.AmountOut) {
+		t.Errorf("split total %s must exceed single-swap amountOut %s", splitTotalOut.Dec(), singleResult.AmountOut.Dec())
+	}
+}

--- a/pkg/liquidity-source/lunarbase/pool_simulator.go
+++ b/pkg/liquidity-source/lunarbase/pool_simulator.go
@@ -25,6 +25,12 @@ type PoolSimulator struct {
 
 type SwapInfo struct {
 	nextSqrtPriceX96 *uint256.Int
+	// feeAskX24/feeBidX24 are the post-swap persisted directional fees.
+	// Unchanged from the pre-swap values on the concentration-curve model;
+	// ratcheted up on the swapped direction for a punishment-model pool
+	// (SDK v0.4.0), since punishment accumulates per swap.
+	feeAskX24 uint32
+	feeBidX24 uint32
 }
 
 var _ = pool.RegisterFactory(DexType, NewPoolSimulator)
@@ -81,12 +87,13 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 	}
 
 	poolParams := &PoolParams{
-		SqrtPriceX96:   s.SqrtPriceX96,
-		FeeAskX24:      s.FeeAskX24,
-		FeeBidX24:      s.FeeBidX24,
-		ReserveX:       s.reserves[0],
-		ReserveY:       s.reserves[1],
-		ConcentrationK: s.ConcentrationK,
+		SqrtPriceX96:     s.SqrtPriceX96,
+		FeeAskX24:        s.FeeAskX24,
+		FeeBidX24:        s.FeeBidX24,
+		ReserveX:         s.reserves[0],
+		ReserveY:         s.reserves[1],
+		ConcentrationK:   s.ConcentrationK,
+		MaxPunishmentX24: s.MaxPunishmentX24,
 	}
 
 	var result *QuoteResult
@@ -104,7 +111,13 @@ func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.Ca
 		TokenAmountOut: &pool.TokenAmount{Token: params.TokenOut, Amount: result.AmountOut.ToBig()},
 		Fee:            &pool.TokenAmount{Token: params.TokenOut, Amount: result.Fee.ToBig()},
 		Gas:            defaultGas,
-		SwapInfo:       SwapInfo{nextSqrtPriceX96: result.SqrtPriceNext},
+		SwapInfo: SwapInfo{
+			nextSqrtPriceX96: result.SqrtPriceNext,
+			// quoteXToY/quoteYToX mutate poolParams' fees in place for a
+			// punishment-model pool (no-op for the concentration-curve model).
+			feeAskX24: poolParams.FeeAskX24,
+			feeBidX24: poolParams.FeeBidX24,
+		},
 	}, nil
 }
 
@@ -129,7 +142,15 @@ func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
 	// SqrtPriceX96 is operator-set on the fix/incident contract; swaps do not
 	// mutate it. The SwapInfo.nextSqrtPriceX96 field is kept for diagnostic
 	// continuity but intentionally not written back to state.
-	_ = SwapInfo{}
+
+	// A punishment-model pool ratchets up the swapped direction's fee on
+	// every swap; persist it so subsequent hops/splits through the same
+	// pool within one route price against the post-swap fee.
+	if swapInfo, ok := params.SwapInfo.(SwapInfo); ok {
+		s.Extra = lo.ToPtr(*s.Extra)
+		s.FeeAskX24 = swapInfo.feeAskX24
+		s.FeeBidX24 = swapInfo.feeBidX24
+	}
 }
 
 func (s *PoolSimulator) GetMetaInfo(tokenIn, tokenOut string) any {

--- a/pkg/liquidity-source/lunarbase/pool_simulator_test.go
+++ b/pkg/liquidity-source/lunarbase/pool_simulator_test.go
@@ -129,3 +129,96 @@ func TestNewPoolSimulatorRejectsStalePool(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, ErrStalePool)
 }
+
+// TestPunishmentModelPersistsFeeThroughUpdateBalance exercises the full
+// CalcAmountOut → UpdateBalance round trip for a punishment-model pool
+// (ConcentrationK == 0, MaxPunishmentX24 > 0). It reuses the on-chain fixture
+// from TestPunishmentQuoteMatchesOnChain to verify the pool simulator, not
+// just the underlying math, persists the ratcheted fee: a route splitting a
+// swap into two hops through the same pool must price the second hop against
+// the post-first-hop fee, and cloned simulators used by other route
+// candidates must not see it.
+func TestPunishmentModelPersistsFeeThroughUpdateBalance(t *testing.T) {
+	wrappedNative := strings.ToLower(valueobject.WrappedNativeMap[valueobject.ChainIDBSC])
+
+	extraBytes, err := json.Marshal(Extra{
+		SqrtPriceX96:     uint256.MustFromDecimal("2124565750896485315338783686656"),
+		FeeAskX24:        7975,
+		FeeBidX24:        2188,
+		MaxPunishmentX24: 83886,
+	})
+	if err != nil {
+		t.Fatalf("marshal extra: %v", err)
+	}
+
+	staticExtraBytes, err := json.Marshal(StaticExtra{})
+	if err != nil {
+		t.Fatalf("marshal static extra: %v", err)
+	}
+
+	newSim := func() *PoolSimulator {
+		sim, err := NewPoolSimulator(pool.FactoryParams{EntityPool: entity.Pool{
+			Address:  "0x00007904d186680c709519e71f4dc3e2df8f1b99",
+			Exchange: DexType,
+			Type:     DexType,
+			Reserves: entity.PoolReserves{"39134580821500176234", "42770804199297762732014"},
+			Tokens: []*entity.PoolToken{
+				{Address: wrappedNative, Decimals: 18},
+				{Address: "0x55d398326f99059ff775485246999027b3197955", Decimals: 18},
+			},
+			Extra:       string(extraBytes),
+			StaticExtra: string(staticExtraBytes),
+		}, ChainID: valueobject.ChainIDBSC})
+		if err != nil {
+			t.Fatalf("new simulator: %v", err)
+		}
+		return sim
+	}
+
+	sim := newSim()
+	cloned := sim.CloneState().(*PoolSimulator)
+
+	dx := big.NewInt(0).SetInt64(1_000_000_000_000_000_000) // 1e18, matches TestPunishmentQuoteMatchesOnChain
+	result, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: sim.GetTokens()[0], Amount: dx},
+		TokenOut:      sim.GetTokens()[1],
+	})
+	if err != nil {
+		t.Fatalf("first hop CalcAmountOut: %v", err)
+	}
+	if got, want := result.TokenAmountOut.Amount.String(), "718956327424094777629"; got != want {
+		t.Fatalf("first hop amountOut = %s, want %s", got, want)
+	}
+
+	sim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: sim.GetTokens()[0], Amount: dx},
+		TokenAmountOut: pool.TokenAmount{Token: sim.GetTokens()[1], Amount: result.TokenAmountOut.Amount},
+		Fee:            *result.Fee,
+		SwapInfo:       result.SwapInfo,
+	})
+
+	if got, want := sim.FeeBidX24, uint32(3039); got != want {
+		t.Errorf("post-swap FeeBidX24 = %d, want %d (punishment must persist through UpdateBalance)", got, want)
+	}
+	if got, want := sim.FeeAskX24, uint32(7975); got != want {
+		t.Errorf("post-swap FeeAskX24 = %d, want unchanged %d", got, want)
+	}
+
+	if got, want := cloned.FeeBidX24, uint32(2188); got != want {
+		t.Errorf("cloned simulator FeeBidX24 = %d, want unchanged %d (must not see the other route's mutation)", got, want)
+	}
+
+	// A second hop through the same (now-mutated) pool must price against the
+	// ratcheted fee, not the original — this is what a router split relies on.
+	secondHop, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: sim.GetTokens()[0], Amount: dx},
+		TokenOut:      sim.GetTokens()[1],
+	})
+	if err != nil {
+		t.Fatalf("second hop CalcAmountOut: %v", err)
+	}
+	if secondHop.Fee.Amount.Cmp(result.Fee.Amount) <= 0 {
+		t.Errorf("second hop fee %s must exceed first hop fee %s (punishment ratchets up)",
+			secondHop.Fee.Amount, result.Fee.Amount)
+	}
+}

--- a/pkg/liquidity-source/lunarbase/pool_tracker.go
+++ b/pkg/liquidity-source/lunarbase/pool_tracker.go
@@ -121,6 +121,10 @@ func (t *PoolTracker) processLogs(p entity.Pool, logs []types.Log) (entity.Pool,
 			if err := t.processConcentrationKSet(&extra, lg); err == nil {
 				changed = true
 			}
+		case topicPunishmentApplied:
+			if err := t.processPunishmentApplied(&extra, lg); err == nil {
+				changed = true
+			}
 		case topicBlockDelaySet:
 			if err := t.processBlockDelaySet(&extra, lg); err == nil {
 				changed = true
@@ -201,6 +205,31 @@ func (t *PoolTracker) processConcentrationKSet(extra *Extra, log types.Log) erro
 
 	extra.ConcentrationK = k
 
+	return nil
+}
+
+// processPunishmentApplied applies the post-swap directional fees carried by
+// a punishment-model pool's PunishmentApplied(bool indexed xToY, uint24
+// punishmentX24, uint24 feeAskX24, uint24 feeBidX24) event. The indexed xToY
+// param is not part of Inputs.Unpack's return; only the three non-indexed
+// fields are.
+func (t *PoolTracker) processPunishmentApplied(extra *Extra, log types.Log) error {
+	values, err := coreABI.Events["PunishmentApplied"].Inputs.Unpack(log.Data)
+	if err != nil {
+		return err
+	}
+	if len(values) < 3 {
+		return ErrQuoteFailed
+	}
+
+	feeAsk, ok1 := values[1].(uint32)
+	feeBid, ok2 := values[2].(uint32)
+	if !ok1 || !ok2 {
+		return ErrQuoteFailed
+	}
+
+	extra.FeeAskX24 = feeAsk
+	extra.FeeBidX24 = feeBid
 	return nil
 }
 
@@ -295,6 +324,9 @@ func (t *PoolTracker) buildPoolFromCachedState(p entity.Pool, state *poolState) 
 	}
 	if state.ConcentrationK > 0 {
 		extra.ConcentrationK = state.ConcentrationK
+	}
+	if state.MaxPunishmentX24 > 0 {
+		extra.MaxPunishmentX24 = state.MaxPunishmentX24
 	}
 
 	extraBytes, err := json.Marshal(extra)

--- a/pkg/liquidity-source/lunarbase/pool_tracker_test.go
+++ b/pkg/liquidity-source/lunarbase/pool_tracker_test.go
@@ -227,3 +227,54 @@ func TestStateUpdatedLogDoesNotDisableStaleCheck(t *testing.T) {
 			got2.BlockNumber, extra2.LatestUpdateBlock, extra2.BlockDelay)
 	}
 }
+
+// TestProcessPunishmentAppliedUpdatesFees replays the real PunishmentApplied
+// log from BSC pool 0x00007904d186680C709519e71f4Dc3e2DF8f1b99, block
+// 119900061, logIndex 577 (xToY=true, punishment=9, feeAsk=2597, feeBid=796).
+// Field order (feeAsk before feeBid) was confirmed against a separate,
+// StateUpdated-free pair of PunishmentApplied logs on the same pool: for
+// xToY=false only the ask-slot word moved, matching mechanism.rs's
+// `YToX => fee_ask_x24 += applied`.
+func TestProcessPunishmentAppliedUpdatesFees(t *testing.T) {
+	tracker := NewPoolTracker(&Config{DexID: DexType, ChainID: valueobject.ChainIDBSC}, nil)
+
+	extraBytes, err := json.Marshal(Extra{
+		SqrtPriceX96:     uint256.NewInt(1),
+		FeeAskX24:        1,
+		FeeBidX24:        2,
+		MaxPunishmentX24: 83886,
+	})
+	if err != nil {
+		t.Fatalf("marshal extra: %v", err)
+	}
+
+	data := common.FromHex(
+		"0x00000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000000000a25000000000000000000000000000000000000000000000000000000000000031c",
+	)
+
+	got, err := tracker.processLogs(entity.Pool{
+		Address: "0x00007904d186680c709519e71f4dc3e2df8f1b99",
+		Extra:   string(extraBytes),
+	}, []types.Log{{
+		Topics: []common.Hash{
+			topicPunishmentApplied,
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+		},
+		Data:        data,
+		BlockNumber: 119900061,
+	}})
+	if err != nil {
+		t.Fatalf("process logs: %v", err)
+	}
+
+	var extra Extra
+	if err := json.Unmarshal([]byte(got.Extra), &extra); err != nil {
+		t.Fatalf("unmarshal extra: %v", err)
+	}
+	if got, want := extra.FeeAskX24, uint32(2597); got != want {
+		t.Errorf("FeeAskX24 = %d, want %d", got, want)
+	}
+	if got, want := extra.FeeBidX24, uint32(796); got != want {
+		t.Errorf("FeeBidX24 = %d, want %d", got, want)
+	}
+}

--- a/pkg/liquidity-source/lunarbase/type.go
+++ b/pkg/liquidity-source/lunarbase/type.go
@@ -15,8 +15,13 @@ type Extra struct {
 	LatestUpdateBlock uint64       `json:"b,omitempty"`
 	Paused            bool         `json:"0,omitempty"`
 	BlockDelay        uint64       `json:"d,omitempty"`
-	// ConcentrationK is Q20.12 (effective K = ConcentrationK / 2^12).
+	// ConcentrationK is Q20.12 (effective K = ConcentrationK / 2^12). Zero on
+	// pools upgraded to the punishment model (see MaxPunishmentX24).
 	ConcentrationK uint32 `json:"k,omitempty"`
+	// MaxPunishmentX24 (Q24) is set on pools upgraded to the linear-anchor,
+	// directional-punishment model in place of ConcentrationK. The two are
+	// mutually exclusive: whichever RPC call succeeds selects the math path.
+	MaxPunishmentX24 uint32 `json:"mp,omitempty"`
 }
 
 func (e *Extra) IsStale(blockNumber uint64) bool {
@@ -45,8 +50,12 @@ type PoolParams struct {
 	FeeBidX24    uint32
 	ReserveX     *uint256.Int
 	ReserveY     *uint256.Int
-	// ConcentrationK is Q20.12 (effective K = ConcentrationK / 2^12).
+	// ConcentrationK is Q20.12 (effective K = ConcentrationK / 2^12). Zero
+	// selects the punishment model below.
 	ConcentrationK uint32
+	// MaxPunishmentX24 (Q24) is the punishment-model maximum directional fee
+	// increment per swap; only meaningful when ConcentrationK == 0.
+	MaxPunishmentX24 uint32
 }
 
 type QuoteResult struct {


### PR DESCRIPTION
lunarbase-pmm-math v0.4.0 replaced the concentration-curve pricing model with a
linear-anchor, directional-punishment fee mechanism. Verified live that Base
and Monad pools, plus one BSC pool, remain on the old model, while a second
BSC pool has upgraded (concentrationK() reverts on-chain). Both models are
now supported concurrently:

- math.go: port the punishment/linear quote math (punishmentX24,
  applyPunishment, applyFee), verified bit-exact against on-chain quoteXToY.
- helper.go: fetchRPCState uses TryBlockAndAggregate, fetching both
  concentrationK and maxPunishmentX24; requires success on all other calls,
  errors only if neither model getter resolves.
- abi.go/constant.go: add maxPunishmentX24() and the PunishmentApplied event
  (field order confirmed from live logs, not just the topic hash).
- pool_tracker.go/flash_block_subscriber.go: handle PunishmentApplied in both
  the poll and websocket log paths.
- pool_simulator.go: thread MaxPunishmentX24 through CalcAmountOut and persist
  the post-swap ratcheted fee via UpdateBalance, so split/multi-hop routes
  through a punishment pool price correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JAjpHhsvSetZ82QdWjB3DL
