### PR TITLE
feat(uniswap-v4): add OneToken hook liquidity source

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/onetoken/abis.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/onetoken/abis.go
@@ -1,0 +1,29 @@
+package onetoken
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// hookABIJson covers only the getters this handler reads from the OneToken hook: the
+// two per-pool mappings keyed by PoolId (launchTime, poolFeeBpsOverride) and the
+// three owner-settable globals (feeBps, snipeTaxBps, snipeWindow). PoolId is a
+// bytes32 alias, so the mapping getters take a bytes32 key.
+const hookABIJson = `[
+	{"inputs":[{"internalType":"PoolId","name":"","type":"bytes32"}],"name":"launchTime","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},
+	{"inputs":[{"internalType":"PoolId","name":"","type":"bytes32"}],"name":"poolFeeBpsOverride","outputs":[{"internalType":"uint16","name":"","type":"uint16"}],"stateMutability":"view","type":"function"},
+	{"inputs":[],"name":"feeBps","outputs":[{"internalType":"uint16","name":"","type":"uint16"}],"stateMutability":"view","type":"function"},
+	{"inputs":[],"name":"snipeTaxBps","outputs":[{"internalType":"uint16","name":"","type":"uint16"}],"stateMutability":"view","type":"function"},
+	{"inputs":[],"name":"snipeWindow","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}
+]`
+
+var HookABI abi.ABI
+
+func init() {
+	var err error
+	HookABI, err = abi.JSON(bytes.NewReader([]byte(hookABIJson)))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/onetoken/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/onetoken/constant.go
@@ -1,0 +1,25 @@
+package onetoken
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// MaxFeeBps mirrors the OneToken hook's MAX_FEE_BPS: a hard 20% ceiling on any fee
+// the owner can set (base, per-pool override, or snipe tax), so the pool can never
+// be priced as a sell-blocking honeypot. feePipsPerBps converts our 1/10_000 bps
+// unit to Uniswap v4's 1/1_000_000 pip fee unit.
+const (
+	MaxFeeBps     = 2_000
+	feePipsPerBps = 100
+)
+
+// HookAddresses is the shared OneToken hook instance reused across every launch, one
+// per chain. All factory generations on a chain point at the same hook, so these
+// three cover every OneToken v4 pool. Per-pool economics (launchTime, fee override)
+// live in the hook's storage keyed by poolId, not in the hook address. The deployed
+// contract is verified on each chain's explorer (its verified name is RampHook).
+var HookAddresses = []common.Address{
+	common.HexToAddress("0x63e0Ff2e9c38dB24C56A075B69653D99c412C880"), // Base (8453)
+	common.HexToAddress("0xD5C0249cC9F32F4696a6357d66B5317870D5C880"), // BNB Smart Chain (56)
+	common.HexToAddress("0xFc1088203547710CdD8a45ba9ec80369cc254880"), // Robinhood (4663)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/onetoken/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/onetoken/hook.go
@@ -1,0 +1,128 @@
+// Package onetoken implements the Uniswap v4 hook shared by every OneToken launch
+// (onetokenhub.xyz; the deployed contract is verified as RampHook on each chain's
+// explorer). A OneToken pool is a one-sided bonding curve whose fee is a plain
+// dynamic LP fee: the hook's beforeSwap returns feePips | OVERRIDE_FEE_FLAG, so the
+// PoolManager applies it as the pool's LP fee for that swap. Unlike b20/LaunchHook,
+// there is no delta and no afterSwap: the fee overrides the LP fee symmetrically, so
+// this handler only sets BeforeSwapResult.SwapFee (pool_simulator.go then swaps that
+// fee in via cloned.V3Pool.Fee). The fee is the normal platform fee, an elevated flat
+// snipe tax during the first snipeWindow seconds after launch, or a per-pool override,
+// always hard-capped at MaxFeeBps.
+package onetoken
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/valueobject"
+)
+
+var ErrNotLaunched = errors.New("onetoken: pool has no launchTime yet (not launched), refusing to quote at an unknown fee")
+
+// Extra is the pricing-relevant state read from the OneToken hook. FeeBps/SnipeTaxBps/
+// SnipeWindow are the hook-global params (owner-settable, rarely change); LaunchTime
+// and OverrideBps are per-pool. Only the fee matters to a swap: creator/admin fee
+// splits happen after collection and never affect the swap-visible amount.
+type Extra struct {
+	FeeBps      int64 `json:"f"`
+	SnipeTaxBps int64 `json:"s"`
+	SnipeWindow int64 `json:"w"`
+	LaunchTime  int64 `json:"lt,omitempty"`
+	OverrideBps int64 `json:"o,omitempty"` // 0 = no per-pool override
+}
+
+// NowFn is a var so tests can pin the snipe-window clock.
+var NowFn = func() int64 { return time.Now().Unix() }
+
+var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
+	h := &Hook{Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4OneToken}}
+	_ = param.HookExtra.Unmarshal(&h.Extra)
+	return h
+}, HookAddresses...)
+
+type Hook struct {
+	uniswapv4.Hook `json:"-"`
+	Extra
+}
+
+// Track reads the pool's launchTime and fee override plus the hook-global fee params
+// in one multicall. launchTime is set on the pool's first liquidity add and never
+// changes; the globals are re-read every pass (cheap) so a later owner setFeeBps /
+// setSnipeTax stays reflected. A zero launchTime means the pool has not launched
+// (nothing to price), so we refuse rather than quote it fee-free.
+func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	var (
+		launchTime  = new(big.Int)
+		overrideRaw uint16
+		feeBps      uint16
+		snipeTax    uint16
+		snipeWindow = new(big.Int)
+	)
+	poolID := common.HexToHash(param.Pool.Address)
+	target := hexutil.Encode(param.HookAddress[:])
+	req := param.RpcClient.NewRequest().SetContext(ctx).SetBlockNumber(param.BlockNumber).SetOverrides(param.Overrides)
+	req.AddCall(&ethrpc.Call{ABI: HookABI, Target: target, Method: "launchTime", Params: []any{poolID}}, []any{&launchTime})
+	req.AddCall(&ethrpc.Call{ABI: HookABI, Target: target, Method: "poolFeeBpsOverride", Params: []any{poolID}}, []any{&overrideRaw})
+	req.AddCall(&ethrpc.Call{ABI: HookABI, Target: target, Method: "feeBps", Params: nil}, []any{&feeBps})
+	req.AddCall(&ethrpc.Call{ABI: HookABI, Target: target, Method: "snipeTaxBps", Params: nil}, []any{&snipeTax})
+	req.AddCall(&ethrpc.Call{ABI: HookABI, Target: target, Method: "snipeWindow", Params: nil}, []any{&snipeWindow})
+	if _, err := req.Aggregate(); err != nil {
+		return nil, err
+	}
+	if launchTime.Sign() == 0 {
+		return nil, ErrNotLaunched
+	}
+
+	// poolFeeBpsOverride stores bps+1 so 0 = unset; decode back to a real bps value.
+	var overrideBps int64
+	if overrideRaw > 0 {
+		overrideBps = int64(overrideRaw) - 1
+	}
+	h.Extra = Extra{
+		FeeBps:      int64(feeBps),
+		SnipeTaxBps: int64(snipeTax),
+		SnipeWindow: snipeWindow.Int64(),
+		LaunchTime:  launchTime.Int64(),
+		OverrideBps: overrideBps,
+	}
+	return json.Marshal(h)
+}
+
+// EffectiveFeeBps mirrors the hook's effectiveFeeBps(): snipe window takes priority,
+// then a per-pool override, then the global fee. Result is hard-capped at MaxFeeBps.
+func (e *Extra) EffectiveFeeBps() int64 {
+	fee := e.FeeBps
+	if e.LaunchTime != 0 && NowFn() < e.LaunchTime+e.SnipeWindow {
+		fee = e.SnipeTaxBps
+	} else if e.OverrideBps > 0 {
+		fee = e.OverrideBps
+	}
+	if fee > MaxFeeBps {
+		fee = MaxFeeBps
+	}
+	return fee
+}
+
+// BeforeSwap overrides the LP fee with the current effective fee (the hook returns
+// feePips | OVERRIDE_FEE_FLAG). V4 fee unit is pips (1e-6) and our bps is 1e-4, so
+// pips = bps * 100. No delta, no direction check: the fee applies symmetrically to
+// exact-in and exact-out, so this returns the same SwapFee for both.
+func (h *Hook) BeforeSwap(params *uniswapv4.BeforeSwapParams) (*uniswapv4.BeforeSwapResult, error) {
+	if h.LaunchTime == 0 {
+		return nil, ErrNotLaunched
+	}
+	return &uniswapv4.BeforeSwapResult{
+		DeltaSpecified:   bignumber.ZeroBI,
+		DeltaUnspecified: bignumber.ZeroBI,
+		SwapFee:          uniswapv4.FeeAmount(h.EffectiveFeeBps() * feePipsPerBps),
+	}, nil
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/onetoken/hook_live_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/onetoken/hook_live_test.go
@@ -1,0 +1,53 @@
+package onetoken
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/entity"
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+)
+
+// TestTrack_Live reads the OneToken hook against a real launch on Base (WEREY),
+// confirming HookABI's method names / arg (bytes32 PoolId) / return types actually
+// match the deployed contract, not just that the ABI JSON compiles. It also proves
+// the multicall of the two per-pool getters plus the three globals decodes together.
+func TestTrack_Live(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping live test in CI environment")
+	}
+
+	rpcClient := ethrpc.New("https://mainnet.base.org").
+		SetMulticallContract(common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11"))
+	hookAddr := common.HexToAddress("0x63e0Ff2e9c38dB24C56A075B69653D99c412C880") // Base OneToken hook
+
+	h := &Hook{Hook: &uniswapv4.BaseHook{}}
+	_, err := h.Track(context.Background(), &uniswapv4.HookParam{
+		RpcClient:   rpcClient,
+		HookAddress: hookAddr,
+		Pool: &entity.Pool{
+			// WEREY/WETH poolId
+			Address: "0xe23622f7d41653c012cfb72e9d4addbffcfd67f7fb142b998cbd050a861d94fc",
+		},
+	})
+	require.NoError(t, err)
+
+	// launchTime and the override are frozen per pool, so they are stable assertions.
+	// Values cross-checked with `cast call ... --rpc-url https://mainnet.base.org` on 2026-09-09.
+	assert.Equal(t, int64(1788896153), h.LaunchTime)
+	assert.Equal(t, int64(0), h.OverrideBps)
+
+	// feeBps / snipeTaxBps / snipeWindow are hook-global and owner-settable, so these
+	// are the values as of the cross-check date; if the owner later changes them, update
+	// these three (the test failing here means the globals moved, not that decoding broke).
+	assert.Equal(t, int64(300), h.FeeBps)
+	assert.Equal(t, int64(1500), h.SnipeTaxBps)
+	assert.Equal(t, int64(900), h.SnipeWindow)
+}

--- a/pkg/liquidity-source/uniswap/v4/hooks/onetoken/hook_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/onetoken/hook_test.go
@@ -1,0 +1,113 @@
+package onetoken
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	uniswapv4 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4"
+	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/util/bignumber"
+)
+
+// reference values are the live globals of the Base OneToken hook plus a real launch
+// (WEREY, poolId 0xe23622f7d41653c012cfb72e9d4addbffcfd67f7fb142b998cbd050a861d94fc),
+// cross-checked with cast on 2026-09-09, so the fee schedule is checked against the
+// actual on-chain contract, not just its own logic restated.
+func refExtra() Extra {
+	return Extra{
+		FeeBps:      300,        // 3%
+		SnipeTaxBps: 1500,       // 15%
+		SnipeWindow: 900,        // 15 min
+		LaunchTime:  1788896153, // WEREY on Base
+		OverrideBps: 0,
+	}
+}
+
+// EffectiveFeeBps must reproduce the hook's effectiveFeeBps() exactly: a wrong bps
+// here silently mis-prices every swap during the snipe window without erroring, so a
+// route built on this quote settles for less than it should on-chain. Unlike b20's
+// linear decay, ours is a step: the elevated tax for the whole window, then base.
+func TestEffectiveFeeBps_Step(t *testing.T) {
+	e := refExtra()
+
+	cases := []struct {
+		name    string
+		elapsed int64
+		want    int64
+	}{
+		{"at launch instant, snipe tax applies", 0, 1500},
+		{"last second of the window, still snipe tax", 899, 1500},
+		{"window boundary (elapsed == window), drops to base", 900, 300},
+		{"long after the window, stays at base", 1_000_000, 300},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			NowFn = func() int64 { return e.LaunchTime + c.elapsed }
+			assert.Equal(t, c.want, e.EffectiveFeeBps())
+		})
+	}
+}
+
+// Per-pool override applies only after the snipe window; during the window the snipe
+// tax wins (matches effectiveFeeBps()'s priority: snipe > override > base).
+func TestEffectiveFeeBps_Override(t *testing.T) {
+	e := refExtra()
+	e.OverrideBps = 500 // 5%
+
+	NowFn = func() int64 { return e.LaunchTime } // in window
+	assert.Equal(t, int64(1500), e.EffectiveFeeBps(), "snipe tax outranks override during the window")
+
+	NowFn = func() int64 { return e.LaunchTime + e.SnipeWindow } // out of window
+	assert.Equal(t, int64(500), e.EffectiveFeeBps(), "override applies after the window")
+}
+
+// The clamp must hold defensively: even an out-of-policy value that somehow made it
+// through Track must never let the simulator quote a fee above the contract's hard
+// ceiling (MAX_FEE_BPS = 20%). Use 9000 so the assertion can fail if the clamp is removed.
+func TestEffectiveFeeBps_CappedAtMax(t *testing.T) {
+	e := Extra{FeeBps: 9000, SnipeTaxBps: 9000, SnipeWindow: 10, LaunchTime: 1}
+
+	NowFn = func() int64 { return 1 } // in window -> snipe tax path
+	assert.Equal(t, int64(MaxFeeBps), e.EffectiveFeeBps())
+
+	NowFn = func() int64 { return 1_000_000 } // out of window -> base path
+	assert.Equal(t, int64(MaxFeeBps), e.EffectiveFeeBps())
+}
+
+// BeforeSwap sets the LP fee via SwapFee (pips = bps * 100), no delta, and is
+// direction/exactness agnostic (a fee override is symmetric), so exact-in and
+// exact-out return the same fee.
+func TestBeforeSwap_SetsSwapFee(t *testing.T) {
+	e := refExtra()
+	NowFn = func() int64 { return e.LaunchTime + e.SnipeWindow } // post-window: 300 bps
+	h := &Hook{Extra: e}
+
+	for _, calcOut := range []bool{true, false} {
+		res, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: calcOut, ZeroForOne: true})
+		require.NoError(t, err)
+		assert.Equal(t, uniswapv4.FeeAmount(300*feePipsPerBps), res.SwapFee) // 30_000 pips = 3%
+		assert.Equal(t, bignumber.ZeroBI, res.DeltaSpecified)
+		assert.Equal(t, bignumber.ZeroBI, res.DeltaUnspecified)
+	}
+}
+
+// During the snipe window BeforeSwap must return the elevated fee.
+func TestBeforeSwap_SnipeWindow(t *testing.T) {
+	e := refExtra()
+	NowFn = func() int64 { return e.LaunchTime } // elapsed 0: in window
+	h := &Hook{Extra: e}
+
+	res, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: false})
+	require.NoError(t, err)
+	assert.Equal(t, uniswapv4.FeeAmount(1500*feePipsPerBps), res.SwapFee) // 150_000 pips = 15%
+}
+
+// A pool whose Track() never succeeded (RPC failure, or the Hook constructed before
+// HookExtra is populated) has LaunchTime == 0 and must refuse to quote rather than
+// default to a zero-value Extra (FeeBps == 0), which would silently price it fee-free.
+func TestBeforeSwap_UntrackedPool_Errors(t *testing.T) {
+	h := &Hook{} // zero-value Extra: LaunchTime == 0
+	_, err := h.BeforeSwap(&uniswapv4.BeforeSwapParams{CalcOut: true, ZeroForOne: true})
+	assert.ErrorIs(t, err, ErrNotLaunched)
+}

--- a/pkg/msgpack/register_pool_types.gen.go
+++ b/pkg/msgpack/register_pool_types.gen.go
@@ -202,6 +202,7 @@ import (
 	pkg_liquiditysource_uniswap_v4_hooks_nft_strategy "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/nft_strategy"
 	pkg_liquiditysource_uniswap_v4_hooks_o1 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/o1"
 	pkg_liquiditysource_uniswap_v4_hooks_odysfun "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/odysfun"
+	pkg_liquiditysource_uniswap_v4_hooks_onetoken "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/onetoken"
 	pkg_liquiditysource_uniswap_v4_hooks_ponsv2 "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/pons-v2"
 	pkg_liquiditysource_uniswap_v4_hooks_renzo "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/renzo"
 	pkg_liquiditysource_uniswap_v4_hooks_st0x "github.com/KyberNetwork/kyberswap-dex-lib/pkg/liquidity-source/uniswap/v4/hooks/st0x"
@@ -464,6 +465,7 @@ func init() {
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_nft_strategy.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_o1.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_odysfun.Hook{})
+	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_onetoken.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_ponsv2.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_renzo.Hook{})
 	_ = msgpack.RegisterConcreteType(&pkg_liquiditysource_uniswap_v4_hooks_st0x.Hook{})

--- a/pkg/valueobject/exchange.go
+++ b/pkg/valueobject/exchange.go
@@ -318,6 +318,7 @@ const (
 	ExchangeUniswapV4NftStrategy        = "uniswap-v4-nftstrat"
 	ExchangeUniswapV4O1                 = "uniswap-v4-o1"
 	ExchangeUniswapV4OdysFun            = "uniswap-v4-odysfun"
+	ExchangeUniswapV4OneToken           = "uniswap-v4-onetoken"
 	ExchangeUniswapV4PonsV2             = "uniswap-v4-pons-v2"
 	ExchangeUniswapV4Renzo              = "uniswap-v4-renzo"
 	ExchangeUniswapV4ST0x               = "uniswap-v4-st0x"


### PR DESCRIPTION
## Summary

Adds a Uniswap V4 hook handler for **OneToken** (https://onetokenhub.xyz), a one-sided
launchpad. Its pools are canonical Uniswap V4 pools with one shared hook per chain; this
handler lets the aggregator price and route them. Same approach as `hooks/clanker` and
`hooks/pons-v2`.

## The hook

`beforeSwap` returns `feePips | OVERRIDE_FEE_FLAG`, i.e. a plain **dynamic LP fee**, no
delta and no afterSwap. The effective fee is:

- normal `feeBps` (3%), or
- an elevated flat `snipeTaxBps` (15%) during the first `snipeWindow` (900s) after `launchTime`, or
- a per-pool `poolFeeBpsOverride`,
- always hard-capped at `MAX_FEE_BPS` (20%), so it can never block sells.

No delta flags (`beforeSwapReturnDelta`/`afterSwapReturnDelta` = false), no custom
hookData, and the hook is **non-upgradeable** and verified on each chain's explorer.

## Handler

Because it only overrides the LP fee, the handler just sets `BeforeSwapResult.SwapFee`
(no delta, direction-agnostic), mirroring the on-chain `effectiveFeeBps()`. It refuses
to quote a pool with `launchTime == 0` (not launched) rather than pricing it fee-free.

## Chains + addresses

Already present in the V4 `PoolManager` map, so no chain changes are needed:

| Chain | Hook | Factory (current) |
|---|---|---|
| Base (8453) | `0x63e0Ff2e9c38dB24C56A075B69653D99c412C880` | `0x3447859526176Cc6D323795196209C05D4c7dAF5` |
| BNB Smart Chain (56) | `0xD5C0249cC9F32F4696a6357d66B5317870D5C880` | `0x9e81EDB0cD05e9AAFb004aa7D015A62268bC3274` |
| Robinhood (4663) | `0xFc1088203547710CdD8a45ba9ec80369cc254880` | `0x582E2cFE52c30C15b3Ed3E8aDA77de4752326D99` |

Verified hook (Base): https://basescan.org/address/0x63e0Ff2e9c38dB24C56A075B69653D99c412C880#code

Pool discovery: `poolId = keccak256(abi.encode(PoolKey{sorted(WETH, token), fee 0x800000, tickSpacing 60, hooks <chain hook>}))`, or enumerate `factory.allTokens()` -> `factory.pools(token).poolId`.

## Tests

- `hook_test.go`: fee-math (step function, override priority, 20% cap), `BeforeSwap` output, and the untracked-pool guard.
- `hook_live_test.go`: `Track` against a live Base pool, decoding cross-checked to on-chain values.

## Request

Please enable `uniswap-v4-onetoken` for Base, BSC, and Robinhood in the per-chain hook config.
