### PR TITLE
feat(uniswap-v4): add CashCatHookV2 hook (Robinhood chain)

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/cashcat/abi.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/cashcat/abi.go
@@ -1,0 +1,17 @@
+package cashcat
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var cashCatHookV2ABI abi.ABI
+
+func init() {
+	var err error
+	cashCatHookV2ABI, err = abi.JSON(bytes.NewReader(cashCatHookV2ABIJson))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/cashcat/abis/CashCatHookV2.json
+++ b/pkg/liquidity-source/uniswap/v4/hooks/cashcat/abis/CashCatHookV2.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "function",
+        "name": "currentFeeRate",
+        "stateMutability": "view",
+        "inputs": [
+            {
+                "name": "poolId",
+                "type": "bytes32"
+            },
+            {
+                "name": "swapper",
+                "type": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ]
+    }
+]

--- a/pkg/liquidity-source/uniswap/v4/hooks/cashcat/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/cashcat/constant.go
@@ -1,0 +1,14 @@
+package cashcat
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	// HookAddresses lists known CashCatHookV2 deployments by chain.
+	// The hook is not upgradeable; append new deployments here as they launch.
+	HookAddresses = []common.Address{
+		// Robinhood (chainID 4663)
+		common.HexToAddress("0x75a54357d9c78a2db19004a5fdc76c50f9242aec"),
+	}
+)

--- a/pkg/liquidity-source/uniswap/v4/hooks/cashcat/embed.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/cashcat/embed.go
@@ -1,0 +1,6 @@
+package cashcat
+
+import _ "embed"
+
+//go:embed abis/CashCatHookV2.json
+var cashCatHookV2ABIJson []byte

--- a/pkg/liquidity-source/uniswap/v4/hooks/cashcat/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/cashcat/hook.go
@@ -1,0 +1,173 @@
+// Package cashcat integrates CashCatHookV2, the fee engine for CashCat pools.
+//
+// The hook takes one flat fee on the quote side of every swap -- skimmed
+// from the quote input on buys and the quote output on sells -- fixed for
+// the life of the pool (no tiers, no decay, no exemptions). By hook
+// construction the quote asset is always currency0, so in dex-lib terms the
+// fee is input-side when zeroForOne and output-side otherwise.
+//
+// Because the fee is read directly from the hook (currentFeeRate) instead of
+// fitted from quoter probes, pools on this hook must NOT fall through to the
+// auto-detection fallback: explicit registration in HookFactories takes
+// precedence over it.
+package cashcat
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+var (
+	// FeeDenom is the hook's fee scale: 1e6 = 100%.
+	FeeDenom = big.NewInt(1e6)
+
+	ErrNotCalibrated = errors.New("cashcat: fee rate not tracked yet")
+	ErrFeeTooHigh    = errors.New("cashcat: fee rate exceeds 100%")
+)
+
+type Hook struct {
+	uniswapv4.Hook `json:"-"`
+	// FeeRate is the pool's flat fee in pips of the quote side (1e6 = 100%),
+	// read once via Track (immutable for the pool's life) and persisted in
+	// HookExtra.
+	FeeRate *big.Int `json:"f,omitempty"`
+}
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	hook := &Hook{
+		Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4Cashcat},
+	}
+	if len(param.HookExtra) > 0 {
+		var persisted Hook
+		if err := param.HookExtra.Unmarshal(&persisted); err == nil {
+			hook.FeeRate = persisted.FeeRate
+		}
+	}
+	return hook
+}, HookAddresses...)
+
+func (h *Hook) feeRate() (*big.Int, error) {
+	if h.FeeRate == nil {
+		return nil, ErrNotCalibrated
+	}
+	if h.FeeRate.Cmp(FeeDenom) > 0 {
+		return nil, ErrFeeTooHigh
+	}
+	return h.FeeRate, nil
+}
+
+// Track reads the pool's immutable fee rate. A present HookExtra in our own
+// schema is returned as-is (the rate never changes, so re-reading is pure
+// cost). Anything else -- empty, or a foreign schema such as the
+// auto-detection model persisted before this hook was explicitly registered
+// -- falls through to a fresh on-chain read, which is also what migrates
+// existing pools off the auto model on the first track after deploy.
+func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	if len(param.HookExtra) > 0 {
+		var persisted Hook
+		if err := param.HookExtra.Unmarshal(&persisted); err == nil && persisted.FeeRate != nil {
+			h.FeeRate = persisted.FeeRate
+			return json.Marshal(h)
+		}
+	}
+	if param.RpcClient == nil {
+		return nil, ErrNotCalibrated
+	}
+
+	var feeRate *big.Int
+	if _, err := param.RpcClient.NewRequest().SetContext(ctx).AddCall(&ethrpc.Call{
+		ABI:    cashCatHookV2ABI,
+		Target: param.HookAddress.Hex(),
+		Method: "currentFeeRate",
+		Params: []any{common.HexToHash(param.Pool.Address), common.Address{}},
+	}, []any{&feeRate}).TryBlockAndAggregate(); err != nil {
+		return nil, err
+	}
+	if feeRate == nil {
+		return nil, ErrNotCalibrated
+	}
+	if feeRate.Cmp(FeeDenom) > 0 {
+		return nil, ErrFeeTooHigh
+	}
+	h.FeeRate = feeRate
+
+	return json.Marshal(h)
+}
+
+// quoteSpecified reports whether the swap's specified side is the quote
+// asset (currency0). Mirrors the hook's `ethSpecified`, where exact-input
+// swaps carry a negative amountSpecified and exact-output a positive one:
+// exact-input selling currency0, or exact-output buying currency0. In
+// dex-lib terms exact-input is CalcOut and exact-output is !CalcOut.
+func quoteSpecified(calcOut, zeroForOne bool) bool {
+	return zeroForOne == calcOut
+}
+
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	feeRate, err := h.feeRate()
+	if err != nil {
+		return nil, err
+	}
+	deltaSpecified := bignumber.ZeroBI
+	if quoteSpecified(params.CalcOut, params.ZeroForOne) {
+		if params.CalcOut {
+			// Exact-input sell of the quote asset: skim the fee off the
+			// full input, _feeFor(amount, rate, exactOutput=false).
+			deltaSpecified = bignumber.MulDivDown(new(big.Int),
+				params.AmountSpecified, feeRate, FeeDenom)
+		} else {
+			// Exact-output buy of the quote asset: the named amount is
+			// what the trader keeps, so gross up to the leg it implies,
+			// _feeFor(amount, rate, exactOutput=true).
+			denom := new(big.Int).Sub(FeeDenom, feeRate)
+			if denom.Sign() <= 0 {
+				return nil, ErrFeeTooHigh
+			}
+			deltaSpecified = bignumber.MulDivDown(new(big.Int),
+				params.AmountSpecified, feeRate, denom)
+		}
+	}
+	return &uniswapv4.BeforeSwapResult{
+		DeltaSpecified:   deltaSpecified,
+		DeltaUnspecified: bignumber.ZeroBI,
+	}, nil
+}
+
+func (h *Hook) AfterSwap(params *uniswapv4.AfterSwapParams) (*uniswapv4.AfterSwapResult, error) {
+	feeRate, err := h.feeRate()
+	if err != nil {
+		return nil, err
+	}
+	hookFee := bignumber.ZeroBI
+	if !quoteSpecified(params.CalcOut, params.ZeroForOne) {
+		if params.CalcOut {
+			// Exact-input sell of the base asset: fee on the actual quote
+			// moved, _feeFor(amountOut, rate, exactOutput=false).
+			hookFee = bignumber.MulDivDown(new(big.Int),
+				params.AmountOut, feeRate, FeeDenom)
+		} else {
+			// Exact-output sell of the base asset: fee on the actual quote
+			// moved, grossed up, _feeFor(amountIn, rate, exactOutput=true).
+			// AmountIn here is the pre-fee requirement, which is exactly
+			// the base the gross-up inverts.
+			denom := new(big.Int).Sub(FeeDenom, feeRate)
+			if denom.Sign() <= 0 {
+				return nil, ErrFeeTooHigh
+			}
+			hookFee = bignumber.MulDivDown(new(big.Int),
+				params.AmountIn, feeRate, denom)
+		}
+	}
+	return &uniswapv4.AfterSwapResult{
+		HookFee: hookFee,
+	}, nil
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/cashcat/hook_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/cashcat/hook_test.go
@@ -1,0 +1,210 @@
+package cashcat
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func feeHook() *Hook {
+	return &Hook{
+		Hook:    &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4Cashcat},
+		FeeRate: big.NewInt(30000), // 3.0%: pool 0x6f0e... on Robinhood (CashCatHookV2.currentFeeRate)
+	}
+}
+
+// TestFactory_ExchangeAndRestore covers registration: the hook resolves by
+// address (taking precedence over the auto-detection fallback), reports its
+// own exchange, and restores the tracked fee rate from HookExtra.
+func TestFactory_ExchangeAndRestore(t *testing.T) {
+	t.Parallel()
+
+	hook, ok := uniswapv4.GetHook(common.HexToAddress("0x75a54357d9c78a2db19004a5fdc76c50f9242aec"), nil)
+	require.True(t, ok)
+	require.Equal(t, string(valueobject.ExchangeUniswapV4Cashcat), hook.GetExchange())
+
+	restored, ok := uniswapv4.GetHook(
+		common.HexToAddress("0x75a54357d9c78a2db19004a5fdc76c50f9242aec"),
+		&uniswapv4.HookParam{HookExtra: uniswapv4.HookExtra(`{"f":30000}`)},
+	)
+	require.True(t, ok)
+	cashcatHook, ok := restored.(*Hook)
+	require.True(t, ok)
+	require.Equal(t, "30000", cashcatHook.FeeRate.String())
+}
+
+// TestQuoteSpecified mirrors the hook's ethSpecified truth table.
+func TestQuoteSpecified(t *testing.T) {
+	t.Parallel()
+
+	// CalcOut = exact input: quote specified only when selling currency0.
+	require.True(t, quoteSpecified(true, true))
+	require.False(t, quoteSpecified(true, false))
+	// CalcIn = exact output: quote specified only when buying currency0.
+	require.True(t, quoteSpecified(false, false))
+	require.False(t, quoteSpecified(false, true))
+}
+
+// TestCalcOut_SellBaseTakesOutputFee mirrors the Tenderly ground truth for
+// selling 264665 PURRS: beforeSwap delta (0,0), afterSwap takes exactly 3%
+// of the quote moved.
+func TestCalcOut_SellBaseTakesOutputFee(t *testing.T) {
+	t.Parallel()
+	h := feeHook()
+
+	before, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{
+		CalcOut: true, ZeroForOne: false,
+		AmountSpecified: mustBig("264665000000000000000000"),
+	})
+	require.NoError(t, err)
+	require.Zero(t, before.DeltaSpecified.Sign())
+	require.Zero(t, before.DeltaUnspecified.Sign())
+
+	after, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false},
+		AmountOut:        mustBig("16019790377638234"),
+	})
+	require.NoError(t, err)
+	// 16019790377638234 * 30000 / 1e6 = 480593711329147.02 -> floor.
+	require.Equal(t, "480593711329147", after.HookFee.String())
+}
+
+// TestCalcOut_BuyQuoteSkimsInput mirrors a 0.01 WETH buy: 3% off the input
+// in beforeSwap, nothing in afterSwap.
+func TestCalcOut_BuyQuoteSkimsInput(t *testing.T) {
+	t.Parallel()
+	h := feeHook()
+
+	before, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{
+		CalcOut: true, ZeroForOne: true,
+		AmountSpecified: mustBig("10000000000000000"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "300000000000000", before.DeltaSpecified.String())
+	require.Zero(t, before.DeltaUnspecified.Sign())
+
+	after, err := h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true},
+		AmountIn:         mustBig("10000000000000000"),
+		AmountOut:        mustBig("159187442666741124038656"),
+	})
+	require.NoError(t, err)
+	require.Zero(t, after.HookFee.Sign())
+}
+
+// TestCalcIn_ExactOutputGrossUp mirrors _feeFor gross-up: naming 1 WETH out
+// adds 1e18*30000/970000 on the specified side.
+func TestCalcIn_ExactOutputGrossUp(t *testing.T) {
+	t.Parallel()
+	h := feeHook()
+
+	before, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{
+		CalcOut: false, ZeroForOne: false,
+		AmountSpecified: mustBig("1000000000000000000"),
+	})
+	require.NoError(t, err)
+	// 1e18 * 30000 / 970000 = 30927835051546391.75 -> floor.
+	require.Equal(t, "30927835051546391", before.DeltaSpecified.String())
+}
+
+// TestUntrackedFeeRateFailsLoud: without a tracked rate the hook refuses to
+// quote instead of silently quoting zero-fee.
+func TestUntrackedFeeRateFailsLoud(t *testing.T) {
+	t.Parallel()
+	h := &Hook{Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4Cashcat}}
+
+	_, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true,
+		AmountSpecified: big.NewInt(1000)})
+	require.ErrorIs(t, err, ErrNotCalibrated)
+
+	_, err = h.AfterSwap(&uniswapv4.AfterSwapParams{
+		BeforeSwapParams: &uniswapv4.BeforeSwapParams{CalcOut: true},
+		AmountOut:        big.NewInt(1000),
+	})
+	require.ErrorIs(t, err, ErrNotCalibrated)
+}
+
+// TestTrack_PassthroughAndNilRPC: own-schema HookExtra returns normalized;
+// missing extra without RPC errors instead of panicking.
+func TestTrack_PassthroughAndNilRPC(t *testing.T) {
+	t.Parallel()
+
+	h := feeHook()
+	out, err := h.Track(t.Context(), &uniswapv4.HookParam{
+		HookExtra: uniswapv4.HookExtra(`{"f":30000}`),
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"f":30000}`, string(out))
+
+	_, err = (&Hook{}).Track(t.Context(), &uniswapv4.HookParam{})
+	require.ErrorIs(t, err, ErrNotCalibrated)
+}
+
+// TestTrack_RefetchesOnForeignSchema: the auto-detection model persisted
+// before explicit registration must NOT be adopted -- without an "f" rate
+// the hook falls through to an on-chain read (nil RPC here), so the first
+// track after deploy migrates the pool instead of freezing the stale fit.
+func TestTrack_RefetchesOnForeignSchema(t *testing.T) {
+	t.Parallel()
+
+	autoModel := `{"f":[{},{"s":[{"x":53.07,"o":0.147}]}],"m":["688502902323479103",null],"b":64}`
+	_, err := (&Hook{}).Track(t.Context(), &uniswapv4.HookParam{
+		HookAddress: common.HexToAddress("0x75a54357d9c78a2db19004a5fdc76c50f9242aec"),
+		HookExtra:   uniswapv4.HookExtra(autoModel),
+	})
+	require.ErrorIs(t, err, ErrNotCalibrated,
+		"foreign schema must trigger refetch (nil RPC here), never passthrough")
+}
+
+func mustBig(s string) *big.Int {
+	v, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		panic(s)
+	}
+	return v
+}
+
+// TestEndToEnd_SellQuotesThroughPoolSimulator builds the real pool simulator
+// for 0x6f0e... (Robinhood snapshot, HookExtra already migrated to {"f":30000})
+// and asserts the previously-banned size quotes at raw*0.97: no Min bound,
+// no fitted spline, exactly the flat 3% the hook charges on-chain.
+func TestEndToEnd_SellQuotesThroughPoolSimulator(t *testing.T) {
+	t.Parallel()
+
+	extra := `{"liquidity":36819258015569838458222,"sqrtPriceX96":321747665048613514693004700497438,"tickSpacing":200,"tick":166192,"ticks":[{"index":-887200,"liquidityGross":36819258015569838458222,"liquidityNet":36819258015569838458222},{"index":204200,"liquidityGross":36819258015569838458222,"liquidityNet":-36819258015569838458222}],"hX":{"f":30000}}`
+	ep := entity.Pool{
+		Address:  "0x6f0e1919cb58a4b617e28e9be011c2fe4cb499663e89a4bb5ef7e9e487438383",
+		Exchange: string(valueobject.ExchangeUniswapV4Cashcat),
+		Type:     "uniswap-v4",
+		Reserves: entity.PoolReserves{"7710832767622379520", "149523981364570752796327936"},
+		Tokens: []*entity.PoolToken{
+			{Address: "0x0bd7d308f8e1639fab988df18a8011f41eacad73", Symbol: "WETH", Decimals: 18, Swappable: true},
+			{Address: "0x65fa36fe3c0f4beb9d793cd9a79c7f53ef4b82cc", Symbol: "PURRS", Decimals: 18, Swappable: true},
+		},
+		Extra:       extra,
+		StaticExtra: `{"0x0":[true,false],"fee":0,"tS":200,"hooks":"0x75a54357d9c78a2db19004a5fdc76c50f9242aec","uR":"0x8876789976decbfcbbbe364623c63652db8c0904","pm2":"0x000000000022d473030f116ddee9f6b43ac78ba3","mc3":"0x2cac2d899ecc914d704feaae33ac1bf36277dad1"}`,
+	}
+	sim, err := uniswapv4.NewPoolSimulator(ep, valueobject.ChainIDRobinhood)
+	require.NoError(t, err)
+	require.Equal(t, string(valueobject.ExchangeUniswapV4Cashcat), sim.GetExchange())
+
+	out, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{
+			Token:  "0x65fa36fe3c0f4beb9d793cd9a79c7f53ef4b82cc",
+			Amount: mustBig("264665000000000000000000"),
+		},
+		TokenOut: "0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+	})
+	require.NoError(t, err, "previously banned size must quote once migrated")
+	// raw AMM ~16019790377638234; flat 3% -> ~15539196666309087, matching the
+	// Tenderly execution intermediate. Allow 1% tolerance for state drift.
+	got, _ := new(big.Float).SetInt(out.TokenAmountOut.Amount).Float64()
+	require.InDelta(t, 15539196666309087.0, got, 15539196666309087.0*0.01)
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -186,6 +186,7 @@ import (
 	pkg_liquiditysource_uniswap_v4_hooks_arrakis "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/arrakis"
 	pkg_liquiditysource_uniswap_v4_hooks_b20 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/b20"
 	pkg_liquiditysource_uniswap_v4_hooks_bunniv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/bunni-v2"
+	pkg_liquiditysource_uniswap_v4_hooks_cashcat "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/cashcat"
 	pkg_liquiditysource_uniswap_v4_hooks_clanker "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/clanker"
 	pkg_liquiditysource_uniswap_v4_hooks_cult "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/cult"
 	pkg_liquiditysource_uniswap_v4_hooks_deli "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/deli"
@@ -442,6 +443,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_arrakis.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_b20.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_bunniv2.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_cashcat.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_clanker.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_cult.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_deli.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -300,6 +300,7 @@ const (
 	ExchangeUniswapV4Arrakis            = "uniswap-v4-arrakis"
 	ExchangeUniswapV4B20                = "uniswap-v4-b20"
 	ExchangeUniswapV4BunniV2            = "uniswap-v4-bunni-v2"
+	ExchangeUniswapV4Cashcat            = "uniswap-v4-cashcat"
 	ExchangeUniswapV4Clanker            = "uniswap-v4-clanker"
 	ExchangeUniswapV4Cult               = "uniswap-v4-cult"
 	ExchangeUniswapV4Deli               = "uniswap-v4-deli"


### PR DESCRIPTION
Integrates CashCatHookV2, the fee engine for CashCat pools: one flat fee on the quote side (currency0), fixed for the pool's life. BeforeSwap skims the quote input on buys, AfterSwap takes the quote output on sells, with exact-output gross-up mirroring _feeFor. The rate is read once via currentFeeRate and persisted in HookExtra; foreign schemas (e.g. the auto-detection model) trigger a refetch so existing pools migrate on the first track after deploy. Explicit registration takes precedence over the auto-detection fallback.


<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
