### PR TITLE
chore: add stable-stable hook on robinhood

### DIFF
--- a/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/constant.go
+++ b/pkg/liquidity-source/uniswap/v4/hooks/stable-stable/constant.go
@@ -11,6 +11,7 @@ const (
 var HookAddresses = []common.Address{
 	common.HexToAddress("0x4509b7Eb3F9641226804Fea4976963435d1c6080"),
 	common.HexToAddress("0x0000113dCf4ADd69999Fad8F20F2b63F979bfcC0"),
+	common.HexToAddress("0x3b64660a35a09AfDe554cE545bca9166D6A23CC0"), // Robinhood Chain (4663)
 }
 
 // legacyHookAddress is the only deployment whose feeConfig() still returns an


### PR DESCRIPTION
Adds the StablePairHook deployment on Robinhood Chain (chain id 4663) to `HookAddresses`
in `pkg/liquidity-source/uniswap/v4/hooks/stable-stable/constant.go`. One line, same shape
as #1595.

**The deployment.** Uniswap Labs' StablePairHook from v4-hooks-public (commit e4eabe52),
deployed unmodified by Twofold (https://twofold.fi) as an ERC1967 proxy with permission
flags `0x3cc0`:

- hook (proxy): `0x3b64660a35a09AfDe554cE545bca9166D6A23CC0`
- implementation: `0xf227E6aC66514E8ca043a1a373C2af63c3200000`
- PoolManager: `0x8366a39CC670B4001A1121B8F6A443A643e40951`

The implementation's runtime is the same code as Uniswap's mainnet implementation
`0x5f216d21b1C81346938EDDc1Df7e0111A0F64000` apart from immutables and the CBOR trailer,
and both contracts are an exact match on Sourcify.

**Which code path it takes.** It is the current StablePairHook: `feeConfig()` returns
`(k, optimalFeeE6, targetMultiplier, referenceSqrtPriceX96)` with no on-chain logK, so it
is not `legacyHookAddress` and uses the V2 path added in #1664. It is appended after the
existing entries, so `HookAddresses[0]` is unchanged.

**Block clock.** The hook reads its block number from BlockNumberish, which on this chain
resolves to the ArbSys precompile (`arbBlockNumber()`, the L2 block height; the constructor
probe stored `_USE_ARB_SYS = 1`, read from the deployed runtime), not `block.number`. The
decay is therefore counted in L2 blocks (~10 per second), so `TrackedBlock` needs to be the
L2 block number for the simulated fee to match.

`go test ./pkg/liquidity-source/uniswap/v4/hooks/stable-stable/` passes.
