### PR TITLE
fix(ladder): prevent index out of range panic in CollectLadder

### DIFF
--- a/pkg/liquidity-source/ladder/sampling.go
+++ b/pkg/liquidity-source/ladder/sampling.go
@@ -389,6 +389,9 @@ func dedupSorted(sorted []*big.Int) []*big.Int {
 func CollectLadder(points []*big.Int, results []*big.Int) []Point {
 	pts := make([]Point, 0, len(points))
 	for i, amt := range points {
+		if i >= len(results) {
+			break
+		}
 		out := results[i]
 		if out == nil || out.Sign() <= 0 {
 			continue

--- a/pkg/liquidity-source/liquidcore/pool_tracker.go
+++ b/pkg/liquidity-source/liquidcore/pool_tracker.go
@@ -76,7 +76,7 @@ func (t *PoolTracker) getNewPoolState(
 
 	points0 := ladder.SamplePoints(p, 0, reserves.Reserve0, reserves.Reserve1)
 	points1 := ladder.SamplePoints(p, 1, reserves.Reserve1, reserves.Reserve0)
-	ladders, err := t.probeQuotes(ctx, p.Address, overrides, token0, token1, points0, points1)
+	ladders, err := t.probeQuotes(ctx, p.Address, overrides, resp.BlockNumber, token0, token1, points0, points1)
 	if err != nil {
 		logger.Errorf("failed to probe quotes: %v", err)
 		return p, err
@@ -99,12 +99,13 @@ func (t *PoolTracker) probeQuotes(
 	ctx context.Context,
 	poolAddr string,
 	overrides map[common.Address]gethclient.OverrideAccount,
+	blockNumber *big.Int,
 	token0, token1 common.Address,
 	points0, points1 []*big.Int,
 ) ([2][]ladder.Point, error) {
 	var amountsOut0, amountsOut1 []*big.Int
 
-	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides)
+	req := t.ethrpcClient.R().SetContext(ctx).SetOverrides(overrides).SetBlockNumber(blockNumber)
 	if len(points0) > 0 {
 		req.AddCall(&ethrpc.Call{
 			ABI:    poolABI,


### PR DESCRIPTION
CollectLadder assumed len(results) == len(points), but TryAggregate tolerates individual call failures and leaves the corresponding output variable at its zero value (nil/empty slice) when a per-token-direction estimateSwapBatch call reverts on-chain. This caused a panic in liquidcore's pool tracker (index out of range [0] with length 0) when one direction's batch quote reverted while the other succeeded.

Treat any point past the end of results as reverted instead of indexing out of bounds.


<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
