### PR TITLE
feat: add tidefi-prop liquidity source

### DIFF
--- a/pkg/liquidity-source/tidefi-prop/abis.go
+++ b/pkg/liquidity-source/tidefi-prop/abis.go
@@ -1,0 +1,30 @@
+package tidefiprop
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	swapperABI abi.ABI
+	erc20ABI   abi.ABI
+)
+
+func init() {
+	builder := []struct {
+		ABI  *abi.ABI
+		data []byte
+	}{
+		{&swapperABI, swapperABIData},
+		{&erc20ABI, erc20ABIData},
+	}
+
+	for _, b := range builder {
+		parsed, err := abi.JSON(bytes.NewReader(b.data))
+		if err != nil {
+			panic(err)
+		}
+		*b.ABI = parsed
+	}
+}

--- a/pkg/liquidity-source/tidefi-prop/abis/ERC20.json
+++ b/pkg/liquidity-source/tidefi-prop/abis/ERC20.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "stateMutability": "view",
+    "inputs": [{ "name": "account", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  }
+]

--- a/pkg/liquidity-source/tidefi-prop/abis/TideFiSwapper.json
+++ b/pkg/liquidity-source/tidefi-prop/abis/TideFiSwapper.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "function",
+    "name": "quote",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "tokenIn", "type": "address" },
+      { "name": "tokenOut", "type": "address" },
+      { "name": "maxAmountIn", "type": "uint256" },
+      { "name": "limitPrice", "type": "uint256" }
+    ],
+    "outputs": [
+      { "name": "amountIn", "type": "uint256" },
+      { "name": "amountOut", "type": "uint256" }
+    ]
+  }
+]

--- a/pkg/liquidity-source/tidefi-prop/config.go
+++ b/pkg/liquidity-source/tidefi-prop/config.go
@@ -1,0 +1,21 @@
+package tidefiprop
+
+import (
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+// Config is the per-dex-id configuration. TideFi is a single fixed contract
+// backing every pair (not a per-pair router/lens), so the supported token
+// set is config-static rather than on-chain discovered -- see
+// pools_list_updater.go.
+type Config struct {
+	DexID   string              `json:"dexId"`
+	ChainID valueobject.ChainID `json:"chainId"`
+
+	// Address is the TideFi swapper contract: both the source of quote()
+	// and the swap entrypoint the executor calls.
+	Address string `json:"address"`
+
+	Tokens []string `json:"tokens"`
+	Buffer int64    `json:"buffer"`
+}

--- a/pkg/liquidity-source/tidefi-prop/constant.go
+++ b/pkg/liquidity-source/tidefi-prop/constant.go
@@ -1,0 +1,24 @@
+package tidefiprop
+
+import (
+	"errors"
+	"time"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+const (
+	DexType = valueobject.ExchangeTideFiProp
+
+	defaultGas = 150_000
+
+	// MaxAge gates how long a sampled ladder stays routable: TideFi's own
+	// quote() prices off a per-token config with an on-chain expiry
+	// (observed ~60s validity window), so a snapshot that's gone stale
+	// shouldn't stay routable indefinitely -- same reasoning as
+	// manta-prop/fermi-prop's freshness gate. Kept well under the observed
+	// 60s on-chain expiry.
+	MaxAge = 15 * time.Second
+)
+
+var ErrInsufficientLiquidity = errors.New("insufficient liquidity")

--- a/pkg/liquidity-source/tidefi-prop/embed.go
+++ b/pkg/liquidity-source/tidefi-prop/embed.go
@@ -1,0 +1,9 @@
+package tidefiprop
+
+import _ "embed"
+
+//go:embed abis/TideFiSwapper.json
+var swapperABIData []byte
+
+//go:embed abis/ERC20.json
+var erc20ABIData []byte

--- a/pkg/liquidity-source/tidefi-prop/pool_simulator.go
+++ b/pkg/liquidity-source/tidefi-prop/pool_simulator.go
@@ -1,0 +1,49 @@
+package tidefiprop
+
+import (
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+type PoolSimulator struct {
+	*ladder.PoolSimulator
+
+	staticExtra StaticExtra
+}
+
+var (
+	_ = pool.RegisterFactory0(DexType, NewPoolSimulator)
+	_ = pool.RegisterUseSwapLimit(valueobject.ExchangeTideFiProp)
+)
+
+func NewPoolSimulator(p entity.Pool) (*PoolSimulator, error) {
+	base, err := ladder.NewPoolSimulatorWith(p, MaxAge)
+	if err != nil {
+		return nil, err
+	}
+	base.Gas = defaultGas
+
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return nil, err
+	}
+
+	return &PoolSimulator{PoolSimulator: base, staticExtra: staticExtra}, nil
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.PoolSimulator = s.PoolSimulator.CloneState().(*ladder.PoolSimulator)
+	return &cloned
+}
+
+// GetMetaInfo keeps ApprovalAddress (rather than ladder.PoolMeta's default
+// shape) so callers that read pool.ApprovalInfo off it still resolve the
+// swapper contract to approve.
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return pool.MetaInfo{ApprovalAddress: s.staticExtra.Address, BlockNumber: s.Info.BlockNumber}
+}

--- a/pkg/liquidity-source/tidefi-prop/pool_simulator_test.go
+++ b/pkg/liquidity-source/tidefi-prop/pool_simulator_test.go
@@ -1,0 +1,88 @@
+package tidefiprop
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/testutil"
+)
+
+// Synthetic pool: both ladders lie on a straight line through the origin
+// (dir0 rate=2, dir1 rate=0.5), so the spline's implicit (0,0) anchor makes
+// every point on the curve -- not just the sampled ones -- an exact linear
+// interpolation, letting expected outputs be hand-computed.
+var (
+	entityAB entity.Pool
+	_        = json.Unmarshal([]byte(`{
+		"address":"0xdef100000000000000000000000000000000000c",
+		"exchange":"tidefi-prop",
+		"type":"tidefi-prop",
+		"reserves":["1000000","1000000"],
+		"tokens":[
+			{"address":"0xdef100000000000000000000000000000000000a","symbol":"A","decimals":18,"swappable":true},
+			{"address":"0xdef100000000000000000000000000000000000b","symbol":"B","decimals":6,"swappable":true}
+		],
+		"extra":"{\"l\":[[[1000,2000],[2000,4000],[3000,6000]],[[20,10],[40,20],[60,30]]]}",
+		"staticExtra":"{\"a\":\"0x71def100007a540305dd65d1034d10e809679fd5\"}",
+		"blockNumber":100
+	}`), &entityAB)
+	poolSimAB *PoolSimulator
+)
+
+func init() {
+	entityAB.Timestamp = time.Now().Unix() // keep MaxAge's staleness check happy
+	poolSimAB = lo.Must(NewPoolSimulator(entityAB))
+}
+
+func TestPoolSimulator_CalcAmountOut(t *testing.T) {
+	t.Parallel()
+	testutil.TestCalcAmountOut(t, poolSimAB, map[int]map[int]map[string]string{
+		0: {
+			1: {
+				"500":  "1000", // below first ladder entry -> spline toward origin
+				"1000": "2000", // exact first ladder entry
+				"1500": "3000", // between entries -> spline-interpolated
+				"3000": "6000", // exact last ladder entry
+				"3001": ladder.ErrAmountInTooLarge.Error(),
+				"0":    "",
+			},
+		},
+		1: {
+			0: {
+				"10": "5",  // below first ladder entry -> spline toward origin
+				"20": "10", // exact first ladder entry
+				"30": "15", // between entries -> spline-interpolated
+				"60": "30", // exact last ladder entry
+				"61": ladder.ErrAmountInTooLarge.Error(),
+				"0":  "",
+			},
+		},
+	})
+}
+
+func TestPoolSimulator_UpdateBalance(t *testing.T) {
+	t.Parallel()
+	// Two sequential B->A swaps on a fresh clone; consumedIn/consumedOut track
+	// correctly since the curve is linear (no depletion within the range tested).
+	testutil.TestCalcAmountOutWithUpdateBalance(t, poolSimAB, map[int]map[int][][][2]string{
+		1: {
+			0: {{{"20", "10"}, {"20", "10"}}},
+		},
+	})
+}
+
+func TestPoolSimulator_GetMetaInfo(t *testing.T) {
+	t.Parallel()
+	meta := poolSimAB.GetMetaInfo("", "")
+	assert.Equal(t, pool.MetaInfo{
+		ApprovalAddress: "0x71def100007a540305dd65d1034d10e809679fd5",
+		BlockNumber:     100,
+	}, meta)
+}

--- a/pkg/liquidity-source/tidefi-prop/pool_tracker.go
+++ b/pkg/liquidity-source/tidefi-prop/pool_tracker.go
@@ -1,0 +1,231 @@
+package tidefiprop
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/ladder"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+// noLimitPrice is passed as TideFi's limitPrice cap when sampling: the docs
+// specify type(uint256).max as "no limit", which lets the sampled ladder
+// reflect the engine's own pricing/inventory caps rather than an arbitrary
+// probe-time price ceiling.
+var noLimitPrice = bignumber.MaxUint256
+
+type quoteResult struct {
+	AmountIn  *big.Int `abi:"amountIn"`
+	AmountOut *big.Int `abi:"amountOut"`
+}
+
+type PoolTracker struct {
+	cfg          *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = pooltrack.RegisterFactoryCE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(cfg *Config, ethrpcClient *ethrpc.Client) *PoolTracker {
+	return &PoolTracker{
+		cfg:          cfg,
+		ethrpcClient: ethrpcClient,
+	}
+}
+
+func (t *PoolTracker) GetNewPoolState(
+	ctx context.Context,
+	p entity.Pool,
+	_ pool.GetNewPoolStateParams,
+) (entity.Pool, error) {
+	var staticExtra StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &staticExtra); err != nil {
+		return p, err
+	}
+
+	balances, blockNumber, err := t.fetchBalances(ctx, p.Tokens)
+	if err != nil {
+		return p, err
+	}
+
+	points := [2][]*big.Int{
+		ladder.SamplePoints(p, 0, balances[0], balances[1]),
+		ladder.SamplePoints(p, 1, balances[1], balances[0]),
+	}
+
+	results, err := t.fetchQuotes(ctx, p, staticExtra.Address, points, blockNumber)
+	if err != nil {
+		return p, err
+	}
+
+	t.warnGapInQuotes(p, results)
+	t.applyBuffer(results)
+
+	ladders := [2][]ladder.Point{
+		collectLadder(results[0]),
+		collectLadder(results[1]),
+	}
+
+	r0, r1 := uint256.MustFromBig(balances[0]), uint256.MustFromBig(balances[1])
+	return t.persist(p, ladder.Extra{Ladders: ladders}, r0, r1, blockNumber), nil
+}
+
+// fetchBalances reads each pool token's balanceOf(swapper) directly: TideFi
+// is a single global contract backing every pair, not a per-pool
+// router/lens, so on-chain reserves are just the swapper's own token
+// balances.
+func (t *PoolTracker) fetchBalances(
+	ctx context.Context, tokens []*entity.PoolToken,
+) ([]*big.Int, *big.Int, error) {
+	req := t.ethrpcClient.NewRequest().SetContext(ctx)
+	balances := make([]*big.Int, len(tokens))
+	for i, tok := range tokens {
+		balances[i] = new(big.Int)
+		req.AddCall(&ethrpc.Call{
+			ABI:    erc20ABI,
+			Target: tok.Address,
+			Method: "balanceOf",
+			Params: []any{common.HexToAddress(t.cfg.Address)},
+		}, []any{&balances[i]})
+	}
+
+	res, err := req.TryBlockAndAggregate()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return balances, res.BlockNumber, nil
+}
+
+// fetchQuotes probes the swapper's quote(tokenIn, tokenOut, maxAmountIn,
+// limitPrice) for every point in each direction's grid, returning the raw
+// (amountIn, amountOut) results aligned index-for-index with points.
+// amountIn can come back below the requested maxAmountIn -- TideFi's quote
+// stops filling once the marginal price would exceed limitPrice or the
+// engine's own inventory runs out -- so the returned amountIn (not the
+// requested point) is what must be used as the ladder's x-value.
+func (t *PoolTracker) fetchQuotes(
+	ctx context.Context,
+	p entity.Pool,
+	swapperAddr string,
+	points [2][]*big.Int,
+	blockNumber *big.Int,
+) ([2][]quoteResult, error) {
+	req := t.ethrpcClient.NewRequest().SetContext(ctx).SetBlockNumber(blockNumber)
+	tokenAddr := [2]common.Address{
+		common.HexToAddress(p.Tokens[0].Address),
+		common.HexToAddress(p.Tokens[1].Address),
+	}
+
+	var results [2][]quoteResult
+	callCount := 0
+	for dir := range points {
+		tokenIn, tokenOut := tokenAddr[dir], tokenAddr[1-dir]
+		results[dir] = make([]quoteResult, len(points[dir]))
+		for i, pt := range points[dir] {
+			req.AddCall(&ethrpc.Call{
+				ABI:    swapperABI,
+				Target: swapperAddr,
+				Method: "quote",
+				Params: []any{tokenIn, tokenOut, pt, noLimitPrice},
+			}, []any{&results[dir][i]})
+			callCount++
+		}
+	}
+	if callCount == 0 {
+		return results, nil
+	}
+
+	if _, err := req.TryAggregate(); err != nil {
+		return [2][]quoteResult{}, err
+	}
+
+	return results, nil
+}
+
+func (t *PoolTracker) applyBuffer(results [2][]quoteResult) {
+	if t.cfg.Buffer <= 0 {
+		return
+	}
+	buf := big.NewInt(t.cfg.Buffer)
+	for dir := range results {
+		for _, r := range results[dir] {
+			if r.AmountOut == nil {
+				continue
+			}
+			r.AmountOut.Mul(r.AmountOut, buf)
+			r.AmountOut.Div(r.AmountOut, bignumber.BasisPoint)
+		}
+	}
+}
+
+func (t *PoolTracker) warnGapInQuotes(p entity.Pool, results [2][]quoteResult) {
+	for dir := range results {
+		seenPositive := false
+		zeroRunStart := -1
+
+		for i, r := range results[dir] {
+			out := r.AmountOut
+			if out == nil {
+				continue
+			}
+			if out.Sign() > 0 {
+				if zeroRunStart >= 0 {
+					logger.WithFields(logger.Fields{
+						"pool":     p.Address,
+						"dir":      dir,
+						"tokenIn":  p.Tokens[dir].Address,
+						"tokenOut": p.Tokens[1-dir].Address,
+						"holeAt":   zeroRunStart,
+						"resumeAt": i,
+					}).Warn("tidefi-prop quote gap detected (positive -> zero -> positive)")
+					zeroRunStart = -1
+				}
+				seenPositive = true
+				continue
+			}
+			if seenPositive && zeroRunStart < 0 {
+				zeroRunStart = i
+			}
+		}
+	}
+}
+
+// collectLadder pairs each quote result's actual returned amountIn with its
+// amountOut, dropping any point that reverted or returned zero. Unlike
+// ladder.CollectLadder, the x-value comes from the result itself, not the
+// requested probe point, since TideFi's quote can cap amountIn below what
+// was asked.
+func collectLadder(results []quoteResult) []ladder.Point {
+	pts := make([]ladder.Point, 0, len(results))
+	for _, r := range results {
+		if r.AmountIn == nil || r.AmountOut == nil || r.AmountIn.Sign() <= 0 || r.AmountOut.Sign() <= 0 {
+			continue
+		}
+		inF, _ := r.AmountIn.Float64()
+		outF, _ := r.AmountOut.Float64()
+		pts = append(pts, ladder.Point{inF, outF})
+	}
+	return pts
+}
+
+func (t *PoolTracker) persist(p entity.Pool, extra ladder.Extra, r0, r1 *uint256.Int, blockNumber *big.Int) entity.Pool {
+	extraBytes, _ := json.Marshal(extra)
+	p.Extra = string(extraBytes)
+	p.Reserves = entity.PoolReserves{r0.Dec(), r1.Dec()}
+	if blockNumber != nil {
+		p.BlockNumber = blockNumber.Uint64()
+	}
+	p.Timestamp = time.Now().Unix()
+	return p
+}

--- a/pkg/liquidity-source/tidefi-prop/pools_list_updater.go
+++ b/pkg/liquidity-source/tidefi-prop/pools_list_updater.go
@@ -1,0 +1,74 @@
+package tidefiprop
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+// PoolsListUpdater builds pools from a fixed, config-provided token list:
+// TideFi has no on-chain enumerable asset registry (pricing config is
+// pushed by a trusted off-chain signer with no corresponding event log), so
+// unlike 1010-prop's getAssets()-driven discovery, the supported token set
+// has to come from config until/unless an off-chain source of truth is
+// wired in. Every configured token is assumed tradeable against every
+// other; the tracker's sampled quotes naturally return an empty ladder for
+// any pair TideFi doesn't actually support.
+type PoolsListUpdater struct {
+	cfg          *Config
+	ethrpcClient *ethrpc.Client
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, ethrpcClient *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{cfg: cfg, ethrpcClient: ethrpcClient}
+}
+
+func (u *PoolsListUpdater) GetNewPools(_ context.Context, metadataBytes []byte) ([]entity.Pool, []byte, error) {
+	if metadataBytes != nil {
+		return nil, metadataBytes, nil
+	}
+
+	staticExtraBytes, _ := json.Marshal(StaticExtra{
+		Address: strings.ToLower(u.cfg.Address),
+	})
+
+	now := time.Now().Unix()
+	tokens := u.cfg.Tokens
+	pools := make([]entity.Pool, 0, len(tokens)*(len(tokens)-1)/2)
+
+	for i := range tokens {
+		for j := i + 1; j < len(tokens); j++ {
+			pools = append(pools, entity.Pool{
+				Address:   poolAddress(tokens[i], tokens[j]),
+				Exchange:  u.cfg.DexID,
+				Type:      DexType,
+				Timestamp: now,
+				Reserves:  entity.PoolReserves{"0", "0"},
+				Tokens: []*entity.PoolToken{
+					{Address: strings.ToLower(tokens[i]), Swappable: true},
+					{Address: strings.ToLower(tokens[j]), Swappable: true},
+				},
+				Extra:       "{}",
+				StaticExtra: string(staticExtraBytes),
+			})
+		}
+	}
+
+	return pools, []byte("done"), nil
+}
+
+// poolAddress is synthetic, following manta-prop's pattern: TideFi has no
+// per-pair contract of its own (it's a single fixed swapper backing every
+// pair), so a fixed namespace plus the pair already disambiguates every
+// pool without needing the swapper address itself.
+func poolAddress(token0, token1 string) string {
+	return "tidefiprop_" + strings.ToLower(token0) + "_" + strings.ToLower(token1)
+}

--- a/pkg/liquidity-source/tidefi-prop/type.go
+++ b/pkg/liquidity-source/tidefi-prop/type.go
@@ -1,0 +1,8 @@
+package tidefiprop
+
+// StaticExtra is stored in entity.Pool.StaticExtra, once per pool. Address
+// is fixed at discovery time -- TideFi has a single swapper contract shared
+// by every pool on a chain.
+type StaticExtra struct {
+	Address string `json:"a"`
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -168,6 +168,7 @@ import (
 	pkg_liquiditysource_syncswapv2_stable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/stable"
 	pkg_liquiditysource_synthereum "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/synthereum"
 	pkg_liquiditysource_tessera "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tessera"
+	pkg_liquiditysource_tidefiprop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tidefi-prop"
 	pkg_liquiditysource_umbrae_damm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae/damm"
 	pkg_liquiditysource_umbrae_dlmm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae/dlmm"
 	pkg_liquiditysource_unipool "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/unipool"
@@ -420,6 +421,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_syncswapv2_stable.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_synthereum.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_tessera.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_tidefiprop.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_umbrae_damm.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_umbrae_dlmm.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_unipool.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -166,6 +166,7 @@ import (
 	syncswapv2stable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/syncswapv2/stable"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/synthereum"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tessera"
+	tidefiprop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/tidefi-prop"
 	umbraedamm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae/damm"
 	umbraedlmm "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/umbrae/dlmm"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/unipool"
@@ -441,6 +442,7 @@ type Types struct {
 	Infinifi                   string
 	Nabla                      string
 	Tessera                    string
+	TideFiProp                 string
 	UmbraeDamm                 string
 	UmbraeDlmm                 string
 	LiquidCore                 string
@@ -686,6 +688,7 @@ var (
 		Infinifi:                   infinifi.DexType,
 		Nabla:                      nabla.DexType,
 		Tessera:                    tessera.DexType,
+		TideFiProp:                 tidefiprop.DexType,
 		UmbraeDamm:                 umbraedamm.DexType,
 		UmbraeDlmm:                 umbraedlmm.DexType,
 		LiquidCore:                 liquidcore.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -280,6 +280,7 @@ const (
 	ExchangeSynthetix                   = "synthetix"
 	ExchangeTessera                     = "tessera"
 	ExchangeThenaFusionV3               = "thena-fusion-v3"
+	ExchangeTideFiProp                  = "tidefi-prop"
 	ExchangeUmbraeDamm                  = "umbrae-damm"
 	ExchangeUmbraeDlmm                  = "umbrae-dlmm"
 	ExchangeUniPool                     = "unipool"
@@ -421,6 +422,7 @@ var PropAMMSourceSet = map[Exchange]struct{}{
 	ExchangeFluxProp:      {},
 	ExchangeParityProp:    {},
 	ExchangePrismProp:     {},
+	ExchangeTideFiProp:    {},
 }
 
 func IsPropAMMSource[T ~string](exchange T) bool {


### PR DESCRIPTION
Integrates TideFi (Ulmo Markets' PropAMM) on Base: an on-chain RFQ-style
PropAMM with a quote() view function, sampled via the shared ladder
package (same shape as 1010-prop/manta-prop/fermi-prop). TideFi has no
enumerable on-chain token registry (pricing config is pushed by a trusted
off-chain signer with no event log), so the tracked token set is
config-driven rather than discovered. Uses the naming/config convention
of prism-prop and manta-prop, and a 15s MaxAge staleness gate matching
TideFi's observed ~60s on-chain price-feed expiry.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VdFcaJgkqr8inKJUWMAAfY
