### PR TITLE
feat(uniswap-v4): add o1 launchpad hook, reusing b20's LaunchHook logic

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/direct_protocol_match_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/direct_protocol_match_test.go
@@ -84,11 +84,11 @@ func TestDirectProtocolMatch_ReferenceLaunch(t *testing.T) {
 
 	// The pool's launchTime (1786986263) is long past for all these fixtures (recorded
 	// 2026-08-25), so totalFeeBps resolves to the flat baseFeeBps=100 regardless of
-	// nowFn -- pinned explicitly anyway so this test's outcome never depends on another
-	// test file's leftover package-level nowFn override.
-	orig := nowFn
-	nowFn = func() int64 { return time.Now().Unix() }
-	defer func() { nowFn = orig }()
+	// NowFn -- pinned explicitly anyway so this test's outcome never depends on another
+	// test file's leftover package-level NowFn override.
+	orig := NowFn
+	NowFn = func() int64 { return time.Now().Unix() }
+	defer func() { NowFn = orig }()
 
 	sim, err := uniswapv4.NewPoolSimulator(pool, valueobject.ChainIDBase)
 	require.NoError(t, err)

--- a/pkg/liquidity-source/uniswap/v4/hooks/b20/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/b20/hook.go
@@ -1,9 +1,9 @@
-// Package b20 implements the Uniswap v4 hook shared by every B20 launchpad
-// pool. See LaunchHook.sol on Base (0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc):
-// liquidity is permanently locked to the factory-seeded band (no third-party LP),
-// and every swap pays a fee on the quote currency -- a base rate plus a
-// linearly-decaying anti-snipe surcharge over the first antiSnipeWindowSeconds
-// after launch. PoolKey.fee is always 0; all economics come from this overlay.
+// Package b20 implements the Uniswap v4 hook shared by every B20 launchpad pool
+// (LaunchHook.sol on Base, 0x985c14baa2A18316ffDA0AefB3a632faDFCA2acc): liquidity
+// is locked to the factory-seeded band, and every swap pays a fee on the quote
+// currency plus a decaying anti-snipe surcharge. Extra and its methods are
+// exported so other LaunchHook.sol deployments with a different poolConfig ABI
+// (e.g. hooks/o1) can embed Extra and reuse this logic.
 package b20
 
 import (
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	errNotRegistered     = errors.New("pool not registered with the B20 factory yet")
-	errNotTracked        = errors.New("b20-launch: pool config not yet tracked, refusing to quote at an unknown fee")
-	errCalcInUnsupported = errors.New("b20-launch: exact-out not supported (matches pool_simulator.go's CalcAmountOut-only scope)")
+	ErrNotRegistered     = errors.New("pool not registered with the launch factory yet")
+	ErrNotTracked        = errors.New("launchhook: pool config not yet tracked, refusing to quote at an unknown fee")
+	ErrCalcInUnsupported = errors.New("launchhook: exact-out not supported (matches pool_simulator.go's CalcAmountOut-only scope)")
 )
 
 // Extra is the pricing-relevant subset of LaunchHook.sol's poolConfig -- frozen at
 // registration except for the live block.timestamp comparison against LaunchTime.
-// creator/platformTreasury/creatorBps/platformBps/referrerBps only affect how the
-// FeeEscrow later splits the fee, not the swap-visible amount, so they're omitted.
+// creator/platformTreasury/creatorBps/platformBps/referrerBps (or their equivalents
+// on other deployments) only affect how the FeeEscrow later splits the fee, not the
+// swap-visible amount, so they're omitted.
 type Extra struct {
 	TokenIsCurrency0       bool  `json:"t0,omitempty"`
 	BaseFeeBps             int64 `json:"bf"`
@@ -40,8 +41,9 @@ type Extra struct {
 	LaunchTime             int64 `json:"lt,omitempty"`
 }
 
-// nowFn is a var so tests can pin the anti-snipe decay clock.
-var nowFn = func() int64 { return time.Now().Unix() }
+// NowFn is a var so tests (in this package and embedders) can pin the anti-snipe
+// decay clock.
+var NowFn = func() int64 { return time.Now().Unix() }
 
 var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
 	h := &Hook{Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4B20}}
@@ -75,7 +77,7 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 		return nil, err
 	}
 	if !raw.Initialized {
-		return nil, errNotRegistered
+		return nil, ErrNotRegistered
 	}
 
 	h.Extra = Extra{
@@ -88,30 +90,29 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 	return json.Marshal(h)
 }
 
-// totalFeeBps mirrors LaunchHook.sol's _totalFeeBps: base + a linearly-decaying
+// TotalFeeBps mirrors LaunchHook.sol's _totalFeeBps: base + a linearly-decaying
 // anti-snipe surcharge over the first AntiSnipeWindowSeconds after LaunchTime,
-// capped at MaxTotalFeeBps. Evaluated against wall-clock time, same as every
-// other time-decaying v4 hook in this package (see hooks/fairflow/hook.go).
-func (h *Hook) totalFeeBps() int64 {
-	elapsed := nowFn() - h.LaunchTime
-	if elapsed >= h.AntiSnipeWindowSeconds {
-		return h.BaseFeeBps
+// capped at MaxTotalFeeBps.
+func (e *Extra) TotalFeeBps() int64 {
+	elapsed := NowFn() - e.LaunchTime
+	if elapsed >= e.AntiSnipeWindowSeconds {
+		return e.BaseFeeBps
 	}
-	maxSurcharge := h.AntiSnipeStartTotalBps - h.BaseFeeBps
-	surcharge := maxSurcharge * (h.AntiSnipeWindowSeconds - elapsed) / h.AntiSnipeWindowSeconds
-	total := h.BaseFeeBps + surcharge
+	maxSurcharge := e.AntiSnipeStartTotalBps - e.BaseFeeBps
+	surcharge := maxSurcharge * (e.AntiSnipeWindowSeconds - elapsed) / e.AntiSnipeWindowSeconds
+	total := e.BaseFeeBps + surcharge
 	if total > MaxTotalFeeBps {
 		return MaxTotalFeeBps
 	}
 	return total
 }
 
-// quoteIsSpecified reports whether the swap's specified (input, exact-in) currency
+// QuoteIsSpecified reports whether the swap's specified (input, exact-in) currency
 // is the quote currency -- i.e. the swap is buying the launch token with the quote.
-func (h *Hook) quoteIsSpecified(zeroForOne bool) bool {
+func (e *Extra) QuoteIsSpecified(zeroForOne bool) bool {
 	// exact-in: specified currency is currency0 iff zeroForOne.
 	specifiedIsCurrency0 := zeroForOne
-	quoteIsCurrency0 := !h.TokenIsCurrency0
+	quoteIsCurrency0 := !e.TokenIsCurrency0
 	return specifiedIsCurrency0 == quoteIsCurrency0
 }
 
@@ -119,23 +120,23 @@ func (h *Hook) quoteIsSpecified(zeroForOne bool) bool {
 // pool_simulator.go's CalcAmountOut ever drives. When the quote currency is the
 // swap's input, LaunchHook.sol charges the fee pre-swap (floor-rounded) so the
 // AMM sees a reduced input; see AfterSwap for the output-side case.
-func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+func (e *Extra) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
 	if !params.CalcOut {
-		return nil, errCalcInUnsupported
+		return nil, ErrCalcInUnsupported
 	}
-	if h.LaunchTime == 0 {
+	if e.LaunchTime == 0 {
 		// Never successfully Track()ed (RPC failure, or genuinely not yet registered
 		// with the factory): a zero-value Extra has BaseFeeBps=0, which would
 		// otherwise price this pool as fee-free instead of refusing to quote it.
-		return nil, errNotTracked
+		return nil, ErrNotTracked
 	}
-	if !h.quoteIsSpecified(params.ZeroForOne) {
+	if !e.QuoteIsSpecified(params.ZeroForOne) {
 		return &uniswapv4.BeforeSwapResult{
 			DeltaSpecified:   bignumber.ZeroBI,
 			DeltaUnspecified: bignumber.ZeroBI,
 		}, nil
 	}
-	fee := feeAmount(params.AmountSpecified, h.totalFeeBps())
+	fee := FeeAmount(params.AmountSpecified, e.TotalFeeBps())
 	return &uniswapv4.BeforeSwapResult{
 		DeltaSpecified:   fee,
 		DeltaUnspecified: bignumber.ZeroBI,
@@ -144,25 +145,36 @@ func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.Before
 
 // AfterSwap applies the fee post-swap (floor-rounded, on the realized output) when
 // the quote currency is the swap's output side.
-func (h *Hook) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
+func (e *Extra) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
 	if !params.CalcOut {
-		return nil, errCalcInUnsupported
+		return nil, ErrCalcInUnsupported
 	}
-	if h.LaunchTime == 0 {
-		return nil, errNotTracked
+	if e.LaunchTime == 0 {
+		return nil, ErrNotTracked
 	}
-	if h.quoteIsSpecified(params.ZeroForOne) {
+	if e.QuoteIsSpecified(params.ZeroForOne) {
 		return &uniswapv4.AfterSwapResult{HookFee: bignumber.ZeroBI}, nil
 	}
-	fee := feeAmount(params.AmountOut, h.totalFeeBps())
+	fee := FeeAmount(params.AmountOut, e.TotalFeeBps())
 	return &uniswapv4.AfterSwapResult{HookFee: fee}, nil
 }
 
-// feeAmount mirrors LaunchHook.sol's _feeAmount for the exact-in (non-exactOutput)
+// FeeAmount mirrors LaunchHook.sol's _feeAmount for the exact-in (non-exactOutput)
 // branch: floor(magnitude * feeBps / 10_000).
-func feeAmount(magnitude *big.Int, feeBps int64) *big.Int {
+func FeeAmount(magnitude *big.Int, feeBps int64) *big.Int {
 	if feeBps == 0 || magnitude == nil || magnitude.Sign() == 0 {
 		return bignumber.ZeroBI
 	}
 	return bignumber.MulDivDown(new(big.Int), magnitude, big.NewInt(feeBps), big.NewInt(bps))
+}
+
+// Delegate rather than rely on promotion: Hook embeds both the uniswapv4.Hook
+// interface and Extra at the same depth, both with BeforeSwap/AfterSwap, so an
+// unqualified call would otherwise be an ambiguous selector.
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	return h.Extra.BeforeSwap(params)
+}
+
+func (h *Hook) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
+	return h.Extra.AfterSwap(params)
 }

--- a/pkg/liquidity-source/uniswap/v4/hooks/o1/abis.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/o1/abis.go
@@ -1,0 +1,58 @@
+package o1
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// launchHookABIJson covers LaunchHook.sol's `poolConfig` getter. Field set/order
+// differs from b20's poolConfig (see hooks/b20/abis.go): no per-recipient bps
+// split fields, and creator/platformTreasury were renamed to
+// currentCreator/creatorFeeRecipient. Confirmed live via `cast call
+// poolConfig(bytes32)` on 2026-09-06.
+const launchHookABIJson = `[
+	{
+		"inputs": [{"internalType": "PoolId", "name": "", "type": "bytes32"}],
+		"name": "poolConfig",
+		"outputs": [
+			{"internalType": "bool", "name": "initialized", "type": "bool"},
+			{"internalType": "bool", "name": "tokenIsCurrency0", "type": "bool"},
+			{"internalType": "address", "name": "currentCreator", "type": "address"},
+			{"internalType": "address", "name": "creatorFeeRecipient", "type": "address"},
+			{"internalType": "uint16", "name": "baseFeeBps", "type": "uint16"},
+			{"internalType": "uint16", "name": "antiSnipeStartTotalBps", "type": "uint16"},
+			{"internalType": "uint32", "name": "antiSnipeWindowSeconds", "type": "uint32"},
+			{"internalType": "uint48", "name": "launchTime", "type": "uint48"}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+var LaunchHookABI abi.ABI
+
+func init() {
+	var err error
+	LaunchHookABI, err = abi.JSON(bytes.NewReader([]byte(launchHookABIJson)))
+	if err != nil {
+		panic(err)
+	}
+}
+
+// poolConfigRaw is the ethrpc.Call.AddCall decode target for `poolConfig`, field
+// order matching LaunchHookABI's outputs. go-ethereum's abi.Unpack fills struct
+// fields positionally, so every output must stay present even though only the
+// swap-pricing-relevant fields are read downstream.
+type poolConfigRaw struct {
+	Initialized            bool
+	TokenIsCurrency0       bool
+	CurrentCreator         common.Address
+	CreatorFeeRecipient    common.Address
+	BaseFeeBps             uint16
+	AntiSnipeStartTotalBps uint16
+	AntiSnipeWindowSeconds uint32
+	LaunchTime             *big.Int
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/o1/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/o1/constant.go
@@ -1,0 +1,11 @@
+package o1
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// HookAddresses is the single shared LaunchHook instance reused by every o1 launch
+// (per-pool economics live in poolConfig, not in the hook's own address).
+var HookAddresses = []common.Address{
+	common.HexToAddress("0x1f91c998e7c2f4b690d75bdbf6502bdcd6e02acc"),
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/o1/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/o1/hook.go
@@ -1,0 +1,76 @@
+// Package o1 implements the Uniswap v4 hook shared by every o1 launchpad pool. It
+// is the same LaunchHook.sol lineage as hooks/b20 (same decay/fee logic, reused
+// directly via b20.Extra), deployed separately on Base at
+// 0x1f91c998e7c2f4b690d75bdbf6502bdcd6e02acc with a reworked poolConfig layout
+// that doesn't change the swap-visible fee amount -- only Track's ABI decode
+// differs from b20.
+package o1
+
+import (
+	"context"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/b20"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	h := &Hook{Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4O1}}
+	_ = param.HookExtra.Unmarshal(&h.Extra)
+	return h
+}, HookAddresses...)
+
+type Hook struct {
+	uniswapv4.Hook `json:"-"`
+	b20.Extra
+}
+
+// Track reads poolConfig, whose field set/order differs from b20's (see
+// hooks/b20/abis.go) but whose pricing-relevant fields decode straight into the
+// shared b20.Extra. Reuses an already-populated Extra as-is (LaunchTime != 0)
+// since baseFeeBps/antiSnipe* never change after registration.
+func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	if h.LaunchTime != 0 {
+		return json.Marshal(h)
+	}
+
+	var raw poolConfigRaw
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
+		ABI:    LaunchHookABI,
+		Target: hexutil.Encode(param.HookAddress[:]),
+		Method: "poolConfig",
+		Params: []any{common.HexToHash(param.Pool.Address)},
+	}, []any{&raw})
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+	if !raw.Initialized {
+		return nil, b20.ErrNotRegistered
+	}
+
+	h.Extra = b20.Extra{
+		TokenIsCurrency0:       raw.TokenIsCurrency0,
+		BaseFeeBps:             int64(raw.BaseFeeBps),
+		AntiSnipeStartTotalBps: int64(raw.AntiSnipeStartTotalBps),
+		AntiSnipeWindowSeconds: int64(raw.AntiSnipeWindowSeconds),
+		LaunchTime:             raw.LaunchTime.Int64(),
+	}
+	return json.Marshal(h)
+}
+
+// Delegate rather than rely on promotion: Hook embeds both the uniswapv4.Hook
+// interface and b20.Extra at the same depth, both with BeforeSwap/AfterSwap, so an
+// unqualified call would otherwise be an ambiguous selector.
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	return h.Extra.BeforeSwap(params)
+}
+
+func (h *Hook) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
+	return h.Extra.AfterSwap(params)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/o1/hook_live_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/o1/hook_live_test.go
@@ -1,0 +1,46 @@
+package o1
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+)
+
+// TestTrack_Live decodes poolConfig against a real o1 launch on Base (poolId found
+// via a PoolRegistered log at block 50719550), confirming LaunchHookABI actually
+// matches the deployed contract's poolConfig layout.
+func TestTrack_Live(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	rpcClient := ethrpc.New("https://mainnet.base.org").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+	hookAddr := common.HexToAddress("0x1f91c998e7c2f4b690d75bdbf6502bdcd6e02acc")
+
+	h := &Hook{Hook: &uniswapv4.BaseHook{}}
+	_, err := h.Track(context.Background(), &uniswapv4.HookParam{
+		RpcClient:   rpcClient,
+		HookAddress: hookAddr,
+		Pool: &entity.Pool{
+			Address: "0xd980e58458d4fc3055ce4220b0015c186a3f409a8404f3fbdb6096e5b492da0e",
+		},
+	})
+	require.NoError(t, err)
+
+	// Values cross-checked by hand against `cast call ... poolConfig(bytes32)` on 2026-09-06.
+	assert.False(t, h.TokenIsCurrency0)
+	assert.Equal(t, int64(100), h.BaseFeeBps)
+	assert.Equal(t, int64(9900), h.AntiSnipeStartTotalBps)
+	assert.Equal(t, int64(20), h.AntiSnipeWindowSeconds)
+	assert.Equal(t, int64(1788228447), h.LaunchTime)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/o1/hook_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/o1/hook_test.go
@@ -1,4 +1,4 @@
-package b20
+package o1
 
 import (
 	"math/big"
@@ -8,29 +8,26 @@ import (
 	"github.com/stretchr/testify/require"
 
 	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/b20"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
 )
 
-// reference values pulled from LaunchHook.sol's live poolConfig for a real B20 launch
-// on Base (poolId 0x68d39022eee9e18f82fe929f70dd8d2009e442e6d80c6c1ffc170c32b7d3b671),
-// so the decay math is checked against the actual on-chain fee schedule, not just its
-// own logic restated.
-func refExtra() Extra {
-	return Extra{
+// reference values from a real o1 launch on Base (poolId
+// 0xd980e584...92da0e, via `cast call poolConfig(bytes32)` on 2026-09-06).
+// Exercises b20.Extra's shared logic through o1's embedding; decay/fee math
+// itself is already covered by hooks/b20/hook_test.go.
+func refExtra() b20.Extra {
+	return b20.Extra{
 		TokenIsCurrency0:       false,
 		BaseFeeBps:             100,
 		AntiSnipeStartTotalBps: 9900,
-		AntiSnipeWindowSeconds: 16,
-		LaunchTime:             1786986263,
+		AntiSnipeWindowSeconds: 20,
+		LaunchTime:             1788228447,
 	}
 }
 
-// totalFeeBps must reproduce LaunchHook.sol's _totalFeeBps exactly: a wrong bps here
-// silently mis-prices every swap during the anti-snipe window (first 16s after
-// launch for this reference pool) without erroring, so a route built on this quote
-// would settle for less than it should on-chain.
 func TestTotalFeeBps_Decay(t *testing.T) {
-	h := &Hook{Extra: refExtra()}
+	e := refExtra()
 
 	cases := []struct {
 		name    string
@@ -38,29 +35,16 @@ func TestTotalFeeBps_Decay(t *testing.T) {
 		want    int64
 	}{
 		{"at launch instant, surcharge is maximal", 0, 9900},
-		{"halfway through the window, surcharge is halved", 8, 5000},
-		{"window boundary, decays to just base fee", 16, 100},
+		{"halfway through the window, surcharge is halved", 10, 5000},
+		{"window boundary, decays to just base fee", 20, 100},
 		{"long after the window, stays at base fee", 1_000_000, 100},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			NowFn = func() int64 { return h.LaunchTime + c.elapsed }
-			assert.Equal(t, c.want, h.TotalFeeBps())
+			b20.NowFn = func() int64 { return e.LaunchTime + c.elapsed }
+			assert.Equal(t, c.want, e.TotalFeeBps())
 		})
 	}
-}
-
-// A misconfigured pool (antiSnipeStartTotalBps above the hard ceiling somehow making
-// it through Track) must never let the simulator quote a fee above what the contract
-// can ever charge -- MaxTotalFeeBps is the contract's own hard ceiling.
-func TestTotalFeeBps_CappedAtMax(t *testing.T) {
-	// On-chain _validateFeeConfig rejects antiSnipeStartTotalBps > MAX_TOTAL_FEE_BPS at
-	// registration time, but the Go clamp must hold defensively too -- use an
-	// out-of-policy value (10_000) so the surcharge math alone would exceed the cap and
-	// the assertion can actually fail if the `if total > MaxTotalFeeBps` clamp is removed.
-	h := &Hook{Extra: Extra{BaseFeeBps: 0, AntiSnipeStartTotalBps: 10_000, AntiSnipeWindowSeconds: 10, LaunchTime: 1}}
-	NowFn = func() int64 { return 1 } // elapsed=0 -> surcharge=10_000, would exceed the cap uncapped
-	assert.Equal(t, int64(MaxTotalFeeBps), h.TotalFeeBps())
 }
 
 func TestQuoteIsSpecified(t *testing.T) {
@@ -77,8 +61,8 @@ func TestQuoteIsSpecified(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			h := &Hook{Extra: Extra{TokenIsCurrency0: c.tokenIsCurrency0}}
-			assert.Equal(t, c.want, h.QuoteIsSpecified(c.zeroForOne))
+			e := b20.Extra{TokenIsCurrency0: c.tokenIsCurrency0}
+			assert.Equal(t, c.want, e.QuoteIsSpecified(c.zeroForOne))
 		})
 	}
 }
@@ -87,7 +71,7 @@ func TestQuoteIsSpecified(t *testing.T) {
 // (beforeSwap), floor-rounded, reducing what the AMM sees as input.
 func TestBeforeSwap_QuoteSpecified_ChargesFeeOnInput(t *testing.T) {
 	e := refExtra()
-	NowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds } // post-window: flat 100bps
+	b20.NowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds } // post-window: flat 100bps
 	h := &Hook{Extra: e}
 
 	// tokenIsCurrency0=false -> quote is currency0 -> zeroForOne=true sells quote in.
@@ -95,7 +79,7 @@ func TestBeforeSwap_QuoteSpecified_ChargesFeeOnInput(t *testing.T) {
 	result, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true, AmountSpecified: amountIn})
 	require.NoError(t, err)
 
-	// floor(1_000_000 * 100 / 10_000) = 10_000, matching _feeAmount's floor mulDiv.
+	// floor(1_000_000 * 100 / 10_000) = 10_000, matching FeeAmount's floor mulDiv.
 	assert.Equal(t, big.NewInt(10_000), result.DeltaSpecified)
 	assert.Equal(t, bignumber.ZeroBI, result.DeltaUnspecified)
 }
@@ -105,7 +89,7 @@ func TestBeforeSwap_QuoteSpecified_ChargesFeeOnInput(t *testing.T) {
 // double-count against AfterSwap's own fee application.
 func TestBeforeSwap_TokenSpecified_NoFeeHere(t *testing.T) {
 	e := refExtra()
-	NowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds }
+	b20.NowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds }
 	h := &Hook{Extra: e}
 
 	result, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false, AmountSpecified: big.NewInt(1_000_000)})
@@ -117,7 +101,7 @@ func TestBeforeSwap_TokenSpecified_NoFeeHere(t *testing.T) {
 // Selling the token for quote: fee lands post-swap on the realized quote output.
 func TestAfterSwap_TokenSpecified_ChargesFeeOnOutput(t *testing.T) {
 	e := refExtra()
-	NowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds }
+	b20.NowFn = func() int64 { return e.LaunchTime + e.AntiSnipeWindowSeconds }
 	h := &Hook{Extra: e}
 
 	amountOut := big.NewInt(1_000_000)
@@ -132,7 +116,7 @@ func TestAfterSwap_TokenSpecified_ChargesFeeOnOutput(t *testing.T) {
 func TestBeforeSwap_ExactOutUnsupported(t *testing.T) {
 	h := &Hook{Extra: refExtra()}
 	_, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: false, AmountSpecified: big.NewInt(1)})
-	assert.ErrorIs(t, err, ErrCalcInUnsupported)
+	assert.ErrorIs(t, err, b20.ErrCalcInUnsupported)
 }
 
 // A pool whose Track() never succeeded (RPC failure, or a factory that constructs the
@@ -142,11 +126,11 @@ func TestBeforeAfterSwap_UntrackedPool_Errors(t *testing.T) {
 	h := &Hook{} // zero-value Extra: LaunchTime == 0
 
 	_, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true, AmountSpecified: big.NewInt(1_000_000)})
-	assert.ErrorIs(t, err, ErrNotTracked)
+	assert.ErrorIs(t, err, b20.ErrNotTracked)
 
 	_, err = h.AfterSwap(&uniswapv4.AfterSwapParams{
 		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false},
 		AmountOut:        big.NewInt(1_000_000),
 	})
-	assert.ErrorIs(t, err, ErrNotTracked)
+	assert.ErrorIs(t, err, b20.ErrNotTracked)
 }

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -194,6 +194,7 @@ import (
 	pkg_liquiditysource_uniswap_v4_hooks_idle "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/idle"
 	pkg_liquiditysource_uniswap_v4_hooks_livo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/livo"
 	pkg_liquiditysource_uniswap_v4_hooks_nft_strategy "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/nft_strategy"
+	pkg_liquiditysource_uniswap_v4_hooks_o1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/o1"
 	pkg_liquiditysource_uniswap_v4_hooks_odysfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/odysfun"
 	pkg_liquiditysource_uniswap_v4_hooks_renzo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/renzo"
 	pkg_liquiditysource_uniswap_v4_hooks_st0x "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/st0x"
@@ -448,6 +449,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_idle.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_livo.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_nft_strategy.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_o1.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_odysfun.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_renzo.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_st0x.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -311,6 +311,7 @@ const (
 	ExchangeUniswapV4Kem                = "uniswap-v4-kem"
 	ExchangeUniswapV4Livo               = "uniswap-v4-livo"
 	ExchangeUniswapV4NftStrategy        = "uniswap-v4-nftstrat"
+	ExchangeUniswapV4O1                 = "uniswap-v4-o1"
 	ExchangeUniswapV4OdysFun            = "uniswap-v4-odysfun"
 	ExchangeUniswapV4Renzo              = "uniswap-v4-renzo"
 	ExchangeUniswapV4ST0x               = "uniswap-v4-st0x"


### PR DESCRIPTION
o1 (0x1f91c998e7c2f4b690d75bdbf6502bdcd6e02acc on Base, verified via Sourcify)
is the same LaunchHook.sol lineage as hooks/b20: identical getHookPermissions
bitmask, byte-for-byte identical anti-snipe decay formula, and the same
fee-timing split between beforeSwap/afterSwap. It differs only in the
poolConfig getter's field layout (fee distribution moved to a FeeComponent[]
array that doesn't affect the swap-visible fee amount) plus launch-buy adapter
support that doesn't change generic-swap pricing.

Rather than duplicate the shared logic, b20.Extra's decay/fee/BeforeSwap/
AfterSwap methods and its sentinel errors are now exported so o1 can embed
b20.Extra directly; only o1's Track (its own poolConfig ABI decode) is
package-specific. Confirmed against a live pool on Base via
`cast call poolConfig(bytes32)`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01APFnpr2rSKgyenzYqdC5oQ
