### PR TITLE
fix(lo1inch): always parse MakerTraits and implement CloneState

### DIFF
--- a/pkg/liquidity-source/lo1inch/pool_simulator.go
+++ b/pkg/liquidity-source/lo1inch/pool_simulator.go
@@ -68,52 +68,12 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 		return nil, err
 	}
 
-	for _, order := range extra.TakeToken0Orders {
-		if order.Extension == "" || order.Extension == helper1inch.ZX {
-			continue
-		}
-
-		order.MakerTraitsInstance = helper1inch.NewMakerTraits(order.MakerTraits)
-
-		extensionInstance, err := helper1inch.DecodeExtension(order.Extension)
-		if err != nil {
-			return nil, fmt.Errorf("decode extension: %w", err)
-		}
-		order.ExtensionInstance = &extensionInstance
-
-		feeTakerExtension, err := helper1inch.NewFeeTakerFromExtension(extensionInstance)
-		if err != nil {
-			// logger.Errorf("failed to decode fee taker extension: %v", err)
-			// not always that extension data can be used to create new fee taker extension
-			// so we need to continue
-			continue
-		}
-
-		order.FeeTakerExtension = &feeTakerExtension
+	if err := decodeOrders(extra.TakeToken0Orders); err != nil {
+		return nil, err
 	}
 
-	for _, order := range extra.TakeToken1Orders {
-		if order.Extension == "" || order.Extension == helper1inch.ZX {
-			continue
-		}
-
-		order.MakerTraitsInstance = helper1inch.NewMakerTraits(order.MakerTraits)
-
-		extensionInstance, err := helper1inch.DecodeExtension(order.Extension)
-		if err != nil {
-			return nil, fmt.Errorf("decode extension: %w", err)
-		}
-		order.ExtensionInstance = &extensionInstance
-
-		feeTakerExtension, err := helper1inch.NewFeeTakerFromExtension(extensionInstance)
-		if err != nil {
-			logger.Debugf("failed to decode fee taker extension: %v", err)
-			// not always that extension data can be used to create new fee taker extension
-			// so we need to continue
-			continue
-		}
-
-		order.FeeTakerExtension = &feeTakerExtension
+	if err := decodeOrders(extra.TakeToken1Orders); err != nil {
+		return nil, err
 	}
 
 	takeToken0OrdersMapping := make(map[string]int, len(extra.TakeToken0Orders))
@@ -159,6 +119,33 @@ func NewPoolSimulator(entityPool entity.Pool) (*PoolSimulator, error) {
 		takerAddress:                       common.HexToAddress(staticExtra.TakerAddress),
 		takerTargetInteraction:             staticExtra.TakerTargetInteraction,
 	}, nil
+}
+
+func decodeOrders(orders []*Order) error {
+	for _, order := range orders {
+		order.MakerTraitsInstance = helper1inch.NewMakerTraits(order.MakerTraits)
+
+		if order.Extension == "" || order.Extension == helper1inch.ZX {
+			continue
+		}
+
+		extensionInstance, err := helper1inch.DecodeExtension(order.Extension)
+		if err != nil {
+			return fmt.Errorf("decode extension: %w", err)
+		}
+		order.ExtensionInstance = &extensionInstance
+
+		feeTakerExtension, err := helper1inch.NewFeeTakerFromExtension(extensionInstance)
+		if err != nil {
+			// an extension does not necessarily carry fee taker data
+			logger.Debugf("failed to decode fee taker extension: %v", err)
+			continue
+		}
+
+		order.FeeTakerExtension = &feeTakerExtension
+	}
+
+	return nil
 }
 
 func (p *PoolSimulator) CalcAmountOut(param pool.CalcAmountOutParams) (*pool.CalcAmountOutResult, error) {
@@ -423,6 +410,26 @@ func getMakerRemainingBalance(
 	} else {
 		return makerBalanceAllowanceUint256
 	}
+}
+
+// CloneState deep-copies what UpdateBalance writes: the order slices and the Order values behind them, which
+// are shared with the order hash indexes. Everything else is immutable after construction and stays shared.
+func (p *PoolSimulator) CloneState() pool.IPoolSimulator {
+	cloned := *p
+	cloned.takeToken0Orders = cloneOrders(p.takeToken0Orders)
+	cloned.takeToken1Orders = cloneOrders(p.takeToken1Orders)
+
+	return &cloned
+}
+
+func cloneOrders(orders []*Order) []*Order {
+	cloned := make([]*Order, len(orders))
+	for i, order := range orders {
+		clonedOrder := *order
+		cloned[i] = &clonedOrder
+	}
+
+	return cloned
 }
 
 func (p *PoolSimulator) UpdateBalance(params pool.UpdateBalanceParams) {

--- a/pkg/liquidity-source/lo1inch/pool_simulator_msgpack_test.go
+++ b/pkg/liquidity-source/lo1inch/pool_simulator_msgpack_test.go
@@ -1,0 +1,62 @@
+package lo1inch_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/lo1inch"
+	helper1inch "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/lo1inch/helper"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/msgpack"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
+)
+
+// Router-service ships pool simulators over msgpack, so the full-fill-only rule has to survive the round-trip.
+func TestPoolSimulator_NoPartialFillsSurvivesMsgpack(t *testing.T) {
+	t.Parallel()
+
+	const (
+		takerAsset = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+		makerAsset = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+	)
+
+	makerTraits := "0x" + helper1inch.DefaultMakerTraits().DisablePartialFills().Build().Text(16)
+
+	extra, err := json.Marshal(lo1inch.Extra{TakeToken0Orders: []*lo1inch.Order{{
+		OrderHash:            "0x177af74e4d3880743ac6603323a9a50f6999968e499f44966dd00d642e933285",
+		Maker:                "0xdf4039a454d58868dfd43f076ee46c92a35fdfd9",
+		MakerAsset:           makerAsset,
+		TakerAsset:           takerAsset,
+		MakingAmount:         uint256.NewInt(10000),
+		TakingAmount:         uint256.NewInt(101),
+		RemainingMakerAmount: uint256.NewInt(10000),
+		MakerBalance:         uint256.NewInt(10000),
+		MakerAllowance:       uint256.NewInt(10000),
+		MakerTraits:          makerTraits,
+	}}})
+	require.NoError(t, err)
+
+	sim, err := lo1inch.NewPoolSimulator(entity.Pool{
+		Address:     "lo1inch_" + takerAsset + "_" + makerAsset,
+		Tokens:      []*entity.PoolToken{{Address: takerAsset}, {Address: makerAsset}},
+		Reserves:    entity.PoolReserves{"0", "0"},
+		StaticExtra: `{"token0":"` + takerAsset + `","token1":"` + makerAsset + `"}`,
+		Extra:       string(extra),
+	})
+	require.NoError(t, err)
+
+	encoded, err := msgpack.EncodePoolSimulatorsMap(map[string]pool.IPoolSimulator{"pool": sim})
+	require.NoError(t, err)
+	decoded, err := msgpack.DecodePoolSimulatorsMap(encoded)
+	require.NoError(t, err)
+
+	_, err = decoded["pool"].CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: takerAsset, Amount: big.NewInt(50)},
+		TokenOut:      makerAsset,
+	})
+	require.ErrorIs(t, err, lo1inch.ErrCannotFulfillAmountIn)
+}

--- a/pkg/liquidity-source/lo1inch/pool_simulator_test.go
+++ b/pkg/liquidity-source/lo1inch/pool_simulator_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/KyberNetwork/blockchain-toolkit/integer"
 	"github.com/goccy/go-json"
@@ -721,4 +722,141 @@ func TestPoolSimulatorFeeTakerExtension(t *testing.T) {
 
 	feeTakerExtension, err := helper1inch.NewFeeTakerFromExtension(extensionInstance)
 	t.Log(feeTakerExtension, err)
+}
+
+// mainnetNoPartialFillsTraits is the MakerTraits of a real mainnet order that sets NO_PARTIAL_FILLS
+// (maker 0x9a0ef3c32785daf9161ed6e9701308e622d36e4d, OrderFilled scan around block 25936800).
+const mainnetNoPartialFillsTraits = "0x8a00000000000000000000001254000014006a9f8ac700000000000000000000"
+
+func TestPoolSimulator_CalcAmountOut_NoPartialFillsWithoutExtension(t *testing.T) {
+	t.Parallel()
+
+	const (
+		takerAsset = "0xc0fe7f77ed2f522978b719372282ca89de8cf3e4"
+		makerAsset = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+	)
+
+	makingAmount := uint256.MustFromDecimal("100730000")
+	takingAmount := uint256.MustFromDecimal("1647844178754187351427369")
+
+	// the original order has already expired, drop its expiration so the case does not depend on wall clock
+	makerTraits := "0x" + helper1inch.NewMakerTraits(mainnetNoPartialFillsTraits).WithExpiration(nil).Build().Text(16)
+	require.False(t, helper1inch.NewMakerTraits(makerTraits).IsPartialFillAllowed())
+	require.False(t, helper1inch.NewMakerTraits(makerTraits).IsExpired(time.Now().Unix()))
+
+	poolEntity := entity.Pool{
+		Address:  "lo1inch_" + takerAsset + "_" + makerAsset,
+		Exchange: "lo1inch",
+		Type:     "lo1inch",
+		Reserves: entity.PoolReserves{"0", "0"},
+		Tokens:   []*entity.PoolToken{{Address: takerAsset}, {Address: makerAsset}},
+		Extra: marshalPoolExtra(&Extra{
+			TakeToken0Orders: []*Order{
+				{
+					OrderHash:            "0x9f0f27a9b1a41cf24a5b95c3b1f4f00e0e4e2f1a2d7e5b4c3a2918070605f4e3d",
+					Maker:                "0x9a0ef3c32785daf9161ed6e9701308e622d36e4d",
+					MakerAsset:           makerAsset,
+					TakerAsset:           takerAsset,
+					MakingAmount:         makingAmount,
+					TakingAmount:         takingAmount,
+					RemainingMakerAmount: makingAmount,
+					MakerBalance:         makingAmount,
+					MakerAllowance:       makingAmount,
+					MakerTraits:          makerTraits,
+					// the order has no extension, which used to leave MakerTraitsInstance nil
+					Extension: "",
+				},
+			},
+		}),
+		StaticExtra: fmt.Sprintf(`{"token0":%q,"token1":%q}`, takerAsset, makerAsset),
+	}
+
+	sim, err := NewPoolSimulator(poolEntity)
+	require.NoError(t, err)
+
+	halfTakingAmount := new(uint256.Int).Div(takingAmount, uint256.NewInt(2))
+	_, err = sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: takerAsset, Amount: halfTakingAmount.ToBig()},
+		TokenOut:      makerAsset,
+	})
+	require.ErrorIs(t, err, ErrCannotFulfillAmountIn)
+
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: takerAsset, Amount: takingAmount.ToBig()},
+		TokenOut:      makerAsset,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, makingAmount.ToBig(), res.TokenAmountOut.Amount)
+}
+
+func TestPoolSimulator_CloneState(t *testing.T) {
+	t.Parallel()
+
+	const (
+		takerAsset = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+		makerAsset = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+	)
+
+	poolEntity := entity.Pool{
+		Address:  "lo1inch_" + takerAsset + "_" + makerAsset,
+		Exchange: "lo1inch",
+		Type:     "lo1inch",
+		Reserves: entity.PoolReserves{"0", "0"},
+		Tokens:   []*entity.PoolToken{{Address: takerAsset}, {Address: makerAsset}},
+		Extra: marshalPoolExtra(&Extra{
+			TakeToken0Orders: []*Order{
+				{
+					OrderHash:            "0x177af74e4d3880743ac6603323a9a50f6999968e499f44966dd00d642e933285",
+					Maker:                "0xdf4039a454d58868dfd43f076ee46c92a35fdfd9",
+					MakerAsset:           makerAsset,
+					TakerAsset:           takerAsset,
+					MakingAmount:         uint256.NewInt(10000),
+					TakingAmount:         uint256.NewInt(101),
+					RemainingMakerAmount: uint256.NewInt(10000),
+					MakerBalance:         uint256.NewInt(10437135),
+					MakerAllowance:       uint256.NewInt(900000),
+				},
+			},
+		}),
+		StaticExtra: fmt.Sprintf(`{"token0":%q,"token1":%q}`, takerAsset, makerAsset),
+	}
+
+	sim, err := NewPoolSimulator(poolEntity)
+	require.NoError(t, err)
+
+	amountIn := big.NewInt(50)
+	res, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: takerAsset, Amount: amountIn},
+		TokenOut:      makerAsset,
+	})
+	require.NoError(t, err)
+
+	cloned := sim.CloneState()
+	require.NotNil(t, cloned)
+
+	clonedSim, ok := cloned.(*PoolSimulator)
+	require.True(t, ok)
+	require.NotSame(t, sim.takeToken0Orders[0], clonedSim.takeToken0Orders[0])
+
+	clonedSim.UpdateBalance(pool.UpdateBalanceParams{
+		TokenAmountIn:  pool.TokenAmount{Token: takerAsset, Amount: amountIn},
+		TokenAmountOut: *res.TokenAmountOut,
+		Fee:            *res.Fee,
+		SwapInfo:       res.SwapInfo,
+	})
+
+	assert.Equal(t, "10000", sim.takeToken0Orders[0].RemainingMakerAmount.String())
+	assert.Equal(t, "10437135", sim.takeToken0Orders[0].MakerBalance.String())
+	assert.Equal(t, "900000", sim.takeToken0Orders[0].MakerAllowance.String())
+
+	assert.Equal(t, "5050", clonedSim.takeToken0Orders[0].RemainingMakerAmount.String())
+	assert.Equal(t, "10432185", clonedSim.takeToken0Orders[0].MakerBalance.String())
+	assert.Equal(t, "895050", clonedSim.takeToken0Orders[0].MakerAllowance.String())
+
+	after, err := sim.CalcAmountOut(pool.CalcAmountOutParams{
+		TokenAmountIn: pool.TokenAmount{Token: takerAsset, Amount: amountIn},
+		TokenOut:      makerAsset,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, res.TokenAmountOut.Amount, after.TokenAmountOut.Amount)
 }

--- a/pkg/source/limitorder/rfq_test.go
+++ b/pkg/source/limitorder/rfq_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
-// opSigServer answers /orders/operator-signature with a signature for every requested id
-// present in signed, mimicking the service dropping ids that are no longer active.
-func opSigServer(t *testing.T, signed map[int64]bool) *httptest.Server {
+// signedOrderServer answers /orders/operator-signature with a signature for every requested
+// id present in signed, mimicking the service dropping ids that are no longer active.
+func signedOrderServer(t *testing.T, signed map[int64]bool) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +53,7 @@ func filledOrder(id int64, isFallback bool) *FilledOrderInfo {
 func rfqWith(t *testing.T, signed map[int64]bool, orders []*FilledOrderInfo) (*pool.RFQResult, error) {
 	t.Helper()
 
-	srv := opSigServer(t, signed)
+	srv := signedOrderServer(t, signed)
 	t.Cleanup(srv.Close)
 
 	cfg := &Config{LimitOrderHTTPUrl: srv.URL, ChainID: 1}


### PR DESCRIPTION
Two defects in the `lo1inch` pool simulator, found while re-enabling lo1inch in the vtv2 reserve-taker bot.

## 1. `MakerTraitsInstance` is skipped for empty-extension orders

```go
for _, order := range extra.TakeToken0Orders {
    if order.Extension == "" || order.Extension == helper1inch.ZX { continue }
    order.MakerTraitsInstance = helper1inch.NewMakerTraits(order.MakerTraits)
```

The `continue` fires before the assignment, so an order with no extension keeps `MakerTraitsInstance == nil`. Both fill-amount paths gate the full-fill-only rule on non-nil (`type.go:170` in `CalcTakingAmount`, `type.go:201` in `CalcMakingAmount`), so a `NO_PARTIAL_FILLS` order with no extension is quoted as **partially fillable**. The encoder then builds `fillOrderArgs` with `amount < TakingAmount` and the protocol reverts `PartialFillNotAllowed`.

Fix: the two near-identical loops become one `decodeOrders()`. `MakerTraitsInstance` is assigned first, unconditionally; the extension early-return now only skips the extension-derived instances (`ExtensionInstance`, `FeeTakerExtension`).

This also removed a real divergence between the two loops: the token0 copy swallowed the `NewFeeTakerFromExtension` error behind a commented-out log line, while the token1 copy logged it at Debug. Both now log at Debug.

**Scope honesty:** in a 24h sample of 3,420 on-chain fills the `(NO_PARTIAL_FILLS, HAS_EXTENSION)` split is (0,0):1701, (1,1):925, (0,1):794 — **zero** orders with `NO_PARTIAL_FILLS=1` and `HAS_EXTENSION=0`, which is the only combination that triggers the bug. So this is not currently causing reverts in that window. It is still a real defect: the protocol does not couple those two bits, and the same fix covers the `HAS_EXTENSION`-with-empty-extension case that would otherwise mis-encode silently.

## 2. `CloneState()` is not implemented

The simulator does not override `CloneState()`, so it falls through to `pool.Pool.CloneState()`, which returns `nil`. `Order` is a pointer shared with the entity-derived slices and with the `orderHash -> index` maps, so a caller doing clone-then-`UpdateBalance` mutates the shared simulator's orders instead of a copy. reserve-taker's backrun path clones pending-pool simulators, so this silently corrupts normal-flow state.

Fix: `CloneState()` plus a `cloneOrders` helper — `cloned := *p`, then both order slices rebuilt with a fresh `*Order` per element.

`minBalanceAllowanceByMakerAndAsset` is deliberately **not** cloned. `UpdateBalance` does not write it: it writes `order.{RemainingMakerAmount,MakerBalance,MakerAllowance}` and the external `params.SwapLimit`. The map is written only in `NewPoolSimulator` and read only in `CalculateLimit`, which builds fresh `*big.Int` via `ToBig()`. Per `AGENTS.md:82` ("deep-copy every slice/map/pointer `UpdateBalance` writes by index or in place") sharing is correct and conventional, and it avoids an O(orders) map allocation on every clone in the backrun hot path, where books run to pool-service's 500-order cap. Same reasoning for the two hash->index maps and `Info.Reserves`.

## Tests

Verified before/after by stashing only `pool_simulator.go`: **0 passed / 3 failed** before, **3 pass** after.

| Test | Before |
|---|---|
| `TestPoolSimulator_CalcAmountOut_NoPartialFillsWithoutExtension` | partial take is quoted, so `require.ErrorIs(ErrCannotFulfillAmountIn)` fails with "got nil" |
| `TestPoolSimulator_NoPartialFillsSurvivesMsgpack` | same, through `EncodePoolSimulatorsMap`/`DecodePoolSimulatorsMap` — confirms `IncludeUnexported(true)` carries `MakerTraitsInstance` and its unexported `*big.Int` through the transport router-service actually uses |
| `TestPoolSimulator_CloneState` | `require.NotNil(sim.CloneState())` fails — base returns nil |

The defect-1 fixture uses real mainnet `makerTraits` `0x8a00000000000000000000001254000014006a9f8ac700000000000000000000` (maker `0x9a0ef3c3…`, `NO_PARTIAL_FILLS=1`, `ALLOW_MULTIPLE_FILLS=0`, bit-invalidator) with only the expiration cleared via `helper.WithExpiration(nil)`, so the test does not depend on the wall clock.

## Deliberately out of scope

**`AllowedSender` is not enforced here**, and I recommend it stays out. `AllowedSender()`, `IsPrivate()`, `IsBitInvalidatorMode()` and `IsEpochManagerEnabled()` have zero call sites outside `helper/maker_traits.go`, so the simulator does quote orders it cannot legally fill — but this is the wrong layer to fix it:

1. `p.takerAddress` comes from `staticExtra.TakerAddress`, written by the pool-service scanner. Where that differs from the address that is actually `msg.sender` at the protocol, enforcement would silently delete private orders from other consumers' quotes. The existing fixtures have no `takerAddress` at all (zero address), which would drop every private order.
2. Wrong semantics for that field: here `takerAddress` is the **fee** identity (`FeeTakerExtension` -> `Whitelist.IsWhitelisted`, a half-address match), while the protocol checks `allowedSender` against `msg.sender`.
3. It is the only *static* member of a family of live-state predicates — bit-invalidator consumption, epoch, expiry-at-execution-block, remaining staleness. Enforcing just this one creates a false impression of legality checking.
4. The caller that needs it is building a chain-state overlay anyway, where `!IsAllowedSender(actualMsgSender)` is one line in the same pre-flight.

If it is ever wanted here, the honest shape is an opt-in `StaticExtra` field defaulting to off.

Also noticed, untouched: `rfq.go` returns `(nil, nil)` from both `RFQ` and `BatchRFQ` — a no-op handler that reports success; `Order.GetFilledMakingAmount()` always returns 0 and `GetRouterContract()` returns `""`, both looking like unimplemented stubs; and `helper/whitelist.go` already fails `gofmt -l` on `main` (verified by stashing).

## Verification

`go build ./...` · `go test -race ./pkg/liquidity-source/lo1inch/... ./pkg/msgpack/...` · `golangci-lint run ./pkg/liquidity-source/lo1inch/...` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpoYU9hULTGoHo2kuosoax
