### PR TITLE
feat: integrate Spire proprietary AMM on Base

### DIFF
--- a/pkg/liquidity-source/spire-prop/README.md
+++ b/pkg/liquidity-source/spire-prop/README.md
@@ -1,0 +1,41 @@
+# Spire proprietary AMM (`spire-prop`)
+
+Spire combines maker books into a compressed on-chain curve. This integration supports exact-input WETH–USDC ERC20 swaps on Base (chain ID 8453). It has no RFQ HTTP dependency, native ETH support, partial fills, or separate taker fee.
+
+Protocol documentation: [overview](https://docs.baibai.cx/takers/overview), [quoting and swapping](https://docs.baibai.cx/takers/quoting-and-swapping), [deployments](https://docs.baibai.cx/takers/deployments).
+
+| Contract | Base mainnet |
+|---|---|
+| Entrypoint / approval target | [0x98c1D9E102Eb2806D902b13186BDc7892aC4fFBa](https://basescan.org/address/0x98c1D9E102Eb2806D902b13186BDc7892aC4fFBa#code) |
+| Curve book | [0x604d9b9eB1e1571C78661a6C1088427EC9c8c6E5](https://basescan.org/address/0x604d9b9eB1e1571C78661a6C1088427EC9c8c6E5#code) |
+| Shared custodian | [0xAaC48FEB93c5C97E0fb3c7C57E1633922A4ACDa3](https://basescan.org/address/0xAaC48FEB93c5C97E0fb3c7C57E1633922A4ACDa3#code) |
+
+Example discovery configuration:
+
+```json
+{
+  "dexID": "spire-prop",
+  "entrypoint": "0x98c1d9e102eb2806d902b13186bdc7892ac4ffba",
+  "bases": ["0x4200000000000000000000000000000000000006"]
+}
+```
+
+There is no enumerable factory. Discovery uses configured base tokens and reads the entrypoint's immutable curve, custodian and quote token. The pool identifier is the low 20 bytes of `keccak256(entrypoint || base)` with both addresses packed as 20 bytes. This identifier is not a deployed contract. Execution uses `meta.entrypoint` and `meta.base`; balances are held in the custodian. Discovery emits zero reserve placeholders; tracking supplies `availableLiquidity`, excluding pending claims.
+
+Tracking reads a block header, pins both multicalls to its hash, and checks the canonical hash again before returning. It verifies contract wiring and stores the actual block number in pool state and metadata. Routing should enable `FactoryOpts.StaleCheck`: expiry is checked again on every quote. Historical fixture replay leaves that option disabled but still validates expiry at the snapshot timestamp. Expiry is strict `timestamp > min(validUntil, lastUpdateAt + ttl)`; `ttl = 0` disables only the second bound. Refresh immediately before routing because fills, curve replacement and expiry can invalidate a snapshot.
+
+Pricing ports the curve's checked uint256 operations, including operation order. Signed spread adjusts the midpoint. Cumulative quote impact is linearly interpolated with ceiling rounding. Buys walk ask segments from the consumed cursor, round segment costs upward, and use full-width floor multiplication/division for the last partial segment. Sells subtract the change in cumulative bid impact from the floor midpoint value. Depth limits and available custody are checked before returning a quote. Spread and curve impact are already in the output; the additional fee is zero.
+
+`UpdateBalance` consumes returned swap information, advances the appropriate cursor/fill sequence, and adjusts reserves. Clones own their mutable values. Shared route inventory is keyed by custodian and token so two configured bases cannot independently spend the same quote balance. Gas uses a conservative 200,000 baseline plus 5,000 per knot on the larger side; fork measurements for this deployment were below 174,000 for the adapter call, excluding enclosing router overhead.
+
+The execution adapter receives `abi.encode(meta.entrypoint, meta.base)`. The enclosing router must enforce final minimum output and deadline; the entrypoint has no caller deadline argument.
+
+Validation:
+
+```sh
+go test ./pkg/liquidity-source/spire-prop ./pkg/msgpack/... ./pkg/pooltypes
+go test -race ./pkg/liquidity-source/spire-prop
+SPIRE_RPC_URL=<Base RPC> go test -tags integration ./pkg/liquidity-source/spire-prop -v
+```
+
+The committed fixture records 34 comparisons at [Base block 50979793](https://basescan.org/block/50979793): 17 executable results match the deployed curve exactly, and 17 are rejected for zero output or insufficient available custody. Additional tests cover signed spread, multi-knot integer rounding, consumed cursors, clone/purity, shared inventory, expiry, malformed state and overflow. The explicit integration test also exercises discovery, metadata replay, tracking and same-block contract comparisons. `SPIRE_FIXTURE_PATH` optionally writes a refreshed fixture.

--- a/pkg/liquidity-source/spire-prop/README.md
+++ b/pkg/liquidity-source/spire-prop/README.md
@@ -1,6 +1,6 @@
 # Spire proprietary AMM (`spire-prop`)
 
-Spire combines maker books into a compressed on-chain curve. This integration supports exact-input WETH–USDC ERC20 swaps on Base (chain ID 8453). It has no RFQ HTTP dependency, native ETH support, partial fills, or separate taker fee.
+Spire combines maker books into a compressed on-chain curve. This integration supports exact-input swaps between configured base ERC20s and a Spire entrypoint's quote token. WETH–USDC on Base (chain ID 8453) is the deployment verified below. It has no RFQ HTTP dependency, native ETH support, partial fills, or separate taker fee.
 
 Protocol documentation: [overview](https://docs.baibai.cx/takers/overview), [quoting and swapping](https://docs.baibai.cx/takers/quoting-and-swapping), [deployments](https://docs.baibai.cx/takers/deployments).
 
@@ -19,6 +19,8 @@ Example discovery configuration:
   "bases": ["0x4200000000000000000000000000000000000006"]
 }
 ```
+
+Add another listed base to `bases` to discover another pair; the existing simulator and adapter do not require pair-specific code. One entrypoint has one quote token; a different quote token requires a separate deployment/source configuration. On-chain `qUnit`, `cUnit` and midpoint values carry token scaling, so the simulator does not assume 18-decimal WETH or 6-decimal USDC. A regression test exercises an eight-decimal base and prevents two bases from spending the same shared quote inventory. Fee-on-transfer and rebasing tokens are unsupported.
 
 There is no enumerable factory. Discovery uses configured base tokens and reads the entrypoint's immutable curve, custodian and quote token. The pool identifier is the low 20 bytes of `keccak256(entrypoint || base)` with both addresses packed as 20 bytes. This identifier is not a deployed contract. Execution uses `meta.entrypoint` and `meta.base`; balances are held in the custodian. Discovery emits zero reserve placeholders; tracking supplies `availableLiquidity`, excluding pending claims.
 

--- a/pkg/liquidity-source/spire-prop/abis.go
+++ b/pkg/liquidity-source/spire-prop/abis.go
@@ -1,0 +1,28 @@
+package spireprop
+
+import (
+	"bytes"
+	_ "embed"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+var (
+	//go:embed abis/Entrypoint.json
+	entrypointABIData []byte
+	//go:embed abis/CurveBook.json
+	curveBookABIData []byte
+	//go:embed abis/Custodian.json
+	custodianABIData []byte
+	entrypointABI    = mustABI(entrypointABIData)
+	curveBookABI     = mustABI(curveBookABIData)
+	custodianABI     = mustABI(custodianABIData)
+)
+
+func mustABI(raw []byte) abi.ABI {
+	parsed, err := abi.JSON(bytes.NewReader(raw))
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}

--- a/pkg/liquidity-source/spire-prop/abis/CurveBook.json
+++ b/pkg/liquidity-source/spire-prop/abis/CurveBook.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "function",
+    "name": "cUnit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "entrypoint",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "knot",
+    "inputs": [
+      {
+        "name": "base",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "side",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "q",
+        "type": "uint48",
+        "internalType": "uint48"
+      },
+      {
+        "name": "extra",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pair",
+    "inputs": [
+      {
+        "name": "base",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "v",
+        "type": "tuple",
+        "internalType": "struct IBaibaiCurveBook.PairView",
+        "components": [
+          {
+            "name": "seq",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "fillSeq",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "lastUpdateAt",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "mid",
+            "type": "uint80",
+            "internalType": "uint80"
+          },
+          {
+            "name": "qUnit",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ask",
+            "type": "tuple",
+            "internalType": "struct IBaibaiCurveBook.Side",
+            "components": [
+              {
+                "name": "spreadBps",
+                "type": "int16",
+                "internalType": "int16"
+              },
+              {
+                "name": "depthBps",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "filled",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "knotCount",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          },
+          {
+            "name": "bid",
+            "type": "tuple",
+            "internalType": "struct IBaibaiCurveBook.Side",
+            "components": [
+              {
+                "name": "spreadBps",
+                "type": "int16",
+                "internalType": "int16"
+              },
+              {
+                "name": "depthBps",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "filled",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "knotCount",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quote",
+    "inputs": [
+      {
+        "name": "base",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ttl",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "validUntil",
+    "inputs": [
+      {
+        "name": "base",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/pkg/liquidity-source/spire-prop/abis/Custodian.json
+++ b/pkg/liquidity-source/spire-prop/abis/Custodian.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "function",
+    "name": "availableLiquidity",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "curveBook",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "entrypoint",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/pkg/liquidity-source/spire-prop/abis/Entrypoint.json
+++ b/pkg/liquidity-source/spire-prop/abis/Entrypoint.json
@@ -1,0 +1,80 @@
+[
+  {
+    "type": "function",
+    "name": "curveBook",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "custodian",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "swapExactAmountIn",
+    "inputs": [
+      {
+        "name": "base",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minAmountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  }
+]

--- a/pkg/liquidity-source/spire-prop/integration_test.go
+++ b/pkg/liquidity-source/spire-prop/integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package spireprop
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/KyberNetwork/logger"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+func TestLiveSnapshot(t *testing.T) {
+	endpoint := os.Getenv("SPIRE_RPC_URL")
+	if endpoint == "" {
+		t.Fatal("SPIRE_RPC_URL is required for the explicit integration build")
+	}
+	_ = logger.SetLogLevel("fatal")
+	fail := func(stage string, err error) {
+		t.Helper()
+		t.Fatalf("%s: %s", stage, strings.ReplaceAll(err.Error(), endpoint, "<rpc>"))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	client := ethrpc.New(endpoint).SetMulticallContract(common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"))
+	cfg := &Config{DexID: DexType, Entrypoint: "0x98c1d9e102eb2806d902b13186bdc7892ac4ffba", Bases: []string{"0x4200000000000000000000000000000000000006"}}
+	lister := NewPoolsListUpdater(cfg, client)
+	listed, metadata, err := lister.GetNewPools(ctx, nil)
+	if err != nil {
+		fail("list", err)
+	}
+	if len(listed) != 1 || listed[0].Reserves[0] != "0" || listed[0].Tokens[0].Decimals != 0 {
+		t.Fatal("discovery contract")
+	}
+	duplicate, _, err := lister.GetNewPools(ctx, metadata)
+	if err != nil {
+		fail("list again", err)
+	}
+	if len(duplicate) != 0 {
+		t.Fatal("duplicated discovery")
+	}
+	p, err := NewPoolTracker(client).GetNewPoolState(ctx, listed[0], pool.GetNewPoolStateParams{})
+	if err != nil {
+		fail("track", err)
+	}
+	simulator, err := NewPoolSimulator(pool.FactoryParams{EntityPool: p})
+	if err != nil {
+		fail("construct", err)
+	}
+	fixture := QuoteFixture{Pool: p}
+	req := client.NewRequest().SetContext(ctx).SetBlockNumber(new(big.Int).SetUint64(p.BlockNumber))
+	inputs := []string{"1", "2", "100", "10000", "1000000", "25000000", "100000000", "500000000", "1000000000", "10000000000", "1000000000000", "100000000000000", "1000000000000000", "10000000000000000", "100000000000000000", "1000000000000000000", "1000000000000000000000"}
+	outputs := make([]*big.Int, 2*len(inputs))
+	for side := 0; side < 2; side++ {
+		for j, input := range inputs {
+			amount, _ := new(big.Int).SetString(input, 10)
+			i := side*len(inputs) + j
+			req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: simulator.StaticExtra.CurveBook, Method: "quote", Params: []any{common.HexToAddress(p.Tokens[0].Address), common.HexToAddress(p.Tokens[side].Address), amount}}, []any{&outputs[i]})
+		}
+	}
+	if _, err = req.Aggregate(); err != nil {
+		fail("reference quotes", err)
+	}
+	success := 0
+	for side := 0; side < 2; side++ {
+		for j, input := range inputs {
+			expected := outputs[side*len(inputs)+j]
+			amount, _ := new(big.Int).SetString(input, 10)
+			result, err := simulator.CalcAmountOut(pool.CalcAmountOutParams{TokenAmountIn: pool.TokenAmount{Token: p.Tokens[side].Address, Amount: amount}, TokenOut: p.Tokens[1-side].Address})
+			executable := expected.Sign() > 0 && expected.Cmp(simulator.Info.Reserves[1-side]) <= 0
+			if executable {
+				if err != nil {
+					fail("simulate executable reference", err)
+				}
+				if result.TokenAmountOut.Amount.Cmp(expected) != 0 {
+					t.Fatalf("quote mismatch side=%d input=%s actual=%s expected=%s", side, input, result.TokenAmountOut.Amount, expected)
+				}
+				success++
+			} else if err == nil {
+				t.Fatalf("accepted non-executable quote side=%d input=%s", side, input)
+			}
+			fixture.Quotes = append(fixture.Quotes, QuoteCase{IndexIn: side, AmountIn: input, AmountOut: expected.String(), Executable: executable})
+		}
+	}
+	if success < 10 {
+		t.Fatal("too few executable comparison cases")
+	}
+	if path := os.Getenv("SPIRE_FIXTURE_PATH"); path != "" {
+		raw, err := json.MarshalIndent(fixture, "", "  ")
+		if err != nil {
+			fail("fixture encode", err)
+		}
+		if err := os.WriteFile(path, append(raw, '\n'), 0644); err != nil {
+			fail("fixture write", err)
+		}
+	}
+	t.Logf("same-block comparison: block=%d cases=%d executable=%d; discovery replay passed", p.BlockNumber, len(fixture.Quotes), success)
+}

--- a/pkg/liquidity-source/spire-prop/math.go
+++ b/pkg/liquidity-source/spire-prop/math.go
@@ -97,6 +97,9 @@ func (s *PoolSimulator) sell(amount *uint256.Int) (out, cursor uint256.Int, err 
 	side := &s.Extra.Bid
 	cursor, err = add(&side.Filled, amount)
 	if err != nil {
+		// BaibaiCurveBook._sellBase uses Math.tryAdd and maps a failed add
+		// to Fail.BeyondDepth. Preserve that result; the multiplication below
+		// instead uses Solidity checked arithmetic and remains ErrOverflow.
 		return out, cursor, ErrDepth
 	}
 	maxQ, err := s.effectiveMax(side)

--- a/pkg/liquidity-source/spire-prop/math.go
+++ b/pkg/liquidity-source/spire-prop/math.go
@@ -1,0 +1,205 @@
+package spireprop
+
+import (
+	"github.com/holiman/uint256"
+)
+
+var wad = uint256.NewInt(1_000_000_000_000_000_000)
+var bps = uint256.NewInt(10_000)
+
+func mul(a, b *uint256.Int) (uint256.Int, error) {
+	var z uint256.Int
+	if _, overflow := z.MulOverflow(a, b); overflow {
+		return z, ErrOverflow
+	}
+	return z, nil
+}
+
+func add(a, b *uint256.Int) (uint256.Int, error) {
+	var z uint256.Int
+	if _, overflow := z.AddOverflow(a, b); overflow {
+		return z, ErrOverflow
+	}
+	return z, nil
+}
+
+// Solidity's ceilDiv(a,b), including the no-overflow operation order.
+func ceilDiv(a, b *uint256.Int) uint256.Int {
+	if a.IsZero() {
+		return uint256.Int{}
+	}
+	var z uint256.Int
+	z.SubUint64(a, 1).Div(&z, b).AddUint64(&z, 1)
+	return z
+}
+
+func (s *PoolSimulator) sidePrice(side *Side) uint256.Int {
+	var scale, price uint256.Int
+	scale.SetUint64(uint64(10_000 + int32(side.SpreadBps)))
+	// Mid is uint80 and scale <= 42767; validated state cannot overflow.
+	price.Mul(&s.Extra.Mid, &scale).Div(&price, bps)
+	return price
+}
+
+func (s *PoolSimulator) atomic(knot *Knot) (q, c uint256.Int, err error) {
+	q, err = mul(&knot.Q, &s.Extra.QUnit)
+	if err != nil {
+		return
+	}
+	c, err = mul(&knot.Extra, &s.Extra.CUnit)
+	return
+}
+
+func (s *PoolSimulator) effectiveMax(side *Side) (uint256.Int, error) {
+	if len(side.Knots) == 0 || side.DepthBps == 0 {
+		return uint256.Int{}, nil
+	}
+	q, _, err := s.atomic(&side.Knots[len(side.Knots)-1])
+	if err != nil {
+		return q, err
+	}
+	var scale uint256.Int
+	scale.SetUint64(uint64(side.DepthBps))
+	q, err = mul(&q, &scale)
+	q.Div(&q, bps)
+	return q, err
+}
+
+func interp(prevQ, prevC, qA, cA, x *uint256.Int) (uint256.Int, error) {
+	var dc, dx, dq uint256.Int
+	dc.Sub(cA, prevC)
+	dx.Sub(x, prevQ)
+	dq.Sub(qA, prevQ)
+	product, err := mul(&dc, &dx)
+	if err != nil {
+		return uint256.Int{}, err
+	}
+	extra := ceilDiv(&product, &dq)
+	return add(prevC, &extra)
+}
+
+func (s *PoolSimulator) extraAt(side *Side, x *uint256.Int) (uint256.Int, error) {
+	var prevQ, prevC uint256.Int
+	for i := range side.Knots {
+		qA, cA, err := s.atomic(&side.Knots[i])
+		if err != nil {
+			return uint256.Int{}, err
+		}
+		if x.Cmp(&qA) <= 0 {
+			return interp(&prevQ, &prevC, &qA, &cA, x)
+		}
+		prevQ, prevC = qA, cA
+	}
+	return prevC, nil
+}
+
+func (s *PoolSimulator) sell(amount *uint256.Int) (out, cursor uint256.Int, err error) {
+	side := &s.Extra.Bid
+	cursor, err = add(&side.Filled, amount)
+	if err != nil {
+		return out, cursor, ErrDepth
+	}
+	maxQ, err := s.effectiveMax(side)
+	if err != nil {
+		return out, cursor, err
+	}
+	if cursor.Gt(&maxQ) {
+		return out, cursor, ErrDepth
+	}
+	price := s.sidePrice(side)
+	mid, err := mul(&price, amount)
+	if err != nil {
+		return out, cursor, err
+	}
+	mid.Div(&mid, wad)
+	end, err := s.extraAt(side, &cursor)
+	if err != nil {
+		return out, cursor, err
+	}
+	start, err := s.extraAt(side, &side.Filled)
+	if err != nil {
+		return out, cursor, err
+	}
+	end.Sub(&end, &start)
+	if end.Cmp(&mid) >= 0 {
+		return out, cursor, ErrDepth
+	}
+	out.Sub(&mid, &end)
+	return
+}
+
+func (s *PoolSimulator) buy(amount *uint256.Int) (out, cursor uint256.Int, err error) {
+	side := &s.Extra.Ask
+	cursor = side.Filled
+	maxQ, err := s.effectiveMax(side)
+	if err != nil {
+		return out, cursor, err
+	}
+	if cursor.Cmp(&maxQ) >= 0 {
+		return out, cursor, ErrDepth
+	}
+	price, remaining := s.sidePrice(side), *amount
+	var prevQ, prevC uint256.Int
+	for i := range side.Knots {
+		if remaining.IsZero() {
+			break
+		}
+		qA, cA, e := s.atomic(&side.Knots[i])
+		if e != nil {
+			return out, cursor, e
+		}
+		if qA.Gt(&cursor) {
+			endQ := qA
+			if maxQ.Lt(&endQ) {
+				endQ = maxQ
+			}
+			var delta uint256.Int
+			delta.Sub(&endQ, &cursor)
+			product, e := mul(&price, &delta)
+			if e != nil {
+				return out, cursor, e
+			}
+			cost := ceilDiv(&product, wad)
+			endExtra, e := interp(&prevQ, &prevC, &qA, &cA, &endQ)
+			if e != nil {
+				return out, cursor, e
+			}
+			startExtra, e := interp(&prevQ, &prevC, &qA, &cA, &cursor)
+			if e != nil {
+				return out, cursor, e
+			}
+			// Preserve Solidity's left-to-right checked addition before subtracting.
+			cost, e = add(&cost, &endExtra)
+			if e != nil {
+				return out, cursor, e
+			}
+			cost.Sub(&cost, &startExtra)
+			if remaining.Lt(&cost) {
+				var dq uint256.Int
+				if _, overflow := dq.MulDivOverflow(&remaining, &delta, &cost); overflow {
+					return out, cursor, ErrOverflow
+				}
+				if dq.IsZero() {
+					return out, cursor, ErrDepth
+				}
+				cursor.Add(&cursor, &dq)
+				remaining.Clear()
+			} else {
+				remaining.Sub(&remaining, &cost)
+				cursor = endQ
+			}
+			if cursor.Eq(&maxQ) {
+				break
+			}
+		}
+		prevQ, prevC = qA, cA
+	}
+	if !remaining.IsZero() {
+		return out, cursor, ErrDepth
+	}
+	out.Sub(&cursor, &side.Filled)
+	if out.IsZero() {
+		return out, cursor, ErrDepth
+	}
+	return
+}

--- a/pkg/liquidity-source/spire-prop/pool_simulator.go
+++ b/pkg/liquidity-source/spire-prop/pool_simulator.go
@@ -1,0 +1,210 @@
+package spireprop
+
+import (
+	"math"
+	"math/big"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+type PoolSimulator struct {
+	pool.Pool
+	Extra       Extra
+	StaticExtra StaticExtra
+	StaleCheck  bool
+}
+
+var (
+	_ = pool.RegisterFactory(DexType, NewPoolSimulator)
+	_ = pool.RegisterUseSwapLimit(valueobject.ExchangeSpireProp)
+)
+
+func NewPoolSimulator(params pool.FactoryParams) (*PoolSimulator, error) {
+	p := params.EntityPool
+	if len(p.Tokens) != 2 || len(p.Reserves) != 2 || p.BlockNumber == 0 {
+		return nil, ErrInvalidState
+	}
+	s := &PoolSimulator{StaleCheck: params.Opts.StaleCheck}
+	if err := json.Unmarshal([]byte(p.Extra), &s.Extra); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(p.StaticExtra), &s.StaticExtra); err != nil {
+		return nil, err
+	}
+	for _, a := range []string{s.StaticExtra.Entrypoint, s.StaticExtra.CurveBook, s.StaticExtra.Custodian} {
+		if !validAddress(a) {
+			return nil, ErrInvalidState
+		}
+	}
+	s.Info = pool.PoolInfo{Address: strings.ToLower(p.Address), Exchange: p.Exchange, Type: p.Type, BlockNumber: p.BlockNumber}
+	for i, token := range p.Tokens {
+		if token == nil || !validAddress(token.Address) {
+			return nil, ErrInvalidState
+		}
+		value, ok := new(big.Int).SetString(p.Reserves[i], 10)
+		if !ok || value.Sign() < 0 || value.BitLen() > 256 {
+			return nil, ErrInvalidState
+		}
+		s.Info.Tokens = append(s.Info.Tokens, strings.ToLower(token.Address))
+		s.Info.Reserves = append(s.Info.Reserves, value)
+	}
+	if s.Info.Tokens[0] == s.Info.Tokens[1] {
+		return nil, ErrInvalidState
+	}
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if s.expired(s.Extra.BlockTimestamp) || (s.StaleCheck && s.expired(uint64(time.Now().Unix()))) {
+		return nil, ErrExpired
+	}
+	return s, nil
+}
+
+func validAddress(a string) bool {
+	return common.IsHexAddress(a) && common.HexToAddress(a) != (common.Address{})
+}
+
+func (s *PoolSimulator) validate() error {
+	e := &s.Extra
+	if e.Mid.IsZero() || e.Mid.BitLen() > 80 || e.QUnit.IsZero() || e.CUnit.IsZero() || e.BlockTimestamp == 0 || e.LastUpdateAt > e.BlockTimestamp {
+		return ErrInvalidState
+	}
+	for _, side := range []*Side{&e.Ask, &e.Bid} {
+		if side.SpreadBps <= -10000 || side.DepthBps > 10000 || len(side.Knots) > 36 {
+			return ErrInvalidState
+		}
+		var previous Knot
+		for i := range side.Knots {
+			k := &side.Knots[i]
+			if k.Q.BitLen() > 48 || k.Extra.BitLen() > 48 || k.Q.Cmp(&previous.Q) <= 0 || k.Extra.Lt(&previous.Extra) {
+				return ErrInvalidState
+			}
+			if _, _, err := s.atomic(k); err != nil {
+				return err
+			}
+			previous = *k
+		}
+		if _, err := s.effectiveMax(side); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *PoolSimulator) deadline() uint64 {
+	until := s.Extra.ValidUntil
+	// Solidity adds the uint64 timestamps as uint256, so overflow must not wrap.
+	if s.Extra.TTL != 0 && s.Extra.TTL <= math.MaxUint64-s.Extra.LastUpdateAt {
+		until = min(until, s.Extra.LastUpdateAt+s.Extra.TTL)
+	}
+	return until
+}
+
+func (s *PoolSimulator) expired(now uint64) bool { return now > s.deadline() }
+
+func (s *PoolSimulator) CalcAmountOut(params pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
+	in, out := s.GetTokenIndex(strings.ToLower(params.TokenAmountIn.Token)), s.GetTokenIndex(strings.ToLower(params.TokenOut))
+	if in < 0 || out < 0 || in == out {
+		return nil, ErrInvalidToken
+	}
+	if params.TokenAmountIn.Amount == nil || params.TokenAmountIn.Amount.Sign() <= 0 {
+		return nil, ErrAmount
+	}
+	amount, overflow := uint256.FromBig(params.TokenAmountIn.Amount)
+	if overflow {
+		return nil, ErrAmount
+	}
+	if s.StaleCheck && s.expired(uint64(time.Now().Unix())) {
+		return nil, ErrExpired
+	}
+	if s.Extra.FillSeq == math.MaxUint64 {
+		return nil, ErrOverflow
+	}
+	var output, cursor uint256.Int
+	var err error
+	if in == 0 {
+		output, cursor, err = s.sell(amount)
+	} else {
+		output, cursor, err = s.buy(amount)
+	}
+	if err != nil {
+		return nil, err
+	}
+	outputBig := output.ToBig()
+	if output.IsZero() || outputBig.Cmp(s.Info.Reserves[out]) > 0 {
+		return nil, pool.ErrNotEnoughInventory
+	}
+	if params.Limit != nil {
+		limit := params.Limit.GetLimit(s.limitKey(s.Info.Tokens[out]))
+		if limit == nil || outputBig.Cmp(limit) > 0 {
+			return nil, pool.ErrNotEnoughInventory
+		}
+	}
+	// Input is transferred to custody before payout. Account for ERC20 balance
+	// arithmetic as well as the curve's own checked arithmetic.
+	if new(big.Int).Add(s.Info.Reserves[in], amount.ToBig()).BitLen() > 256 {
+		return nil, ErrOverflow
+	}
+	return &pool.CalcAmountOutResult{
+		TokenAmountOut: &pool.TokenAmount{Token: s.Info.Tokens[out], Amount: outputBig},
+		Fee:            &pool.TokenAmount{Token: s.Info.Tokens[in], Amount: new(big.Int)},
+		Gas:            defaultGas + 5000*int64(max(len(s.Extra.Ask.Knots), len(s.Extra.Bid.Knots))),
+		SwapInfo:       SwapInfo{IndexIn: in, FillSeq: s.Extra.FillSeq, Cursor: cursor, AmountIn: *amount, AmountOut: output},
+	}, nil
+}
+
+func (s *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {
+	swap, ok := params.SwapInfo.(SwapInfo)
+	if !ok || swap.IndexIn < 0 || swap.IndexIn > 1 || swap.FillSeq != s.Extra.FillSeq {
+		return
+	}
+	in, out := swap.IndexIn, 1-swap.IndexIn
+	amountIn, amountOut := swap.AmountIn.ToBig(), swap.AmountOut.ToBig()
+	if params.SwapLimit != nil {
+		if _, _, err := params.SwapLimit.UpdateLimit(s.limitKey(s.Info.Tokens[out]), s.limitKey(s.Info.Tokens[in]), amountOut, amountIn); err != nil {
+			return
+		}
+	}
+	s.Info.Reserves[in] = new(big.Int).Add(s.Info.Reserves[in], amountIn)
+	s.Info.Reserves[out] = new(big.Int).Sub(s.Info.Reserves[out], amountOut)
+	if in == 0 {
+		s.Extra.Bid.Filled = swap.Cursor
+	} else {
+		s.Extra.Ask.Filled = swap.Cursor
+	}
+	s.Extra.FillSeq++
+}
+
+func (s *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *s
+	cloned.Info.Tokens = slices.Clone(s.Info.Tokens)
+	cloned.Info.Reserves = make([]*big.Int, len(s.Info.Reserves))
+	for i, value := range s.Info.Reserves {
+		cloned.Info.Reserves[i] = new(big.Int).Set(value)
+	}
+	cloned.Extra.Ask.Knots = slices.Clone(s.Extra.Ask.Knots)
+	cloned.Extra.Bid.Knots = slices.Clone(s.Extra.Bid.Knots)
+	return &cloned
+}
+
+func (s *PoolSimulator) limitKey(token string) string {
+	return strings.ToLower(s.StaticExtra.Custodian) + ":" + token
+}
+
+func (s *PoolSimulator) CalculateLimit() map[string]*big.Int {
+	return map[string]*big.Int{s.limitKey(s.Info.Tokens[0]): new(big.Int).Set(s.Info.Reserves[0]), s.limitKey(s.Info.Tokens[1]): new(big.Int).Set(s.Info.Reserves[1])}
+}
+
+func (s *PoolSimulator) GetMetaInfo(_, _ string) any {
+	return PoolMeta{BlockNumber: s.Info.BlockNumber, Entrypoint: s.StaticExtra.Entrypoint, Base: s.Info.Tokens[0], ApprovalAddress: s.StaticExtra.Entrypoint, ValidUntil: s.deadline()}
+}
+
+func (s *PoolSimulator) GetApprovalAddress(_, _ string) string { return s.StaticExtra.Entrypoint }

--- a/pkg/liquidity-source/spire-prop/pool_simulator_test.go
+++ b/pkg/liquidity-source/spire-prop/pool_simulator_test.go
@@ -259,3 +259,17 @@ func TestAdditionalBaseScaleAndSharedQuoteInventory(t *testing.T) {
 	require.Zero(t, other.Extra.FillSeq)
 	require.Equal(t, other.Info.Tokens[0], other.GetMetaInfo("", "").(PoolMeta).Base)
 }
+
+func TestSellCursorOverflowMatchesContractDepthFailure(t *testing.T) {
+	s := flat(t)
+	s.Extra.Bid.Filled.SetUint64(1)
+	max := new(uint256.Int).SetAllOne()
+	_, arithmeticErr := add(&s.Extra.Bid.Filled, max)
+	require.ErrorIs(t, arithmeticErr, ErrOverflow)
+	// The contract uses tryAdd and returns Fail.BeyondDepth on this specific
+	// overflow, causing quote() to return zero and consume() to reject depth.
+	_, err := s.CalcAmountOut(quoteParams(0, max.Dec()))
+	require.ErrorIs(t, err, ErrDepth)
+	require.Equal(t, uint64(1), s.Extra.Bid.Filled.Uint64())
+	require.Zero(t, s.Extra.FillSeq)
+}

--- a/pkg/liquidity-source/spire-prop/pool_simulator_test.go
+++ b/pkg/liquidity-source/spire-prop/pool_simulator_test.go
@@ -1,0 +1,222 @@
+package spireprop
+
+import (
+	"math"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/swaplimit"
+)
+
+const baseToken = "0x4200000000000000000000000000000000000006"
+const quoteToken = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+
+type QuoteCase struct {
+	IndexIn    int
+	AmountIn   string
+	AmountOut  string
+	Executable bool
+}
+type QuoteFixture struct {
+	Pool   entity.Pool
+	Quotes []QuoteCase
+}
+
+func flat(t *testing.T) *PoolSimulator {
+	t.Helper()
+	extra := Extra{Seq: 1, LastUpdateAt: 1000, BlockTimestamp: 1000, ValidUntil: 1008, TTL: 8,
+		Mid: *uint256.NewInt(2_500_000_000), QUnit: *uint256.NewInt(10_000_000_000), CUnit: *uint256.NewInt(1),
+		Ask: Side{DepthBps: 10000, Knots: []Knot{{Q: *uint256.NewInt(1_000_000)}}},
+		Bid: Side{DepthBps: 10000, Knots: []Knot{{Q: *uint256.NewInt(1_000_000)}}}}
+	raw, err := json.Marshal(&extra)
+	require.NoError(t, err)
+	static, err := json.Marshal(StaticExtra{Entrypoint: "0x98c1d9e102eb2806d902b13186bdc7892ac4ffba", CurveBook: "0x604d9b9eb1e1571c78661a6c1088427ec9c8c6e5", Custodian: "0xaac48feb93c5c97e0fb3c7c57e1633922a4acda3"})
+	require.NoError(t, err)
+	s, err := NewPoolSimulator(pool.FactoryParams{EntityPool: entity.Pool{Address: "0x0000000000000000000000000000000000000001", Exchange: DexType, Type: DexType, BlockNumber: 100,
+		Tokens: []*entity.PoolToken{{Address: baseToken}, {Address: quoteToken}}, Reserves: entity.PoolReserves{"100000000000000000000", "1000000000000000"}, Extra: string(raw), StaticExtra: string(static)}})
+	require.NoError(t, err)
+	return s
+}
+
+func quoteParams(side int, amount string) pool.CalcAmountOutParams {
+	value, _ := new(big.Int).SetString(amount, 10)
+	tokens := []string{baseToken, quoteToken}
+	return pool.CalcAmountOutParams{TokenAmountIn: pool.TokenAmount{Token: tokens[side], Amount: value}, TokenOut: tokens[1-side]}
+}
+
+func TestFlatPricesAndDepth(t *testing.T) {
+	s := flat(t)
+	for _, tc := range []struct {
+		side    int
+		in, out string
+	}{{1, "25000000", "10000000000000000"}, {1, "12500000", "5000000000000000"}, {0, "10000000000000000", "25000000"}} {
+		result, err := s.CalcAmountOut(quoteParams(tc.side, tc.in))
+		require.NoError(t, err)
+		require.Equal(t, tc.out, result.TokenAmountOut.Amount.String())
+	}
+	s.Extra.Ask.DepthBps = 5000
+	s.Extra.Bid.DepthBps = 0
+	_, err := s.CalcAmountOut(quoteParams(1, "12500001"))
+	require.ErrorIs(t, err, ErrDepth)
+	_, err = s.CalcAmountOut(quoteParams(0, "1"))
+	require.ErrorIs(t, err, ErrDepth)
+}
+
+func TestSignedSpreadAndCursorConsumption(t *testing.T) {
+	s := flat(t)
+	s.Extra.Ask.SpreadBps = 100
+	s.Extra.Bid.SpreadBps = -100
+	result, err := s.CalcAmountOut(quoteParams(0, "10000000000000000"))
+	require.NoError(t, err)
+	require.Equal(t, "24750000", result.TokenAmountOut.Amount.String())
+	result, err = s.CalcAmountOut(quoteParams(1, "12500000"))
+	require.NoError(t, err)
+	before, err := json.Marshal(s)
+	require.NoError(t, err)
+	again, err := s.CalcAmountOut(quoteParams(1, "12500000"))
+	require.NoError(t, err)
+	require.Equal(t, result, again)
+	after, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	clone := s.CloneState().(*PoolSimulator)
+	// Consumption uses SwapInfo even when the caller's other fields are empty.
+	clone.UpdateBalance(pool.UpdateBalanceParams{SwapInfo: result.SwapInfo})
+	require.Equal(t, uint64(1), clone.Extra.FillSeq)
+	require.Equal(t, uint64(0), s.Extra.FillSeq)
+	require.False(t, clone.Extra.Ask.Filled.IsZero())
+	require.True(t, s.Extra.Ask.Filled.IsZero())
+	clone.UpdateBalance(pool.UpdateBalanceParams{SwapInfo: result.SwapInfo})
+	require.Equal(t, uint64(1), clone.Extra.FillSeq)
+	_, err = clone.CalcAmountOut(quoteParams(1, "25000000"))
+	require.Error(t, err)
+}
+
+func TestDeadlinesAndMalformedState(t *testing.T) {
+	s := flat(t)
+	require.False(t, s.expired(1008))
+	require.True(t, s.expired(1009))
+	s.Extra.TTL = 0
+	require.True(t, s.expired(1009))
+	s.Extra.TTL = 1
+	require.True(t, s.expired(1002))
+	s.Extra.TTL = math.MaxUint64
+	require.False(t, s.expired(1008))
+	require.True(t, s.expired(1009))
+	s.StaleCheck = true
+	_, err := s.CalcAmountOut(quoteParams(1, "1"))
+	require.ErrorIs(t, err, ErrExpired)
+	s.Extra.ValidUntil = uint64(time.Now().Unix() + 5)
+	s.Extra.TTL = 0
+	_, err = s.CalcAmountOut(quoteParams(1, "1"))
+	require.NoError(t, err)
+	s.Extra.Ask.SpreadBps = -10000
+	require.ErrorIs(t, s.validate(), ErrInvalidState)
+	s = flat(t)
+	s.Extra.Ask.Knots = append(s.Extra.Ask.Knots, s.Extra.Ask.Knots[0])
+	require.ErrorIs(t, s.validate(), ErrInvalidState)
+}
+
+func TestInventoryAndFailurePurity(t *testing.T) {
+	s := flat(t)
+	s.Info.Reserves[0] = big.NewInt(1)
+	before, err := json.Marshal(s)
+	require.NoError(t, err)
+	_, err = s.CalcAmountOut(quoteParams(1, "25000000"))
+	require.ErrorIs(t, err, pool.ErrNotEnoughInventory)
+	after, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	s = flat(t)
+	limit := swaplimit.NewInventory(DexType, s.CalculateLimit())
+	params := quoteParams(0, "10000000000000000")
+	params.Limit = limit
+	quote, err := s.CalcAmountOut(params)
+	require.NoError(t, err)
+	old := new(big.Int).Set(limit.GetLimit(s.limitKey(quoteToken)))
+	s.UpdateBalance(pool.UpdateBalanceParams{SwapInfo: quote.SwapInfo, SwapLimit: limit})
+	require.Equal(t, new(big.Int).Sub(old, big.NewInt(25000000)), limit.GetLimit(s.limitKey(quoteToken)))
+	params = quoteParams(1, "25000000")
+	params.Limit = swaplimit.NewInventory(DexType, map[string]*big.Int{})
+	_, err = s.CalcAmountOut(params)
+	require.ErrorIs(t, err, pool.ErrNotEnoughInventory)
+}
+
+func TestWidePartialProductAndCheckedOverflow(t *testing.T) {
+	s := flat(t)
+	s.Extra.QUnit = *uint256.MustFromDecimal("1000000000000000000000000000000000")
+	s.Extra.Ask.Knots[0].Q = *uint256.NewInt((1 << 48) - 1)
+	s.Info.Reserves[0] = uint256.MustFromDecimal("1000000000000000000000000000000000000000000000000000000000000").ToBig()
+	result, err := s.CalcAmountOut(quoteParams(1, "1000000000000000000000000000000"))
+	require.NoError(t, err)
+	require.Equal(t, "400000000000000000000000000000000000000", result.TokenAmountOut.Amount.String())
+	max := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)).String()
+	_, err = s.CalcAmountOut(quoteParams(0, max))
+	require.Error(t, err)
+	s.Extra.CUnit = *uint256.MustFromDecimal(max)
+	s.Extra.Ask.Knots[0].Extra.SetUint64(2)
+	require.ErrorIs(t, s.validate(), ErrOverflow)
+}
+
+func TestPinnedDeploymentFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/base-snapshot.json")
+	require.NoError(t, err)
+	var f QuoteFixture
+	require.NoError(t, json.Unmarshal(raw, &f))
+	s, err := NewPoolSimulator(pool.FactoryParams{EntityPool: f.Pool})
+	require.NoError(t, err)
+	for _, tc := range f.Quotes {
+		result, err := s.CalcAmountOut(quoteParams(tc.IndexIn, tc.AmountIn))
+		if !tc.Executable {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		require.Equal(t, tc.AmountOut, result.TokenAmountOut.Amount.String())
+	}
+	meta := s.GetMetaInfo(baseToken, quoteToken).(PoolMeta)
+	require.Equal(t, f.Pool.BlockNumber, meta.BlockNumber)
+	require.Equal(t, s.StaticExtra.Entrypoint, s.GetApprovalAddress(baseToken, quoteToken))
+}
+
+// Integer-sized segments make each rounding decision independently checkable.
+func TestMultiKnotRoundingAndConsumedOrigin(t *testing.T) {
+	s := flat(t)
+	s.Extra.QUnit.SetUint64(1)
+	s.Extra.CUnit.SetUint64(1)
+	s.Extra.Mid.SetUint64(1_000_000_000_000_000_000)
+	knots := []Knot{{Q: *uint256.NewInt(3), Extra: *uint256.NewInt(1)}, {Q: *uint256.NewInt(10), Extra: *uint256.NewInt(5)}}
+	s.Extra.Ask.Knots = knots
+	s.Extra.Bid.Knots = knots
+	for _, tc := range []struct {
+		side    int
+		in, out string
+	}{{1, "4", "3"}, {1, "15", "10"}, {0, "3", "2"}, {0, "4", "2"}, {0, "10", "5"}} {
+		result, err := s.CalcAmountOut(quoteParams(tc.side, tc.in))
+		require.NoError(t, err)
+		require.Equal(t, tc.out, result.TokenAmountOut.Amount.String())
+	}
+	// One quote unit left after the first knot cannot buy an atomic base unit.
+	_, tinyErr := s.CalcAmountOut(quoteParams(1, "5"))
+	require.ErrorIs(t, tinyErr, ErrDepth)
+	s.Extra.Bid.Filled.SetUint64(3)
+	_, err := s.CalcAmountOut(quoteParams(0, "2"))
+	require.ErrorIs(t, err, ErrDepth)
+	// extra(5)=1+ceil(4*2/7)=3; extra(3)=1, so two units have no net output.
+	// Use a three-unit sale: extra(6)=3, mid=3, net=1.
+	result, err := s.CalcAmountOut(quoteParams(0, "3"))
+	require.NoError(t, err)
+	require.Equal(t, "1", result.TokenAmountOut.Amount.String())
+	s.Extra.Ask.Filled.SetUint64(3)
+	result, err = s.CalcAmountOut(quoteParams(1, "5"))
+	require.NoError(t, err)
+	require.Equal(t, "3", result.TokenAmountOut.Amount.String())
+}

--- a/pkg/liquidity-source/spire-prop/pool_simulator_test.go
+++ b/pkg/liquidity-source/spire-prop/pool_simulator_test.go
@@ -220,3 +220,42 @@ func TestMultiKnotRoundingAndConsumedOrigin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "3", result.TokenAmountOut.Amount.String())
 }
+
+func TestAdditionalBaseScaleAndSharedQuoteInventory(t *testing.T) {
+	weth := flat(t)
+	other := flat(t)
+	other.Info.Tokens[0] = "0x0000000000000000000000000000000000000002"
+	// An eight-decimal base at the same 2,500 quote-token price. qUnit and
+	// midpoint come from the contract, so no WETH/18-decimal assumption applies.
+	other.Extra.QUnit.SetUint64(1)
+	other.Extra.Mid = *uint256.MustFromDecimal("25000000000000000000")
+	other.Info.Reserves[0] = big.NewInt(100_000_000)
+	weth.Info.Reserves[1] = big.NewInt(25_000_000)
+	other.Info.Reserves[1] = big.NewInt(25_000_000)
+	params := pool.CalcAmountOutParams{TokenAmountIn: pool.TokenAmount{Token: quoteToken, Amount: big.NewInt(25_000_000)}, TokenOut: other.Info.Tokens[0]}
+	buy, err := other.CalcAmountOut(params)
+	require.NoError(t, err)
+	require.Equal(t, "1000000", buy.TokenAmountOut.Amount.String())
+	params = pool.CalcAmountOutParams{TokenAmountIn: pool.TokenAmount{Token: other.Info.Tokens[0], Amount: big.NewInt(1_000_000)}, TokenOut: quoteToken}
+	sell, err := other.CalcAmountOut(params)
+	require.NoError(t, err)
+	require.Equal(t, "25000000", sell.TokenAmountOut.Amount.String())
+
+	inventory := weth.CalculateLimit()
+	for key, value := range other.CalculateLimit() {
+		inventory[key] = value
+	}
+	limit := swaplimit.NewInventory(DexType, inventory)
+	firstParams := quoteParams(0, "10000000000000000")
+	firstParams.Limit = limit
+	first, err := weth.CalcAmountOut(firstParams)
+	require.NoError(t, err)
+	weth.UpdateBalance(pool.UpdateBalanceParams{SwapInfo: first.SwapInfo, SwapLimit: limit})
+	require.Zero(t, limit.GetLimit(other.limitKey(quoteToken)).Sign())
+	// The second base has its own cursor but must not spend the same USDC twice.
+	params.Limit = limit
+	_, err = other.CalcAmountOut(params)
+	require.ErrorIs(t, err, pool.ErrNotEnoughInventory)
+	require.Zero(t, other.Extra.FillSeq)
+	require.Equal(t, other.Info.Tokens[0], other.GetMetaInfo("", "").(PoolMeta).Base)
+}

--- a/pkg/liquidity-source/spire-prop/pool_tracker.go
+++ b/pkg/liquidity-source/spire-prop/pool_tracker.go
@@ -1,0 +1,150 @@
+package spireprop
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+	pooltrack "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/tracker"
+)
+
+type rawSide struct {
+	SpreadBps int16
+	DepthBps  uint16
+	Filled    *big.Int
+	KnotCount uint8
+}
+type rawPair struct {
+	Seq          uint64
+	FillSeq      uint64
+	LastUpdateAt uint64
+	Mid          *big.Int
+	QUnit        *big.Int
+	Ask          rawSide
+	Bid          rawSide
+}
+type rawKnot struct {
+	Q     *big.Int
+	Extra *big.Int
+}
+type PoolTracker struct{ client *ethrpc.Client }
+
+var _ = pooltrack.RegisterFactoryE0(DexType, NewPoolTracker)
+
+func NewPoolTracker(client *ethrpc.Client) *PoolTracker { return &PoolTracker{client} }
+
+func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, _ pool.GetNewPoolStateParams) (entity.Pool, error) {
+	if len(p.Tokens) != 2 || p.Tokens[0] == nil || p.Tokens[1] == nil {
+		return p, ErrInvalidState
+	}
+	var static StaticExtra
+	if err := json.Unmarshal([]byte(p.StaticExtra), &static); err != nil {
+		return p, err
+	}
+	for _, addr := range []string{static.Entrypoint, static.CurveBook, static.Custodian, p.Tokens[0].Address, p.Tokens[1].Address} {
+		if !validAddress(addr) {
+			return p, ErrInvalidState
+		}
+	}
+	header, err := t.client.GetETHClient().HeaderByNumber(ctx, nil)
+	if err != nil {
+		return p, err
+	}
+	base, quote := common.HexToAddress(p.Tokens[0].Address), common.HexToAddress(p.Tokens[1].Address)
+	var wrapped struct{ V rawPair }
+	var extra Extra
+	var cUnit *big.Int
+	var reserves [2]*big.Int
+	var curveEntry, curveQuote, entryCurve, entryCustody, entryQuote, custEntry, custCurve common.Address
+	req := t.client.NewRequest().SetContext(ctx).SetBlockHash(header.Hash())
+	req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "pair", Params: []any{base}}, []any{&wrapped})
+	req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "validUntil", Params: []any{base}}, []any{&extra.ValidUntil})
+	req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "ttl"}, []any{&extra.TTL})
+	req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "cUnit"}, []any{&cUnit})
+	for i, token := range []common.Address{base, quote} {
+		req.AddCall(&ethrpc.Call{ABI: custodianABI, Target: static.Custodian, Method: "availableLiquidity", Params: []any{token}}, []any{&reserves[i]})
+	}
+	req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "entrypoint"}, []any{&curveEntry})
+	req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "quoteToken"}, []any{&curveQuote})
+	req.AddCall(&ethrpc.Call{ABI: entrypointABI, Target: static.Entrypoint, Method: "curveBook"}, []any{&entryCurve})
+	req.AddCall(&ethrpc.Call{ABI: entrypointABI, Target: static.Entrypoint, Method: "custodian"}, []any{&entryCustody})
+	req.AddCall(&ethrpc.Call{ABI: entrypointABI, Target: static.Entrypoint, Method: "quoteToken"}, []any{&entryQuote})
+	req.AddCall(&ethrpc.Call{ABI: custodianABI, Target: static.Custodian, Method: "entrypoint"}, []any{&custEntry})
+	req.AddCall(&ethrpc.Call{ABI: custodianABI, Target: static.Custodian, Method: "curveBook"}, []any{&custCurve})
+	result, err := req.Aggregate()
+	if err != nil {
+		return p, err
+	}
+	if result.BlockNumber == nil || result.BlockNumber.Cmp(header.Number) != 0 {
+		return p, ErrInvalidState
+	}
+	if curveEntry != common.HexToAddress(static.Entrypoint) || curveQuote != quote || entryCurve != common.HexToAddress(static.CurveBook) || entryCustody != common.HexToAddress(static.Custodian) || entryQuote != quote || custEntry != curveEntry || custCurve != entryCurve {
+		return p, ErrInvalidState
+	}
+	raw := wrapped.V
+	extra.Seq, extra.FillSeq, extra.LastUpdateAt, extra.BlockTimestamp = raw.Seq, raw.FillSeq, raw.LastUpdateAt, header.Time
+	inputs := []*big.Int{raw.Mid, raw.QUnit, cUnit, raw.Ask.Filled, raw.Bid.Filled}
+	outputs := []*uint256.Int{&extra.Mid, &extra.QUnit, &extra.CUnit, &extra.Ask.Filled, &extra.Bid.Filled}
+	for i, value := range inputs {
+		if value == nil || value.Sign() < 0 || outputs[i].SetFromBig(value) {
+			return p, ErrInvalidState
+		}
+	}
+	for _, reserve := range reserves {
+		if reserve == nil || reserve.Sign() < 0 || reserve.BitLen() > 256 {
+			return p, ErrInvalidState
+		}
+	}
+	extra.Ask.SpreadBps, extra.Ask.DepthBps = raw.Ask.SpreadBps, raw.Ask.DepthBps
+	extra.Bid.SpreadBps, extra.Bid.DepthBps = raw.Bid.SpreadBps, raw.Bid.DepthBps
+	if raw.Ask.KnotCount > 36 || raw.Bid.KnotCount > 36 {
+		return p, ErrInvalidState
+	}
+	knots := [2][]rawKnot{make([]rawKnot, raw.Ask.KnotCount), make([]rawKnot, raw.Bid.KnotCount)}
+	req = t.client.NewRequest().SetContext(ctx).SetBlockHash(header.Hash())
+	for side := range knots {
+		for i := range knots[side] {
+			k := &knots[side][i]
+			req.AddCall(&ethrpc.Call{ABI: curveBookABI, Target: static.CurveBook, Method: "knot", Params: []any{base, uint8(side), big.NewInt(int64(i))}}, []any{k})
+		}
+	}
+	if len(req.Calls) > 0 {
+		if _, err := req.Aggregate(); err != nil {
+			return p, err
+		}
+	}
+	for i, side := range []*Side{&extra.Ask, &extra.Bid} {
+		side.Knots = make([]Knot, len(knots[i]))
+		for j, k := range knots[i] {
+			if k.Q == nil || k.Extra == nil || k.Q.Sign() < 0 || k.Extra.Sign() < 0 || side.Knots[j].Q.SetFromBig(k.Q) || side.Knots[j].Extra.SetFromBig(k.Extra) {
+				return p, ErrInvalidState
+			}
+		}
+	}
+	// Hash-pinned calls remain internally coherent through a reorg; reject an
+	// orphaned snapshot before exposing it to routing.
+	canonical, err := t.client.GetETHClient().HeaderByNumber(ctx, header.Number)
+	if err != nil {
+		return p, err
+	}
+	if canonical.Hash() != header.Hash() {
+		return p, ErrInvalidState
+	}
+	if err := (&PoolSimulator{Extra: extra}).validate(); err != nil {
+		return p, err
+	}
+	encoded, err := json.Marshal(&extra)
+	if err != nil {
+		return p, err
+	}
+	p.Extra, p.BlockNumber, p.Timestamp = string(encoded), header.Number.Uint64(), time.Now().Unix()
+	p.Reserves = entity.PoolReserves{reserves[0].String(), reserves[1].String()}
+	return p, nil
+}

--- a/pkg/liquidity-source/spire-prop/pool_tracker.go
+++ b/pkg/liquidity-source/spire-prop/pool_tracker.go
@@ -107,7 +107,7 @@ func (t *PoolTracker) GetNewPoolState(ctx context.Context, p entity.Pool, _ pool
 	if raw.Ask.KnotCount > 36 || raw.Bid.KnotCount > 36 {
 		return p, ErrInvalidState
 	}
-	knots := [2][]rawKnot{make([]rawKnot, raw.Ask.KnotCount), make([]rawKnot, raw.Bid.KnotCount)}
+	knots := [2][]rawKnot{make([]rawKnot, int(raw.Ask.KnotCount)), make([]rawKnot, int(raw.Bid.KnotCount))}
 	req = t.client.NewRequest().SetContext(ctx).SetBlockHash(header.Hash())
 	for side := range knots {
 		for i := range knots[side] {

--- a/pkg/liquidity-source/spire-prop/pools_list_updater.go
+++ b/pkg/liquidity-source/spire-prop/pools_list_updater.go
@@ -1,0 +1,70 @@
+package spireprop
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/goccy/go-json"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	poollist "github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool/list"
+)
+
+type PoolsListUpdater struct {
+	cfg    *Config
+	client *ethrpc.Client
+}
+
+var _ = poollist.RegisterFactoryCE(DexType, NewPoolsListUpdater)
+
+func NewPoolsListUpdater(cfg *Config, client *ethrpc.Client) *PoolsListUpdater {
+	return &PoolsListUpdater{cfg, client}
+}
+
+func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadata []byte) ([]entity.Pool, []byte, error) {
+	if !validAddress(u.cfg.Entrypoint) {
+		return nil, metadata, ErrInvalidState
+	}
+	known := map[string]bool{}
+	if len(metadata) != 0 {
+		if err := json.Unmarshal(metadata, &known); err != nil {
+			return nil, metadata, err
+		}
+	}
+	var curve, custody, quote common.Address
+	req := u.client.NewRequest().SetContext(ctx)
+	for i, method := range []string{"curveBook", "custodian", "quoteToken"} {
+		req.AddCall(&ethrpc.Call{ABI: entrypointABI, Target: u.cfg.Entrypoint, Method: method}, []any{[]*common.Address{&curve, &custody, &quote}[i]})
+	}
+	if _, err := req.Aggregate(); err != nil {
+		return nil, metadata, err
+	}
+	if curve == (common.Address{}) || custody == (common.Address{}) || quote == (common.Address{}) {
+		return nil, metadata, ErrInvalidState
+	}
+	extra, _ := json.Marshal(StaticExtra{Entrypoint: strings.ToLower(u.cfg.Entrypoint), CurveBook: hexutil.Encode(curve[:]), Custodian: hexutil.Encode(custody[:])})
+	pools := make([]entity.Pool, 0, len(u.cfg.Bases))
+	for _, token := range u.cfg.Bases {
+		if !validAddress(token) || common.HexToAddress(token) == quote {
+			return nil, metadata, ErrInvalidToken
+		}
+		base := common.HexToAddress(token)
+		// Unique per entrypoint/base while every pair can share custodian limits.
+		hash := crypto.Keccak256(common.HexToAddress(u.cfg.Entrypoint).Bytes(), base.Bytes())
+		address := hexutil.Encode(hash[12:])
+		if known[address] {
+			continue
+		}
+		pools = append(pools, entity.Pool{Address: address, Exchange: u.cfg.DexID, Type: DexType, Timestamp: time.Now().Unix(),
+			Tokens:   []*entity.PoolToken{{Address: hexutil.Encode(base[:]), Swappable: true}, {Address: hexutil.Encode(quote[:]), Swappable: true}},
+			Reserves: entity.PoolReserves{"0", "0"}, Extra: "{}", StaticExtra: string(extra)})
+		known[address] = true
+	}
+	next, err := json.Marshal(known)
+	return pools, next, err
+}

--- a/pkg/liquidity-source/spire-prop/pools_list_updater.go
+++ b/pkg/liquidity-source/spire-prop/pools_list_updater.go
@@ -47,7 +47,10 @@ func (u *PoolsListUpdater) GetNewPools(ctx context.Context, metadata []byte) ([]
 	if curve == (common.Address{}) || custody == (common.Address{}) || quote == (common.Address{}) {
 		return nil, metadata, ErrInvalidState
 	}
-	extra, _ := json.Marshal(StaticExtra{Entrypoint: strings.ToLower(u.cfg.Entrypoint), CurveBook: hexutil.Encode(curve[:]), Custodian: hexutil.Encode(custody[:])})
+	extra, err := json.Marshal(StaticExtra{Entrypoint: strings.ToLower(u.cfg.Entrypoint), CurveBook: hexutil.Encode(curve[:]), Custodian: hexutil.Encode(custody[:])})
+	if err != nil {
+		return nil, metadata, err
+	}
 	pools := make([]entity.Pool, 0, len(u.cfg.Bases))
 	for _, token := range u.cfg.Bases {
 		if !validAddress(token) || common.HexToAddress(token) == quote {

--- a/pkg/liquidity-source/spire-prop/testdata/base-snapshot.json
+++ b/pkg/liquidity-source/spire-prop/testdata/base-snapshot.json
@@ -1,0 +1,231 @@
+{
+  "Pool": {
+    "address": "0xe37072bbde68f74333c8b99c572dc5f9b66927cf",
+    "exchange": "spire-prop",
+    "type": "spire-prop",
+    "timestamp": 1788748935,
+    "reserves": [
+      "2462934124905832810",
+      "19635842347"
+    ],
+    "tokens": [
+      {
+        "address": "0x4200000000000000000000000000000000000006",
+        "swappable": true
+      },
+      {
+        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "swappable": true
+      }
+    ],
+    "extra": "{\"seq\":57559,\"fillSeq\":18,\"lastUpdateAt\":1788748933,\"validUntil\":1788748939,\"ttl\":8,\"blockTimestamp\":1788748933,\"mid\":\"2529275000\",\"qUnit\":\"10000000000\",\"cUnit\":\"1\",\"ask\":{\"spreadBps\":0,\"depthBps\":10000,\"filled\":\"0\",\"knots\":[{\"q\":\"12220000\",\"extra\":\"611\"},{\"q\":\"207320000\",\"extra\":\"12535786\"},{\"q\":\"231620000\",\"extra\":\"16247611\"},{\"q\":\"243690000\",\"extra\":\"19923530\"}]},\"bid\":{\"spreadBps\":0,\"depthBps\":10000,\"filled\":\"0\",\"knots\":[{\"q\":\"38530000\",\"extra\":\"1927\"},{\"q\":\"656650000\",\"extra\":\"39654325\"},{\"q\":\"734180000\",\"extra\":\"51489279\"},{\"q\":\"773180000\",\"extra\":\"63362829\"}]}}",
+    "staticExtra": "{\"entrypoint\":\"0x98c1d9e102eb2806d902b13186bdc7892ac4ffba\",\"curveBook\":\"0x604d9b9eb1e1571c78661a6c1088427ec9c8c6e5\",\"custodian\":\"0xaac48feb93c5c97e0fb3c7c57e1633922a4acda3\"}",
+    "blockNumber": 50979793
+  },
+  "Quotes": [
+    {
+      "IndexIn": 0,
+      "AmountIn": "1",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "2",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "100",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "10000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "1000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "25000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "100000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "500000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "1000000000",
+      "AmountOut": "1",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "10000000000",
+      "AmountOut": "24",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "1000000000000",
+      "AmountOut": "2528",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "100000000000000",
+      "AmountOut": "252926",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "1000000000000000",
+      "AmountOut": "2529269",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "10000000000000000",
+      "AmountOut": "25292699",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "100000000000000000",
+      "AmountOut": "252926999",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "1000000000000000000",
+      "AmountOut": "2525329772",
+      "Executable": true
+    },
+    {
+      "IndexIn": 0,
+      "AmountIn": "1000000000000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1",
+      "AmountOut": "395369433",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "2",
+      "AmountOut": "790738866",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "100",
+      "AmountOut": "39536943319",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "10000",
+      "AmountOut": "3953694331983",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1000000",
+      "AmountOut": "395369433198380",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "25000000",
+      "AmountOut": "9884235829959514",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "100000000",
+      "AmountOut": "39536943319838056",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "500000000",
+      "AmountOut": "197493600978033679",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1000000000",
+      "AmountOut": "394677810466537839",
+      "Executable": true
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "10000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "100000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1000000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "10000000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "100000000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1000000000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    },
+    {
+      "IndexIn": 1,
+      "AmountIn": "1000000000000000000000",
+      "AmountOut": "0",
+      "Executable": false
+    }
+  ]
+}

--- a/pkg/liquidity-source/spire-prop/type.go
+++ b/pkg/liquidity-source/spire-prop/type.go
@@ -1,0 +1,75 @@
+package spireprop
+
+import (
+	"errors"
+
+	"github.com/holiman/uint256"
+)
+
+const DexType = "spire-prop"
+const defaultGas int64 = 200000
+
+var (
+	ErrInvalidState = errors.New("spire-prop: invalid state")
+	ErrInvalidToken = errors.New("spire-prop: invalid token")
+	ErrAmount       = errors.New("spire-prop: invalid amount")
+	ErrExpired      = errors.New("spire-prop: curve expired")
+	ErrDepth        = errors.New("spire-prop: beyond depth")
+	ErrOverflow     = errors.New("spire-prop: arithmetic overflow")
+)
+
+type Config struct {
+	DexID      string `json:"dexID"`
+	Entrypoint string `json:"entrypoint"`
+	// The protocol has no enumerable factory. List configured bases; verify the
+	// immutable quote/curve/custodian on chain before emitting each pair.
+	Bases []string `json:"bases"`
+}
+
+type StaticExtra struct {
+	Entrypoint string `json:"entrypoint"`
+	CurveBook  string `json:"curveBook"`
+	Custodian  string `json:"custodian"`
+}
+
+type Knot struct {
+	Q     uint256.Int `json:"q"`
+	Extra uint256.Int `json:"extra"`
+}
+
+type Side struct {
+	SpreadBps int16       `json:"spreadBps"`
+	DepthBps  uint16      `json:"depthBps"`
+	Filled    uint256.Int `json:"filled"`
+	Knots     []Knot      `json:"knots"`
+}
+
+type Extra struct {
+	Seq            uint64      `json:"seq"`
+	FillSeq        uint64      `json:"fillSeq"`
+	LastUpdateAt   uint64      `json:"lastUpdateAt"`
+	ValidUntil     uint64      `json:"validUntil"`
+	TTL            uint64      `json:"ttl"`
+	BlockTimestamp uint64      `json:"blockTimestamp"`
+	Mid            uint256.Int `json:"mid"`
+	QUnit          uint256.Int `json:"qUnit"`
+	CUnit          uint256.Int `json:"cUnit"`
+	Ask            Side        `json:"ask"`
+	Bid            Side        `json:"bid"`
+}
+
+type PoolMeta struct {
+	BlockNumber     uint64 `json:"blockNumber"`
+	Entrypoint      string `json:"entrypoint"`
+	Base            string `json:"base"`
+	ApprovalAddress string `json:"approvalAddress"`
+	ValidUntil      uint64 `json:"validUntil"`
+}
+
+type SwapInfo struct {
+	IndexIn   int
+	FillSeq   uint64
+	Cursor    uint256.Int
+	AmountIn  uint256.Int
+	AmountOut uint256.Int
+}

--- a/pkg/msgpack/generate/generate_register_pool_types.go
+++ b/pkg/msgpack/generate/generate_register_pool_types.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+
+	"golang.org/x/mod/modfile"
 )
 
 var (
@@ -32,7 +34,14 @@ func main() {
 		return
 	}
 
-	moduleName := "github.com/KyberNetwork/" + filepath.Base(dir)
+	modBytes, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	moduleName := modfile.ModulePath(modBytes)
+	if moduleName == "" {
+		log.Fatal("go.mod has no module path")
+	}
 	nameByFile, fileByPath := getPackageNamesAndImportPaths(structByFile, dir, moduleName)
 	paths := slices.Sorted(maps.Keys(fileByPath))
 

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -158,6 +158,7 @@ import (
 	pkg_liquiditysource_solidlyv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/solidly-v2"
 	pkg_liquiditysource_someswap_v1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v1"
 	pkg_liquiditysource_someswap_v2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v2"
+	pkg_liquiditysource_spireprop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/spire-prop"
 	pkg_liquiditysource_stabull "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/stabull"
 	pkg_liquiditysource_staderethx "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/staderethx"
 	pkg_liquiditysource_stonkbrokersfun_v2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/stonkbrokers-fun/v2"
@@ -415,6 +416,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_solidlyv2.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_someswap_v1.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_someswap_v2.PoolSimulator{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_spireprop.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_stabull.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_staderethx.PoolSimulator{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_stonkbrokersfun_v2.PoolSimulator{})

--- a/pkg/pooltypes/pooltypes.go
+++ b/pkg/pooltypes/pooltypes.go
@@ -156,6 +156,7 @@ import (
 	solidlyv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/solidly-v2"
 	someswapv1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v1"
 	someswapv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/someswap/v2"
+	spireprop "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/spire-prop"
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/staderethx"
 	stonkbrokersfunv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/stonkbrokers-fun/v2"
 	swapxv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/swap-x-v2"
@@ -459,6 +460,7 @@ type Types struct {
 	KipseliPamm                string
 	SomeswapV1                 string
 	SomeswapV2                 string
+	SpireProp                  string
 	WasabiProp                 string
 	Whlp                       string
 	Obric                      string
@@ -705,6 +707,7 @@ var (
 		KipseliPamm:                kipselipamm.DexType,
 		SomeswapV1:                 someswapv1.DexType,
 		SomeswapV2:                 someswapv2.DexType,
+		SpireProp:                  spireprop.DexType,
 		WasabiProp:                 wasabiprop.DexType,
 		Whlp:                       whlp.DexType,
 		Obric:                      obric.DexType,

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -330,6 +330,7 @@ const (
 	ExchangeVirtualFunV2                = "virtual-fun-v2"
 	ExchangeVooi                        = "vooi"
 	ExchangeWagyuSwap                   = "wagyuswap"
+	ExchangeSpireProp                   = "spire-prop"
 	ExchangeWasabiProp                  = "wasabi-prop"
 	ExchangeWault                       = "wault"
 	ExchangeWBETH                       = "wbeth"
@@ -417,6 +418,7 @@ var PropAMMSourceSet = map[Exchange]struct{}{
 	ExchangeWildcard:           {},
 	ExchangeKipseliProp:        {},
 	ExchangeWasabiProp:         {},
+	ExchangeSpireProp:          {},
 	ExchangeAximaV2:            {},
 	ExchangeObric:              {},
 	ExchangePoe:                {},


### PR DESCRIPTION
Add `spire-prop` discovery, tracking and exact-input simulation for Spire's Base WETH–USDC deployment. Spire compresses maker books into an on-chain curve and pays output from a shared custodian.

The simulator ports checked uint256 midpoint/spread, cumulative-impact interpolation, ask segment walking, consumed bid/ask cursors and Solidity rounding. It rejects expired or exhausted curves and output exceeding available custody. `UpdateBalance` consumes swap information, clones own mutable state, and route inventory limits are shared by custodian/token. Routing should enable `FactoryOpts.StaleCheck` so wall-clock expiry is rechecked on every quote.

There is no enumerable factory: configured base tokens are paired with the entrypoint's on-chain quote token. Discovery emits zero reserve placeholders. Tracking pins two multicalls to one block hash, verifies contract wiring and the canonical hash, and propagates the actual snapshot block into metadata. Execution metadata contains the entrypoint/base pair for the companion adapter.

Public references: [overview](https://docs.baibai.cx/takers/overview), [quoting and swapping](https://docs.baibai.cx/takers/quoting-and-swapping), [deployments](https://docs.baibai.cx/takers/deployments). The package README describes configuration, synthetic pool identity, pricing, expiry, shared liquidity and execution encoding.

- Entrypoint / approval target: [0x98c1D9E102Eb2806D902b13186BDc7892aC4fFBa](https://basescan.org/address/0x98c1D9E102Eb2806D902b13186BDc7892aC4fFBa#code)
- Curve book: [0x604d9b9eB1e1571C78661a6C1088427EC9c8c6E5](https://basescan.org/address/0x604d9b9eB1e1571C78661a6C1088427EC9c8c6E5#code)
- Custodian: [0xAaC48FEB93c5C97E0fb3c7C57E1633922A4ACDa3](https://basescan.org/address/0xAaC48FEB93c5C97E0fb3c7C57E1633922A4ACDa3#code)

Validation: package tests, pool type/serialization compilation, race checking and vet passed. A committed fixture compares 34 inputs at Base block 50979793: 17 executable outputs match the deployed curve exactly; 17 are rejected for zero output or insufficient custody. The live integration test repeated discovery, metadata replay, tracking and 34 same-block comparisons successfully at block 50980372. Other cases cover multi-knot rounding, signed spread, consumed origin, expiry, overflow, shared inventory and state purity.

Additional pair coverage verifies eight-decimal base scaling and prevents two bases from double-spending shared quote inventory. The source takes a configurable list of bases; the quote token is read from the entrypoint.

Also fix the serialization generator to read its module path from `go.mod`; deriving it from the checkout directory produced invalid imports in renamed checkouts. Regenerated bindings include the new simulator.

Companion execution adapter: https://github.com/KyberNetwork/ks-dex-adapter-lib/pull/11
