### PR TITLE
fix(limitorder): rename the colliding opSigServer test helper

### DIFF
--- a/pkg/source/limitorder/rfq_test.go
+++ b/pkg/source/limitorder/rfq_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/KyberNetwork/kyberswap-dex-lib/pkg/source/pool"
 )
 
-// opSigServer answers /orders/operator-signature with a signature for every requested id
-// present in signed, mimicking the service dropping ids that are no longer active.
-func opSigServer(t *testing.T, signed map[int64]bool) *httptest.Server {
+// signedOrderServer answers /orders/operator-signature with a signature for every requested
+// id present in signed, mimicking the service dropping ids that are no longer active.
+func signedOrderServer(t *testing.T, signed map[int64]bool) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +53,7 @@ func filledOrder(id int64, isFallback bool) *FilledOrderInfo {
 func rfqWith(t *testing.T, signed map[int64]bool, orders []*FilledOrderInfo) (*pool.RFQResult, error) {
 	t.Helper()
 
-	srv := opSigServer(t, signed)
+	srv := signedOrderServer(t, signed)
 	t.Cleanup(srv.Close)
 
 	cfg := &Config{LimitOrderHTTPUrl: srv.URL, ChainID: 1}


### PR DESCRIPTION
`main` does not build, so every open PR inherits a red CI.

`pkg/source/limitorder` declares `opSigServer` twice. #1628 added it as a **function** in `rfq_test.go`; #1637 later added a **struct** of the same name in `http_client_test.go`. Neither PR was wrong on its own branch — the collision only exists once both are on `main`, which is why it slipped through.

```
pkg/source/limitorder/rfq_test.go:19:6: opSigServer redeclared in this block
	pkg/source/limitorder/http_client_test.go:144:6: other declaration of opSigServer
pkg/source/limitorder/rfq_test.go:56:24: too many arguments in conversion to opSigServer
```

Reproduced on a clean `origin/main` worktree, so this is not specific to any branch.

The struct keeps the name: it is the richer helper, it carries methods (`newOpSigServer`, `recorded`), and renaming it would touch four sites instead of two. The function becomes **`signedOrderServer`**, which also describes it better — it serves signatures only for the ids the caller marked as signed.

Test-only, no production code touched. `go vet ./pkg/source/limitorder/` clean, `go test ./pkg/source/limitorder/` 93 pass, `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpoYU9hULTGoHo2kuosoax
