### PR TITLE
fix: support upgraded uniswap-v4 stable-stable hook (dropped on-chain logK)

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/abi.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/abi.go
@@ -7,4 +7,11 @@ import (
 	"github.com/samber/lo"
 )
 
-var stableStableHookABI = lo.Must(abi.JSON(bytes.NewReader(stableStableHookABIJson)))
+var (
+	// stableStableHookABI covers the legacy hook deployment (HookAddresses[0]), whose
+	// feeConfig()/FeeConfigUpdated still carry an explicit on-chain logK.
+	stableStableHookABI = lo.Must(abi.JSON(bytes.NewReader(stableStableHookABIJson)))
+	// stableStableHookV2ABI covers newer hook deployments, whose feeConfig() dropped
+	// logK; it's now derived off-chain from k (see deriveLogK).
+	stableStableHookV2ABI = lo.Must(abi.JSON(bytes.NewReader(stableStableHookV2ABIJson)))
+)

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/abis/StableStableHookV2.json
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/abis/StableStableHookV2.json
@@ -15,10 +15,6 @@
         "type": "uint24"
       },
       {
-        "name": "logK",
-        "type": "uint24"
-      },
-      {
         "name": "optimalFeeE6",
         "type": "uint24"
       },
@@ -29,31 +25,6 @@
       {
         "name": "referenceSqrtPriceX96",
         "type": "uint160"
-      }
-    ]
-  },
-  {
-    "type": "function",
-    "stateMutability": "view",
-    "name": "feeState",
-    "inputs": [
-      {
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "decayingFeeE12",
-        "type": "uint40"
-      },
-      {
-        "name": "sqrtAmmPriceX96",
-        "type": "uint160"
-      },
-      {
-        "name": "blockNumber",
-        "type": "uint40"
       }
     ]
   },
@@ -75,11 +46,6 @@
           },
           {
             "internalType": "uint24",
-            "name": "logK",
-            "type": "uint24"
-          },
-          {
-            "internalType": "uint24",
             "name": "optimalFeeE6",
             "type": "uint24"
           },
@@ -95,7 +61,7 @@
           }
         ],
         "indexed": false,
-        "internalType": "struct FeeConfig",
+        "internalType": "struct StableFeeConfig",
         "name": "feeConfig",
         "type": "tuple"
       }

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/constant.go
@@ -12,3 +12,8 @@ var HookAddresses = []common.Address{
 	common.HexToAddress("0x4509b7Eb3F9641226804Fea4976963435d1c6080"),
 	common.HexToAddress("0x0000113dCf4ADd69999Fad8F20F2b63F979bfcC0"),
 }
+
+// legacyHookAddress is the only deployment whose feeConfig() still returns an
+// explicit on-chain logK; every other (newer) hook address derives it from k
+// off-chain (see deriveLogK). Any hook not equal to this is treated as V2.
+var legacyHookAddress = HookAddresses[0]

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/embed.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/embed.go
@@ -4,3 +4,6 @@ import _ "embed"
 
 //go:embed abis/StableStableHook.json
 var stableStableHookABIJson []byte
+
+//go:embed abis/StableStableHookV2.json
+var stableStableHookV2ABIJson []byte

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/hook.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/hook.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/KyberNetwork/ethrpc"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/goccy/go-json"
 	"github.com/holiman/uint256"
 
@@ -19,8 +20,14 @@ type Hook struct {
 	uniswapv4.Hook          `json:"-"`
 	uniswapv3.ExtraTickU256 `json:"-"`
 
+	// HookAddress is set once from HookParam at construction time (GetHook
+	// re-runs the factory on every pool simulator rebuild, so this is always
+	// fresh — it never needs to round-trip through JSON). isLegacy() derives
+	// which feeConfig()/decay formula this pool's hook deployment uses from it.
+	HookAddress common.Address `json:"-"`
+
 	K                     uint64 `json:"k"`
-	LogK                  uint64 `json:"lk"`
+	LogK                  uint64 `json:"lk"` // legacy hook only; V2 hooks derive it from K (see deriveLogK)
 	OptimalFeeE6          uint64 `json:"o"`
 	TargetMultiplier      uint64 `json:"tm"`
 	ReferenceSqrtPriceX96 string `json:"rsp"`
@@ -32,9 +39,12 @@ type Hook struct {
 	TrackedBlock uint64 `json:"tb"`
 }
 
+func (h *Hook) isLegacy() bool { return h.HookAddress == legacyHookAddress }
+
 var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv4.Hook {
 	hook := &Hook{
-		Hook: &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4StableStable},
+		Hook:        &uniswapv4.BaseHook{Exchange: valueobject.ExchangeUniswapV4StableStable},
+		HookAddress: param.HookAddress,
 	}
 	_ = param.HookExtra.Unmarshal(hook)
 	if param.Pool != nil && param.Pool.Extra != "" {
@@ -43,12 +53,29 @@ var _ = uniswapv4.RegisterHooksFactory(func(param *uniswapv4.HookParam) uniswapv
 	return hook
 }, HookAddresses...)
 
+// feeConfigV2RPC mirrors newer hooks' feeConfig() output order; logK was
+// dropped on-chain and is now derived off-chain from k (see deriveLogK).
+type feeConfigV2RPC struct {
+	K                     *big.Int
+	OptimalFeeE6          *big.Int
+	TargetMultiplier      uint8
+	ReferenceSqrtPriceX96 *big.Int
+}
+
+// feeConfigRPC mirrors the legacy hook's feeConfig() output order, which
+// interleaves LogK between K and OptimalFeeE6.
 type feeConfigRPC struct {
 	K                     *big.Int
 	LogK                  *big.Int
 	OptimalFeeE6          *big.Int
 	TargetMultiplier      uint8
 	ReferenceSqrtPriceX96 *big.Int
+}
+
+// common strips LogK so both feeConfig shapes can be applied to Hook through
+// one code path.
+func (c feeConfigRPC) common() feeConfigV2RPC {
+	return feeConfigV2RPC{c.K, c.OptimalFeeE6, c.TargetMultiplier, c.ReferenceSqrtPriceX96}
 }
 
 type feeStateRPC struct {
@@ -58,8 +85,11 @@ type feeStateRPC struct {
 }
 
 func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawMessage, error) {
+	isLegacy := h.isLegacy()
+
 	var (
 		cfg   feeConfigRPC
+		cfgV2 feeConfigV2RPC
 		state feeStateRPC
 	)
 
@@ -69,12 +99,16 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 	}
 
 	poolId := eth.StringToBytes32(param.Pool.Address)
+	feeConfigABI, feeConfigDst := stableStableHookV2ABI, any(&cfgV2)
+	if isLegacy {
+		feeConfigABI, feeConfigDst = stableStableHookABI, any(&cfg)
+	}
 	req.AddCall(&ethrpc.Call{
-		ABI:    stableStableHookABI,
+		ABI:    feeConfigABI,
 		Target: param.HookAddress.Hex(),
 		Method: "feeConfig",
 		Params: []any{poolId},
-	}, []any{&cfg})
+	}, []any{feeConfigDst})
 	req.AddCall(&ethrpc.Call{
 		ABI:    stableStableHookABI,
 		Target: param.HookAddress.Hex(),
@@ -86,11 +120,15 @@ func (h *Hook) Track(ctx context.Context, param *uniswapv4.HookParam) (json.RawM
 		return nil, err
 	}
 
-	h.K = cfg.K.Uint64()
-	h.LogK = cfg.LogK.Uint64()
-	h.OptimalFeeE6 = cfg.OptimalFeeE6.Uint64()
-	h.TargetMultiplier = uint64(cfg.TargetMultiplier)
-	h.ReferenceSqrtPriceX96 = cfg.ReferenceSqrtPriceX96.String()
+	h.LogK = 0
+	if isLegacy {
+		h.LogK = cfg.LogK.Uint64()
+		cfgV2 = cfg.common()
+	}
+	h.K = cfgV2.K.Uint64()
+	h.OptimalFeeE6 = cfgV2.OptimalFeeE6.Uint64()
+	h.TargetMultiplier = uint64(cfgV2.TargetMultiplier)
+	h.ReferenceSqrtPriceX96 = cfgV2.ReferenceSqrtPriceX96.String()
 	h.DecayingFeeE12 = state.DecayingFeeE12.Uint64()
 	h.SqrtAmmPriceX96 = state.SqrtAmmPriceX96.String()
 	h.BlockNumber = state.BlockNumber.Uint64()
@@ -257,7 +295,10 @@ func (h *Hook) calculateDecayingFee(
 		blocksPassed = h.TrackedBlock - previousBlockNumber
 	}
 
-	return CalculateDecayingFee(targetFee, decayStartFeeE12, h.K, h.LogK, blocksPassed)
+	if h.isLegacy() {
+		return CalculateDecayingFee(targetFee, decayStartFeeE12, h.K, h.LogK, blocksPassed)
+	}
+	return CalculateDecayingFeeV2(targetFee, decayStartFeeE12, h.K, blocksPassed)
 }
 
 func (h *Hook) CloneState() uniswapv4.Hook {

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/math.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/math.go
@@ -23,8 +23,10 @@ var (
 
 	undefinedDecayingFeeE12 = new(uint256.Int).AddUint64(oneE12, 1)
 
-	q48 = new(uint256.Int).Lsh(u256.U1, 48)
-	q96 = new(uint256.Int).Lsh(u256.U1, 96)
+	q24  = new(uint256.Int).Lsh(u256.U1, 24)
+	q48  = new(uint256.Int).Lsh(u256.U1, 48)
+	q96  = new(uint256.Int).Lsh(u256.U1, 96)
+	q120 = new(uint256.Int).Lsh(u256.U1, 120)
 
 	maxTargetMultiplierU = uint256.NewInt(MaxTargetMultiplier)
 )
@@ -36,8 +38,7 @@ func CalculatePriceRatioX96(sqrtPrice1X96, sqrtPrice2X96 *uint256.Int) *uint256.
 	if num.Cmp(den) > 0 {
 		num, den = den, num
 	}
-	r := new(uint256.Int).Mul(num, q48)
-	r.Div(r, den)
+	r := u256.MulDiv(num, q48, den)
 	return r.Mul(r, r)
 }
 
@@ -91,6 +92,18 @@ func AdjustPreviousFeeForPriceMovement(priceRatioX96, previousDecayingFeeE12 *ui
 	return new(uint256.Int).Sub(oneE12, num)
 }
 
+// applyDecay computes target + factor*(previous-target) >> 24, the tail shared
+// by both hooks' calculateDecayingFee once factorX24 has been derived.
+func applyDecay(targetFeeE12, previousDecayingFeeE12, factorX24 *uint256.Int) *uint256.Int {
+	delta := new(uint256.Int).Sub(previousDecayingFeeE12, targetFeeE12)
+	delta.Mul(delta, factorX24)
+	delta.Rsh(delta, 24)
+	return delta.Add(delta, targetFeeE12)
+}
+
+// CalculateDecayingFee is the legacy hook's formula: it uses the on-chain logK
+// directly (see decayFactorX24). Newer hooks dropped logK; use
+// CalculateDecayingFeeV2 for those (see deriveLogK).
 func CalculateDecayingFee(
 	targetFeeE12, previousDecayingFeeE12 *uint256.Int,
 	k, logK, blocksPassed uint64,
@@ -104,11 +117,7 @@ func CalculateDecayingFee(
 		return nil, err
 	}
 
-	delta := new(uint256.Int).Sub(previousDecayingFeeE12, targetFeeE12)
-	delta.Mul(delta, factorX24)
-	delta.Rsh(delta, 24)
-
-	return new(uint256.Int).Add(targetFeeE12, delta), nil
+	return applyDecay(targetFeeE12, previousDecayingFeeE12, factorX24), nil
 }
 
 func decayFactorX24(k, logK, blocksPassed uint64) (*uint256.Int, error) {
@@ -120,7 +129,49 @@ func decayFactorX24(k, logK, blocksPassed uint64) (*uint256.Int, error) {
 	mag.Mul(mag, uint256.NewInt(blocksPassed))
 	mag.Lsh(mag, 40)
 
-	expI := i256.SafeToInt256(mag)
+	return expDecayFactorX24(mag)
+}
+
+// CalculateDecayingFeeV2 mirrors StableFeeCalculation.calculateDecayingFee on
+// hooks that dropped the on-chain logK column: logK is derived from k on the
+// fly (deriveLogK) instead of being read from chain.
+func CalculateDecayingFeeV2(
+	targetFeeE12, previousDecayingFeeE12 *uint256.Int,
+	k, blocksPassed uint64,
+) (*uint256.Int, error) {
+	if previousDecayingFeeE12.Lt(targetFeeE12) {
+		return nil, ErrInvalidFeeConfig
+	}
+
+	factorX24, err := decayFactorX24V2(k, blocksPassed)
+	if err != nil {
+		return nil, err
+	}
+
+	return applyDecay(targetFeeE12, previousDecayingFeeE12, factorX24), nil
+}
+
+func decayFactorX24V2(k, blocksPassed uint64) (*uint256.Int, error) {
+	if blocksPassed <= 4 {
+		return fastPowQ24(k, blocksPassed)
+	}
+
+	logK, err := deriveLogK(k)
+	if err != nil {
+		return nil, err
+	}
+
+	mag := logK.Mul(logK, uint256.NewInt(blocksPassed))
+	mag.Lsh(mag, 24)
+
+	return expDecayFactorX24(mag)
+}
+
+// expDecayFactorX24 computes floor(exp(-magWad) * 2^24 / 1e18), the tail
+// shared by decayFactorX24 and decayFactorX24V2 once each has assembled its
+// (differently-scaled) wad exponent magnitude.
+func expDecayFactorX24(magWad *uint256.Int) (*uint256.Int, error) {
+	expI := i256.SafeToInt256(magWad)
 	if expI == nil {
 		return nil, ErrInvalidFeeConfig
 	}
@@ -131,10 +182,29 @@ func decayFactorX24(k, logK, blocksPassed uint64) (*uint256.Int, error) {
 		return nil, err
 	}
 
-	out := new(uint256.Int).Lsh(expWad, 24)
-	out.Div(out, oneE18)
+	return u256.MulDiv(expWad, q24, oneE18), nil
+}
 
-	return out, nil
+// deriveLogK mirrors StableFeeCalculation.deriveLogK: logK = ceil(-ln(k) / 2^24),
+// where k is Q24 fixed point and the result is the wad-scale (1e18) decay rate
+// decayFactorX24V2's slow path exponentiates with. This is specific to hooks
+// that no longer store logK on-chain — it is NOT interchangeable with the
+// legacy hook's on-chain logK, which uses a different (<<40, not <<24) scale.
+func deriveLogK(k uint64) (*uint256.Int, error) {
+	kQ96 := new(uint256.Int).Lsh(uint256.NewInt(k), 72)
+	kQ96Int := i256.SafeToInt256(kQ96)
+	if kQ96Int == nil {
+		return nil, ErrInvalidFeeConfig
+	}
+
+	lnKQ96, err := bunnimath.LnQ96(kQ96Int)
+	if err != nil {
+		return nil, err
+	}
+
+	absLnKQ96 := i256.UnsafeToUInt256(i256.Abs(lnKQ96))
+
+	return bunnimath.MulDivUp(absLnKQ96, oneE18, q120), nil
 }
 
 func fastPowQ24(k, n uint64) (*uint256.Int, error) {

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/math_test.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/math_test.go
@@ -171,6 +171,28 @@ func TestCalculateDecayingFee_PrevBelowTarget(t *testing.T) {
 	}
 }
 
+// TestDeriveLogK checks deriveLogK against a high-precision reference computed
+// independently in Python (mpmath, 60 digits): logK = ceil(-ln(k/2^24)*1e18/2^24).
+// k = 0.99 in Q24 -> logK = 599049713. LnQ96 isn't bit-identical to solady's
+// lnWad, so allow a small tolerance rather than requiring an exact match.
+func TestDeriveLogK(t *testing.T) {
+	const k uint64 = 16_609_443
+	want := uint256.NewInt(599_049_713)
+
+	got, err := deriveLogK(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := new(uint256.Int).Sub(got, want)
+	if got.Lt(want) {
+		diff.Sub(want, got)
+	}
+	if diff.Uint64() > 10 {
+		t.Fatalf("deriveLogK(%d): got %s want ~%s (diff %s)", k, got, want, diff)
+	}
+}
+
 func TestAdjustPreviousFeeForPriceMovement_Identity(t *testing.T) {
 	// movementRatio = Q96 (i.e. price unchanged) → adjustedFee == prev.
 	prev := uint256.NewInt(123_456_789)

--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/pool_factory.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/pool_factory.go
@@ -29,7 +29,7 @@ func (f *PoolFactory) DecodePoolAddressesFromFactoryLog(_ context.Context, log e
 	}
 
 	switch log.Topics[0] {
-	case stableStableHookABI.Events["FeeConfigUpdated"].ID:
+	case stableStableHookABI.Events["FeeConfigUpdated"].ID, stableStableHookV2ABI.Events["FeeConfigUpdated"].ID:
 		return []string{hexutil.Encode(log.Topics[1][:])}, nil
 	}
 

--- a/pkg/liquidity-source/woofi-v21/pools_list_updater.go
+++ b/pkg/liquidity-source/woofi-v21/pools_list_updater.go
@@ -59,13 +59,11 @@ func (d *PoolsListUpdater) init(ctx context.Context) ([]entity.Pool, error) {
 		ABI:    IntegrationHelperABI,
 		Target: d.config.IntegrationHelperAddress,
 		Method: integrationHelperMethodAllBaseTokens,
-		Params: nil,
 	}, []any{&baseTokens})
 	calls.AddCall(&ethrpc.Call{
 		ABI:    WooPPV2ABI,
 		Target: d.config.WooPPV2Address,
 		Method: wooPPV2MethodQuoteToken,
-		Params: nil,
 	}, []any{&quoteToken})
 
 	if _, err := calls.Aggregate(); err != nil {
@@ -82,7 +80,6 @@ func (d *PoolsListUpdater) init(ctx context.Context) ([]entity.Pool, error) {
 			ABI:    Erc20ABI,
 			Target: token.Hex(),
 			Method: erc20MethodDecimals,
-			Params: nil,
 		}, []any{&tokenDecimals[i]})
 	}
 	if _, err := decimalCalls.Aggregate(); err != nil {


### PR DESCRIPTION
The newer stable-stable hook deployment (0x0000113dcf4add69999fad8f20f2b63f979bfcc0)
changed feeConfig()'s ABI: it dropped the on-chain logK column and now derives it
from k on the fly (StableFeeCalculation.deriveLogK). This broke two things for
pools on the new hook:

- Track(): the stale 5-field ABI decode misaligned every field after k against
  the contract's actual 4-word return.
- Pool discovery: FeeConfigUpdated's tuple signature changed too, so its topic0
  hash no longer matched what pool_factory.go computed from the stale ABI,
  silently dropping new-hook pools from discovery entirely.

The legacy hook deployment is still live and still returns the original 5-field
shape with a genuinely different logK scale (confirmed on-chain: deriveLogK(k)
for the legacy hook's k does not reproduce its stored logK — the two hooks use
different <<40 vs <<24 exponent scales), so this adds a second ABI/decode path
selected by hook address rather than replacing the legacy one.

- abis/StableStableHookV2.json: new hook's feeConfig()/FeeConfigUpdated shape.
- hook.go: Hook.HookAddress set once at construction (GetHook reruns the
  factory on every pool simulator rebuild); isLegacy() derives which decode/
  decay path to use from it.
- math.go: CalculateDecayingFeeV2/decayFactorX24V2/deriveLogK port the new
  contract's on-chain formula; legacy path is unchanged. pool_factory.go now
  recognizes both FeeConfigUpdated topics.

Verified against live chain data (cast call, debug_traceCall, Sourcify-fetched
verified source for both the proxy and implementation) and against pre-release
pool-service data for pools on both hook versions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0171HX441mMoCLaztoSStJcz
