### PR TITLE
feat(uniswap-v4): add pons-v2 meme hook (Robinhood chain)

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/abi.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/abi.go
@@ -1,0 +1,17 @@
+package ponsv2
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var hookABI abi.ABI
+
+func init() {
+	var err error
+	hookABI, err = abi.JSON(bytes.NewReader(hookABIJson))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/abis/Hook.json
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/abis/Hook.json
@@ -1,0 +1,23 @@
+[
+  {
+    "inputs": [{"internalType": "PoolId", "name": "", "type": "bytes32"}],
+    "name": "launches",
+    "outputs": [
+      {"internalType": "bool", "name": "registered", "type": "bool"},
+      {"internalType": "bool", "name": "memecoinIsCurrency0", "type": "bool"},
+      {"internalType": "address", "name": "memecoin", "type": "address"},
+      {"internalType": "address", "name": "quoteToken", "type": "address"},
+      {"internalType": "address", "name": "creator", "type": "address"},
+      {"internalType": "address", "name": "buybackCreatorRecipient", "type": "address"},
+      {"internalType": "address", "name": "protocolFeeRecipient", "type": "address"},
+      {"internalType": "uint16", "name": "creatorTaxBps", "type": "uint16"},
+      {"internalType": "uint16", "name": "protocolFeeShareBps", "type": "uint16"},
+      {"internalType": "uint16", "name": "buybackBurnBps", "type": "uint16"},
+      {"internalType": "uint16", "name": "hookFeeBps", "type": "uint16"},
+      {"internalType": "uint16", "name": "maxInternalPriceImpactBps", "type": "uint16"},
+      {"internalType": "bool", "name": "buybackEnabled", "type": "bool"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/constant.go
@@ -1,0 +1,13 @@
+package ponsv2
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// HookAddresses is the singleton PonsV2MemeHook shared by every graduated pons-v2
+// pool on Robinhood chain. Verified via Sourcify: PonsV2MemeHook.sol.
+var HookAddresses = []common.Address{
+	common.HexToAddress("0xE5e702641Ea86F4ae6cC3cDaeD2B886f976Be044"),
+}
+
+const basisPoints = 10_000

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/embed.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/embed.go
@@ -1,0 +1,6 @@
+package ponsv2
+
+import _ "embed"
+
+//go:embed abis/Hook.json
+var hookABIJson []byte

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/hook.go
@@ -1,0 +1,81 @@
+// Package ponsv2 implements PonsV2MemeHook, the singleton Uniswap v4 hook shared by
+// every graduated pons-v2 pool on Robinhood chain (see the pons-v2 package for the
+// pre-graduation bonding curve). Verified via Sourcify at
+// 0xE5e702641Ea86F4ae6cC3cDaeD2B886f976Be044: only afterSwap (+ afterSwapReturnDelta)
+// is enabled -- the hook takes hookFeeBps + creatorTaxBps of the swap's unspecified
+// currency straight out of the pool manager's flash-accounting ledger via a single
+// `take`, so the fee always lands on the realized output (exact-in) or is added on
+// top of the realized input (exact-out). Both bps are frozen per pool at
+// registerPool time, read here via the `launches` public mapping getter.
+package ponsv2
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+	"github.com/samber/lo"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+type Extra struct {
+	Registered bool  `json:"r,omitempty"`
+	FeeBps     int64 `json:"f,omitempty"`
+}
+
+type Hook struct {
+	uniswapv4.Hook `json:"-"`
+	Extra
+}
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	h := &Hook{Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4PonsV2}}
+	_ = param.HookExtra.Unmarshal(&h.Extra)
+	return h
+}, HookAddresses...)
+
+// Track reads the pool's frozen hookFeeBps + creatorTaxBps from the hook's `launches`
+// getter. Both are snapshotted immutably at registerPool time (later owner-level fee
+// updates only affect pools registered afterward), so an already-registered pool is
+// never re-fetched.
+func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	if h.Registered {
+		return json.Marshal(h)
+	}
+
+	var raw launchRaw
+	if _, err := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).
+		SetOverrides(param.Overrides).AddCall(&ethrpc.Call{
+		ABI:    hookABI,
+		Target: hexutil.Encode(param.HookAddress[:]),
+		Method: "launches",
+		Params: []any{common.HexToHash(param.Pool.Address)},
+	}, []any{&raw}).Call(); err != nil {
+		return nil, err
+	}
+
+	h.Extra = Extra{
+		Registered: raw.Registered,
+		FeeBps:     int64(raw.HookFeeBps) + int64(raw.CreatorTaxBps),
+	}
+	return json.Marshal(h)
+}
+
+// AfterSwap mirrors PonsV2MemeHook._afterSwap: the fee is a flat feeBps of the
+// unspecified currency's magnitude -- the realized output on exact-in, the realized
+// input on exact-out -- taken directly from the pool manager, never recomputed here.
+func (h *Hook) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
+	if !h.Registered || h.FeeBps == 0 {
+		return &uniswapv4.AfterSwapResult{HookFee: bignumber.ZeroBI}, nil
+	}
+	unspecified := lo.Ternary(params.CalcOut, params.AmountOut, params.AmountIn)
+	return &uniswapv4.AfterSwapResult{
+		HookFee: bignumber.MulDivDown(new(big.Int), unspecified, big.NewInt(h.FeeBps), big.NewInt(basisPoints)),
+	}, nil
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/hook_live_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/hook_live_test.go
@@ -1,0 +1,46 @@
+package ponsv2
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+)
+
+// TestTrack_Live decodes `launches` against a real graduated pons-v2 pool on Robinhood
+// chain (found via a live PoolRegistered log from the hook contract itself), confirming
+// hookABI's field order/types actually match the deployed contract -- not just that the
+// hand-written ABI JSON compiles.
+func TestTrack_Live(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
+	rpcClient := ethrpc.New("https://rpc.mainnet.chain.robinhood.com").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862be2a173976CA11"))
+	hookAddr := common.HexToAddress("0xE5e702641Ea86F4ae6cC3cDaeD2B886f976Be044")
+
+	h := &Hook{Hook: &uniswapv4.BaseHook{}}
+	_, err := h.Track(context.Background(), &uniswapv4.HookParam{
+		RpcClient:   rpcClient,
+		HookAddress: hookAddr,
+		Pool: &entity.Pool{
+			Address: "0xad66e295ab58f146c1c19901784444be40ebfa64d49f3311168ba2f27a75f56c",
+		},
+	})
+	require.NoError(t, err)
+
+	// Values cross-checked by hand against a raw eth_call to launches(bytes32) on
+	// 2026-09-06: hookFeeBps=100, creatorTaxBps=0 match the hook's constructor defaults
+	// (hookFeeBps=100), and this launch chose no creator tax.
+	assert.True(t, h.Registered)
+	assert.Equal(t, int64(100), h.FeeBps)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/hook_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/hook_test.go
@@ -1,0 +1,64 @@
+package ponsv2
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+// AfterSwap must mirror PonsV2MemeHook._afterSwap: feeAmount + taxAmount = floor(unspecified
+// * (hookFeeBps + creatorTaxBps) / BASIS_POINTS), taken from the realized output on exact-in.
+func TestAfterSwap_ExactIn_ChargesFeeOnOutput(t *testing.T) {
+	h := &Hook{Extra: Extra{Registered: true, FeeBps: 100 + 50}} // hookFeeBps=100, creatorTaxBps=50
+
+	result, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true},
+		AmountOut:        big.NewInt(1_000_000),
+	})
+	assert.NoError(t, err)
+	// floor(1_000_000 * 150 / 10_000) = 15_000
+	assert.Equal(t, big.NewInt(15_000), result.HookFee)
+}
+
+// On exact-out the unspecified currency is the input, so the fee is taken from the
+// realized input instead -- the swapper pays more than the AMM's own quote, not less.
+func TestAfterSwap_ExactOut_ChargesFeeOnInput(t *testing.T) {
+	h := &Hook{Extra: Extra{Registered: true, FeeBps: 150}}
+
+	result, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: false},
+		AmountIn:         big.NewInt(1_000_000),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewInt(15_000), result.HookFee)
+}
+
+// A pool never seen by Track() (RPC failure, or genuinely not yet registered with the
+// factory) must price as fee-free rather than error -- unlike b20's LaunchHook, an
+// unregistered PonsV2MemeHook pool really does charge nothing (_afterSwap's own
+// `if (!info.registered) return 0` early-out), so refusing to quote would be wrong here.
+func TestAfterSwap_Unregistered_NoFee(t *testing.T) {
+	h := &Hook{}
+
+	result, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true},
+		AmountOut:        big.NewInt(1_000_000),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, bignumber.ZeroBI, result.HookFee)
+}
+
+func TestAfterSwap_ZeroFee_NoOp(t *testing.T) {
+	h := &Hook{Extra: Extra{Registered: true, FeeBps: 0}}
+
+	result, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true},
+		AmountOut:        big.NewInt(1_000_000),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, bignumber.ZeroBI, result.HookFee)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/type.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/pons-v2/type.go
@@ -1,0 +1,25 @@
+package ponsv2
+
+import "github.com/ethereum/go-ethereum/common"
+
+// launchRaw is the ethrpc.Call.AddCall decode target for PonsV2MemeHook.sol's
+// `launches` public mapping getter, field order matching hookABI's outputs.
+// Only registered/hookFeeBps/creatorTaxBps drive the swap-visible fee; the
+// remaining fields govern fee distribution at sweep time, not pricing, so
+// they aren't decoded (abi.Unpack fills struct fields positionally and skips
+// absent ones, so every output must still be kept in the struct).
+type launchRaw struct {
+	Registered                bool
+	MemecoinIsCurrency0       bool
+	Memecoin                  common.Address
+	QuoteToken                common.Address
+	Creator                   common.Address
+	BuybackCreatorRecipient   common.Address
+	ProtocolFeeRecipient      common.Address
+	CreatorTaxBps             uint16
+	ProtocolFeeShareBps       uint16
+	BuybackBurnBps            uint16
+	HookFeeBps                uint16
+	MaxInternalPriceImpactBps uint16
+	BuybackEnabled            bool
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -195,6 +195,7 @@ import (
 	pkg_liquiditysource_uniswap_v4_hooks_livo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/livo"
 	pkg_liquiditysource_uniswap_v4_hooks_nft_strategy "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/nft_strategy"
 	pkg_liquiditysource_uniswap_v4_hooks_odysfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/odysfun"
+	pkg_liquiditysource_uniswap_v4_hooks_ponsv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/pons-v2"
 	pkg_liquiditysource_uniswap_v4_hooks_renzo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/renzo"
 	pkg_liquiditysource_uniswap_v4_hooks_st0x "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/st0x"
 	pkg_liquiditysource_uniswap_v4_hooks_stablestable "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/stable-stable"
@@ -449,6 +450,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_livo.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_nft_strategy.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_odysfun.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_ponsv2.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_renzo.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_st0x.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_stablestable.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -312,6 +312,7 @@ const (
 	ExchangeUniswapV4Livo               = "uniswap-v4-livo"
 	ExchangeUniswapV4NftStrategy        = "uniswap-v4-nftstrat"
 	ExchangeUniswapV4OdysFun            = "uniswap-v4-odysfun"
+	ExchangeUniswapV4PonsV2             = "uniswap-v4-pons-v2"
 	ExchangeUniswapV4Renzo              = "uniswap-v4-renzo"
 	ExchangeUniswapV4ST0x               = "uniswap-v4-st0x"
 	ExchangeUniswapV4StableStable       = "uniswap-v4-stable-stable"


### PR DESCRIPTION
Implements PonsV2MemeHook, the singleton V4 hook shared by every graduated
pons-v2 pool on Robinhood chain (0xE5e702641Ea86F4ae6cC3cDaeD2B886f976Be044,
verified via Sourcify). Only afterSwap is enabled: the hook takes
hookFeeBps + creatorTaxBps of the swap's unspecified currency, both frozen
per pool at registration and read via the launches() getter.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DhDdQNR2QpnSUjPFrxR3zE
